### PR TITLE
Fix mysql error logging

### DIFF
--- a/202-config/connect2.php
+++ b/202-config/connect2.php
@@ -2146,7 +2146,7 @@ function setPrePopVars($urlvars, $redirect_site_url, $b64 = false)
 
 function record_mysql_error($db, $sql)
 {
-    global $server_row;
+    global $server_row, $ip_address;
     
     // record the mysql error
     $clean['mysql_error_text'] = mysqli_error($db);


### PR DESCRIPTION
## Summary
- reference global `$ip_address` in `record_mysql_error`

## Testing
- `php -l 202-config/connect2.php` *(fails: `php` not installed)*