### PR TITLE
Fix comment typos

### DIFF
--- a/202-config-sample.php
+++ b/202-config-sample.php
@@ -10,7 +10,7 @@ $mchost = 'localhost'; // this is the memcache server host, if you don't know wh
 
 /*---DONT EDIT ANYTHING BELOW THIS LINE!---*/
 
-//Database conncetion class
+//Database connection class
 class DB {
         private $_connection,$_connectionro;
         private static $_instance; //The single instance

--- a/202-config/class-dataengine.php
+++ b/202-config/class-dataengine.php
@@ -341,7 +341,7 @@ class DataEngine
         }
                 
         if ($memcacheWorking) {
-            $time = 2592000; // 7 days in sec
+            $time = 2592000; // 30 days in sec
                             // get from memcached
             $getID = $memcache->get(md5("ip-id" . $mysql['ip_address'] . systemHash()));
             


### PR DESCRIPTION
## Summary
- fix spelling in sample DB connection comment
- correct cache duration comment in DataEngine

## Testing
- `php -v` *(fails: command not found)*