### PR TITLE
Add PR workflow for PHP lint

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,21 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  php-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+      - name: PHP Syntax Check
+        run: |
+          find . -type f -name '*.php' -print0 | xargs -0 -r -n1 php -l
+      - name: Shell Script Syntax Check
+        run: |
+          find . -type f -name '*.sh' -print0 | xargs -0 -r -n1 bash -n


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run on pull requests
- run PHP lint checks on all `.php` files using PHP 8
- add a shell script syntax check

## Testing
- `find . -type f -name '*.php' -print0 | xargs -0 -r -n1 php -l` *(fails: Array and string offset access syntax with curly braces is no longer supported)*
- `find . -type f -name '*.sh' -print0 | xargs -0 -r -n1 bash -n`
