### PR TITLE
[Core] Update PHP version check for PHP 8

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 if ( !file_exists( dirname( __FILE__ ) . '/202-config.php') ) {
 	
 	require_once(dirname( __FILE__ ) . '/202-config/functions.php');
-	//check to make sure this user has php 5 or greater
-	$php_version = phpversion();
-	$php_version = substr($php_version,0,1);
-	if ($php_version < 5) {
-		_die("<center><small>Prosper202 requires PHP 5 or greater to run. Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>. Please either have your hosting provider upgrade to PHP 5 or simply sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.</small></center>");
-	}
+        //check to make sure this user has PHP 8 or greater
+        if (PHP_VERSION_ID < 80000) {
+                _die("<center><small>Prosper202 requires PHP 8.0 or greater to run. Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>. Please upgrade PHP or sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.</small></center>");
+        }
 	
 	//require the 202-config.php file
 	_die("<center><small>There doesn't seem to be a <code>202-config.php</code> file. I need this before we can get started. <br/>Need more help? <a href=\"http://prosper202.com/apps/about/contact/\">Contact Us</a>. You can <a href='".get_absolute_url()."202-config/setup-config.php'>create a <code>202-config.php</code> file through a web interface</a>, but this doesn't work for all server setups. The safest way is to manually create the file.</small></center>", "202 &rsaquo; Error");


### PR DESCRIPTION
## Summary
- ensure PHP 8 is required in index.php

## Testing
- `phpcs --standard=PSR12 .` *(fails: `phpcs` not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*