### PR TITLE
[Config] Update PHP version checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /mysql_data
 p202.patch
 202-config.php
+/vendor

--- a/202-Mobile/index.php
+++ b/202-Mobile/index.php
@@ -5,12 +5,11 @@ if ( !file_exists(substr(dirname( __FILE__ ), 0,-11) . '/202-config.php') ) {
 	
 	require_once(substr(dirname( __FILE__ ), 0,-11) . '/202-config/functions.php');
 	
-	//check to make sure this user has php 5 or greater
-	$php_version = phpversion();
-	$php_version = substr($php_version,0,1);
-	if ($php_version < 5) {
-		_die("Prosper202 requires PHP 5 or greater to run.  Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>.  Please either have your hosting provider upgrade to PHP 5 or simply sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.");
-	}
+        //check to make sure this user has php 8.3 or greater
+        $phpVersion = PHP_VERSION;
+        if (version_compare($phpVersion, '8.3', '<')) {
+                _die("Prosper202 requires PHP 8.3 or greater to run.  Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>.  Please either have your hosting provider upgrade to PHP 8.3 or simply sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.");
+        }
 	
 	//require the 202-config.php file
 	_die("There doesn't seem to be a <code>202-config.php</code> file. I need this before we can get started. Need more help? <a href=\"http://prosper202.com/apps/about/contact/\">Contact Us</a>. You can <a href='<?php echo get_absolute_url();?>202-config/setup-config.php'>create a <code>202-config.php</code> file through a web interface</a>, but this doesn't work for all server setups. The safest way is to manually create the file.", "202 &rsaquo; Error");

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -108,10 +108,10 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
 if (!$success) {
 
-	$phpversion = phpversion(); 
-	if ($phpversion < 5.4) { 
-		$version_error['phpversion'] = 'Prosper202 requires PHP 5.4, or newer.';
-	}
+        $phpVersion = PHP_VERSION;
+        if (version_compare($phpVersion, '8.3', '<')) {
+                $version_error['phpversion'] = 'Prosper202 requires PHP 8.3, or newer.';
+        }
 
     // Get Database version
 	$mysqlversion = $db->server_info;

--- a/202-config/requirements.php
+++ b/202-config/requirements.php
@@ -29,10 +29,9 @@ if (is_installed() == true) {
 	
 	$html['mysqlversion'] = htmlentities($mysqlversion, ENT_QUOTES, 'UTF-8');
 
-	//$phpversion = phpversion(); 
-	if ((version_compare(PHP_VERSION, '5.4') < 0)) { 
-		$version_error['phpversion'] = 'Prosper202 requires PHP 5.4, or newer.';
-	}
+        if (version_compare(PHP_VERSION, '8.3', '<')) {
+                $version_error['phpversion'] = 'Prosper202 requires PHP 8.3, or newer.';
+        }
 
 
 	if (!function_exists('curl_version')) { 
@@ -86,10 +85,10 @@ info_top(); ?>
 		</tr>
 	</thead>
 	<tbody>
-		<tr>
-			<td>PHP >= 5.6 <strong> (Use PHP 7+ For Up to 400x Faster Redirects)</strong></td>
-			<td><span class="label label-<?php if ($version_error['phpversion']) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo phpversion(); ?></span></td>
-		</tr>
+                <tr>
+                        <td>PHP >= 8.3 <strong>(Use PHP 8.3+ for best performance)</strong></td>
+                        <td><span class="label label-<?php if ($version_error['phpversion']) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo phpversion(); ?></span></td>
+                </tr>
 		<tr>
 			<td><?php echo $dbwording?></td>
 			<td><span class="label label-<?php if ($version_error['mysqlversion']) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo $html['mysqlversion'] ;?></span></td>

--- a/202-config/upgrade.php
+++ b/202-config/upgrade.php
@@ -16,10 +16,10 @@ include_once(dirname( __FILE__ ) . '/functions-upgrade.php');
 	}
 	
 	
-	$phpversion = phpversion();
-	if ($phpversion < 5.4) {
-	    $version_error['phpversion'] = 'Prosper202 requires PHP 5.4, or newer.';
-	}
+        $phpVersion = PHP_VERSION;
+        if (version_compare($phpVersion, '8.3', '<')) {
+            $version_error['phpversion'] = 'Prosper202 requires PHP 8.3, or newer.';
+        }
 	
     // Get Database version
 	$mysqlversion = $db->server_info;
@@ -80,10 +80,10 @@ include_once(dirname( __FILE__ ) . '/functions-upgrade.php');
 		</tr>
 	</thead>
 	<tbody>
-		<tr>
-			<td>PHP >= 5.6</td>
-			<td><span class="label label-<?php if ($version_error['phpversion']) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo phpversion(); ?></span></td>
-		</tr>
+                <tr>
+                        <td>PHP >= 8.3</td>
+                        <td><span class="label label-<?php if ($version_error['phpversion']) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo phpversion(); ?></span></td>
+                </tr>
 		<tr>
 			<td>MySQL >= 5.6</td>
 			<td><span class="label label-<?php if ($version_error['mysqlversion']) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo $html['mysqlversion'] ;?></span></td>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Prosper202 provides pay per click affiliate marketers with leading edge self hos
 <b>Version 1.9.56</b>
 
 <ul>
-<li>Add support for PHP 8</li>
-<li>Updated codebase to PHP 8 conventions and enabled strict type checking.</li>
+<li>Add support for PHP 8.3+</li>
+<li>Updated codebase to PHP 8 conventions, enabled strict type checking and modernized version checks.</li>
 </ul>
 
 <b>Version 1.9.55</b>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Prosper202 provides pay per click affiliate marketers with leading edge self hos
 
 <ul>
 <li>Add support for PHP 8.3+</li>
-<li>Updated codebase to PHP 8 conventions, enabled strict type checking and modernized version checks.</li>
+<li>Updated codebase to PHP 8.3+ conventions, enabled strict type checking and modernized version checks.</li>
 </ul>
 
 <b>Version 1.9.55</b>


### PR DESCRIPTION
## Summary
- require PHP 8.3+ throughout install, upgrade, and requirements checks
- update mobile entry point to check PHP 8.3
- note PHP 8.3 in README
- ignore vendor directory in git

## Testing
- `composer install`
- `vendor/bin/phpunit`
- `phpcs --standard=PSR12 .` *(fails: command not found)*