### PR TITLE
[Config] Centralize PHP version check

### DIFF
--- a/202-Mobile/index.php
+++ b/202-Mobile/index.php
@@ -5,10 +5,9 @@ if ( !file_exists(substr(dirname( __FILE__ ), 0,-11) . '/202-config.php') ) {
 	
 	require_once(substr(dirname( __FILE__ ), 0,-11) . '/202-config/functions.php');
 	
-        //check to make sure this user has php 8.3 or greater
-        $phpVersion = PHP_VERSION;
-        if (version_compare($phpVersion, '8.3', '<')) {
-                _die("Prosper202 requires PHP 8.3 or greater to run.  Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>.  Please either have your hosting provider upgrade to PHP 8.3 or simply sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.");
+        //check to make sure this user has the required PHP version
+        if (!php_version_supported()) {
+                _die("Prosper202 requires PHP " . PROSPER202_MIN_PHP_VERSION . " or greater to run.  Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>.  Please either have your hosting provider upgrade to PHP " . PROSPER202_MIN_PHP_VERSION . " or simply sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.");
         }
 	
 	//require the 202-config.php file

--- a/202-config/functions.php
+++ b/202-config/functions.php
@@ -2,6 +2,15 @@
 declare(strict_types=1);
 use GuzzleHttp\json_decode;
 include_once(dirname( __FILE__ ) . '/functions-upgrade.php');
+
+if (!defined('PROSPER202_MIN_PHP_VERSION')) {
+    define('PROSPER202_MIN_PHP_VERSION', '8.3');
+}
+
+function php_version_supported(): bool
+{
+    return version_compare(PHP_VERSION, PROSPER202_MIN_PHP_VERSION, '>=');
+}
 //our own die, that will display the them around the error message
 
 function get_absolute_url(){

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -108,9 +108,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
 if (!$success) {
 
-        $phpVersion = PHP_VERSION;
-        if (version_compare($phpVersion, '8.3', '<')) {
-                $version_error['phpversion'] = 'Prosper202 requires PHP 8.3, or newer.';
+        if (!php_version_supported()) {
+                $version_error['phpversion'] = 'Prosper202 requires PHP ' . PROSPER202_MIN_PHP_VERSION . ', or newer.';
         }
 
     // Get Database version

--- a/202-config/requirements.php
+++ b/202-config/requirements.php
@@ -29,8 +29,8 @@ if (is_installed() == true) {
 	
 	$html['mysqlversion'] = htmlentities($mysqlversion, ENT_QUOTES, 'UTF-8');
 
-        if (version_compare(PHP_VERSION, '8.3', '<')) {
-                $version_error['phpversion'] = 'Prosper202 requires PHP 8.3, or newer.';
+        if (!php_version_supported()) {
+                $version_error['phpversion'] = 'Prosper202 requires PHP ' . PROSPER202_MIN_PHP_VERSION . ', or newer.';
         }
 
 

--- a/202-config/upgrade.php
+++ b/202-config/upgrade.php
@@ -16,9 +16,8 @@ include_once(dirname( __FILE__ ) . '/functions-upgrade.php');
 	}
 	
 	
-        $phpVersion = PHP_VERSION;
-        if (version_compare($phpVersion, '8.3', '<')) {
-            $version_error['phpversion'] = 'Prosper202 requires PHP 8.3, or newer.';
+        if (!php_version_supported()) {
+            $version_error['phpversion'] = 'Prosper202 requires PHP ' . PROSPER202_MIN_PHP_VERSION . ', or newer.';
         }
 	
     // Get Database version

--- a/index.php
+++ b/index.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 if ( !file_exists( dirname( __FILE__ ) . '/202-config.php') ) {
 	
 	require_once(dirname( __FILE__ ) . '/202-config/functions.php');
-        //check to make sure this user has PHP 8 or greater
-        if (PHP_VERSION_ID < 80000) {
-                _die("<center><small>Prosper202 requires PHP 8.0 or greater to run. Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>. Please upgrade PHP or sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.</small></center>");
+        //check to make sure this user has the required PHP version
+        if (!php_version_supported()) {
+                _die("<center><small>Prosper202 requires PHP " . PROSPER202_MIN_PHP_VERSION . " or greater to run. Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>. Please upgrade PHP or sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.</small></center>");
         }
 	
 	//require the 202-config.php file


### PR DESCRIPTION
## Summary
- define `PROSPER202_MIN_PHP_VERSION` and helper `php_version_supported`
- replace inline PHP version checks with helper calls

## Testing
- `composer install` *(fails: cannot reach packagist, uses cache)*
- `phpcs --standard=PSR12 .` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: missing PHPUnit classes)*