### PR TITLE
[Setup] Include ISP preference in rotator

### DIFF
--- a/tracking202/setup/rotator.php
+++ b/tracking202/setup/rotator.php
@@ -22,7 +22,7 @@ $copying = false;
 $slack = false;
 $mysql['user_id'] = $db->real_escape_string((string)$_SESSION['user_own_id']);
 $mysql['user_own_id'] = $db->real_escape_string((string)$_SESSION['user_own_id']);
-$user_sql = "SELECT 2u.user_name as username, 2up.user_slack_incoming_webhook AS url FROM 202_users AS 2u INNER JOIN 202_users_pref AS 2up ON (2up.user_id = 1) WHERE 2u.user_id = '".$mysql['user_own_id']."'";
+$user_sql = "SELECT 2u.user_name as username, 2up.user_slack_incoming_webhook AS url, 2up.maxmind_isp FROM 202_users AS 2u INNER JOIN 202_users_pref AS 2up ON (2up.user_id = 1) WHERE 2u.user_id = '".$mysql['user_own_id']."'";
 $user_results = $db->query($user_sql);
 $user_row = $user_results->fetch_assoc();
 


### PR DESCRIPTION
## Summary
- fix undefined `maxmind_isp` array index in Smart Redirector setup by selecting `maxmind_isp` in the user preference query

## Testing
- `composer install`
- `phpcs --standard=PSR12 .` *(fails: `phpcs` not found)*
- `vendor/bin/phpunit`