### PR TITLE
[Setup] Remove undefined variable from template calls

### DIFF
--- a/tracking202/setup/get_adv_landing_code.php
+++ b/tracking202/setup/get_adv_landing_code.php
@@ -133,4 +133,4 @@ template_top('Get Advanced Landing Page Code',NULL,NULL,NULL);  ?>
 	</div>
 </div>
 	
-<?php template_bottom($server_row);
+<?php template_bottom();

--- a/tracking202/setup/get_landing_code.php
+++ b/tracking202/setup/get_landing_code.php
@@ -33,4 +33,4 @@ template_top('Get Landing Page Code',NULL,NULL,NULL);  ?>
 	</div>
 </div>
 		
-<?php template_bottom($server_row);
+<?php template_bottom();

--- a/tracking202/setup/get_simple_landing_code.php
+++ b/tracking202/setup/get_simple_landing_code.php
@@ -98,4 +98,4 @@ template_top('Get Simple Landing Page Code',NULL,NULL,NULL);  ?>
 	});
 </script>
 		
-<?php template_bottom($server_row);
+<?php template_bottom();

--- a/tracking202/setup/get_trackers.php
+++ b/tracking202/setup/get_trackers.php
@@ -480,4 +480,4 @@ template_top('Get Trackers',NULL,NULL,NULL);  ?>
 
 	});
 </script>
-<?php template_bottom($server_row);
+<?php template_bottom();


### PR DESCRIPTION
## Summary
- fix undefined variable warnings in setup pages

## Testing
- `composer install` *(fails: package information from local cache)*
- `vendor/bin/phpcs --standard=PSR12 tracking202/setup/get_landing_code.php tracking202/setup/get_simple_landing_code.php tracking202/setup/get_adv_landing_code.php tracking202/setup/get_trackers.php` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: Class "PHPUnit\TextUI\Command" not found)*