### PR TITLE
[Update] Handle missing case parameter

### DIFF
--- a/tracking202/update/upload.php
+++ b/tracking202/update/upload.php
@@ -28,7 +28,9 @@ function about_revenue_upload() {
 
 $upload_dir = dirname(__FILE__) . '/reports/';
 
-switch ($_GET['case']) { 
+$case = isset($_GET['case']) ? (int)$_GET['case'] : 0;
+
+switch ($case) {
 
 	case 1:
 		


### PR DESCRIPTION
## Summary
- avoid undefined array key warnings in `upload.php`

## Testing
- `phpcs --standard=PSR12 .` *(fails: command not found)*
- `vendor/bin/phpunit` *(shows usage as no tests are configured)*