### PR TITLE
Fix PHP 8 TypeError in landing pages

### DIFF
--- a/tracking202/setup/landing_pages.php
+++ b/tracking202/setup/landing_pages.php
@@ -174,8 +174,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			//if this landing page is brand new, add on a landing_page_id_public
 			$landing_page_row['landing_page_id'] = $db->insert_id;
 			$landing_page_id_public = rand(1, 9) . $landing_page_row['landing_page_id'] . rand(1, 9);
-			$mysql['landing_page_id_public'] = $db->real_escape_string($landing_page_id_public);
-			$mysql['landing_page_id'] = $db->real_escape_string($landing_page_row['landing_page_id']);
+			$mysql['landing_page_id_public'] = $db->real_escape_string((string)$landing_page_id_public);
+			$mysql['landing_page_id'] = $db->real_escape_string((string)$landing_page_row['landing_page_id']);
 
 			$landing_page_sql = "	UPDATE       `202_landing_pages`
 								 	SET          	 `landing_page_id_public`='" . $mysql['landing_page_id_public'] . "'


### PR DESCRIPTION
## Summary
- Fixed TypeError in `tracking202/setup/landing_pages.php` when running on PHP 8+

## Error Fixed
```
Fatal error: Uncaught TypeError: mysqli::real_escape_string(): Argument #1 ($string) must be of type string, int given
```

## Changes
- Cast integer values to string before passing to `mysqli::real_escape_string()` on lines 177-178
- `$landing_page_id_public` and `$landing_page_row['landing_page_id']` are now explicitly cast to strings

## Test plan
- [ ] Create a new landing page
- [ ] Verify no PHP errors occur
- [ ] Confirm landing page is saved correctly with proper ID values