### PR TITLE
Fix undefined array key warnings and TypeError in generate_tracking_link.php

### DIFF
--- a/tracking202/ajax/generate_tracking_link.php
+++ b/tracking202/ajax/generate_tracking_link.php
@@ -164,7 +164,10 @@ $error = array();
 					WHERE		`tracker_id`='".$mysql['tracker_id']."'"; 
 	$tracker_result = $db->query($tracker_sql) or record_mysql_error($tracker_sql);
 
-	$parsed_url = parse_url($landing_page_row['landing_page_url']);
+	$parsed_url = array();
+	if (!empty($landing_page_row['landing_page_url'])) {
+		$parsed_url = parse_url($landing_page_row['landing_page_url']);
+	}
 
 	//setup array of all internally recognized url variables
 	$t202variables = array(

--- a/tracking202/ajax/generate_tracking_link.php
+++ b/tracking202/ajax/generate_tracking_link.php
@@ -190,6 +190,9 @@ $error = array();
 	$get_variables = "SELECT * FROM 202_ppc_network_variables WHERE ppc_network_id = '".$mysql['ppc_network_id']."' AND deleted = 0";
 	$get_variables_result = $db->query($get_variables);
 	
+	// Initialize html array
+	$html = array();
+	
 	//loop over all our internal vars to see if user has set up a custom var in step 1
 	if ($get_variables_result->num_rows > 0) {
 	    while ($get_variables_row = $get_variables_result->fetch_assoc()) {
@@ -214,7 +217,7 @@ $error = array();
             $html[$key] = $db->real_escape_string(trim($_POST[$key]));
         }
         if (isset($html[$key]) || $key=='t202kw')
-            $tracking_variable_string .= $key . '=' . $html[$key] . '&'; //now write out the values/ but only if they are not empty with the exception of t202kw with we will write out no matter what
+            $tracking_variable_string .= $key . '=' . ($html[$key] ?? '') . '&'; //now write out the values/ but only if they are not empty with the exception of t202kw with we will write out no matter what
     }
     
     //remove & from end of the variable
@@ -372,7 +375,7 @@ $error = array();
 	}
 	
 
-	?><?php if($_POST['edit_tracker'] && $_POST['tracker_id']) { ?><small
+	?><?php if(isset($_POST['edit_tracker']) && $_POST['edit_tracker'] && isset($_POST['tracker_id']) && $_POST['tracker_id']) { ?><small
 	class="success"><em><u>Tracker updated! Your tracking link stays the
 			same.</u></em></small><?php } ?>
 <br>

--- a/tracking202/ajax/generate_tracking_link.php
+++ b/tracking202/ajax/generate_tracking_link.php
@@ -53,42 +53,49 @@ $error = array();
 			$error['landing_page_id'] = '<div class="error"><small><span class="fui-alert"></span> You have not selected a landing page to use.</small></div>'; 
 		}
 		
-		echo $error['landing_page_id']; 
-		if ($error['landing_page_id']) { die(); }    
+		if (isset($error['landing_page_id'])) {
+			echo $error['landing_page_id'];
+			die();
+		}    
 	}
 
 //echo error
-	echo $error['text_ad_id'] . $error['ppc_network_id'] . $error['ppc_account_id'] . $error['cpc'] . $error['click_cloaking'] . $error['cloaking_url'];
+	echo (isset($error['text_ad_id']) ? $error['text_ad_id'] : '') . 
+	     (isset($error['ppc_network_id']) ? $error['ppc_network_id'] : '') . 
+	     (isset($error['ppc_account_id']) ? $error['ppc_account_id'] : '') . 
+	     (isset($error['cpc']) ? $error['cpc'] : '') . 
+	     (isset($error['click_cloaking']) ? $error['click_cloaking'] : '') . 
+	     (isset($error['cloaking_url']) ? $error['cloaking_url'] : '');
 
 //show tracking code
 
-	$mysql['landing_page_id'] = $db->real_escape_string((string)$_POST['landing_page_id']);
+	$mysql['landing_page_id'] = $db->real_escape_string((string)($_POST['landing_page_id'] ?? '0'));
 	$landing_page_sql = "SELECT * FROM `202_landing_pages` WHERE `landing_page_id`='".$mysql['landing_page_id']."'";
 	$landing_page_result = $db->query($landing_page_sql) or record_mysql_error($landing_page_sql);
 	$landing_page_row = $landing_page_result->fetch_assoc();
 	
-	if ($_POST['cost_type'] == 'cpc') {
-		$click_cpc = $_POST['cpc_dollars'] . '.' . $_POST['cpc_cents'];
+	if (isset($_POST['cost_type']) && $_POST['cost_type'] == 'cpc') {
+		$click_cpc = ($_POST['cpc_dollars'] ?? '0') . '.' . ($_POST['cpc_cents'] ?? '00');
 		$mysql['click_cpc'] = $db->real_escape_string($click_cpc);
 		$cost_sql = "`click_cpc`='".$mysql['click_cpc']."',";
-	} else if ($_POST['cost_type'] == 'cpa') {
-		$click_cpa = $_POST['cpa_dollars'] . '.' . $_POST['cpa_cents'];
+	} else if (isset($_POST['cost_type']) && $_POST['cost_type'] == 'cpa') {
+		$click_cpa = ($_POST['cpa_dollars'] ?? '0') . '.' . ($_POST['cpa_cents'] ?? '00');
 		$mysql['click_cpa'] = $db->real_escape_string($click_cpa);
 		$cost_sql = "`click_cpa`='".$mysql['click_cpa']."',";
 	}
 
 	$mysql['user_id'] = $db->real_escape_string((string)$_SESSION['user_id']);
-	$mysql['aff_campaign_id'] = $db->real_escape_string((string)$_POST['aff_campaign_id']);
-	$mysql['text_ad_id'] = $db->real_escape_string((string)$_POST['text_ad_id']);
-	$mysql['ppc_network_id'] = $db->real_escape_string((string)$_POST['ppc_network_id']); 
-	$mysql['ppc_account_id'] = $db->real_escape_string((string)$_POST['ppc_account_id']); 
-	$mysql['click_cloaking'] = $db->real_escape_string((string)$_POST['click_cloaking']); 
-	$mysql['landing_page_id'] = $db->real_escape_string($landing_page_row['landing_page_id']);
-	$mysql['rotator_id'] = $db->real_escape_string((string)$_POST['tracker_rotator']);
+	$mysql['aff_campaign_id'] = $db->real_escape_string((string)($_POST['aff_campaign_id'] ?? '0'));
+	$mysql['text_ad_id'] = $db->real_escape_string((string)($_POST['text_ad_id'] ?? '0'));
+	$mysql['ppc_network_id'] = $db->real_escape_string((string)($_POST['ppc_network_id'] ?? '0')); 
+	$mysql['ppc_account_id'] = $db->real_escape_string((string)($_POST['ppc_account_id'] ?? '0')); 
+	$mysql['click_cloaking'] = $db->real_escape_string((string)($_POST['click_cloaking'] ?? '0')); 
+	$mysql['landing_page_id'] = $db->real_escape_string((string)($landing_page_row['landing_page_id'] ?? '0'));
+	$mysql['rotator_id'] = $db->real_escape_string((string)($_POST['tracker_rotator'] ?? '0'));
 	$mysql['tracker_time'] = time();
 	
 
-	if ($_POST['edit_tracker'] && $_POST['tracker_id']) {
+	if (isset($_POST['edit_tracker']) && $_POST['edit_tracker'] && isset($_POST['tracker_id']) && $_POST['tracker_id']) {
 		$mysql['tracker_id_public'] = $db->real_escape_string((string)$_POST['tracker_id']);
 		$get_tracker_sql = "SELECT 
 							tracker_id, 
@@ -265,7 +272,7 @@ $error = array();
 			if ($_POST['method_of_promotion'] == 'landingpage' || $_POST['tracker_type'] == '1') {
 				if (($get_tracker_row['landing_page_id']) && $_POST['landing_page_id'] != $get_tracker_row['landing_page_id']) {
 					
-					$mysql['landing_page_id'] = $db->real_escape_string((string)$_POST['landing_page_id']);
+					$mysql['landing_page_id'] = $db->real_escape_string((string)($_POST['landing_page_id'] ?? '0'));
 					$sql = "SELECT landing_page_nickname FROM 202_landing_pages WHERE landing_page_id = '".$mysql['landing_page_id']."'";
 					$result = $db->query($sql);
 					$row = $result->fetch_assoc();
@@ -274,10 +281,10 @@ $error = array();
 				}
 			}
 
-			if ($_POST['tracker_type'] == '0' || $_POST['tracker_type'] == '1') {
+			if (isset($_POST['tracker_type']) && ($_POST['tracker_type'] == '0' || $_POST['tracker_type'] == '1')) {
 
 				if (isset($_POST['text_ad_id']) && $get_tracker_row['text_ad_id']) {
-					$mysql['text_ad_id'] = $db->real_escape_string((string)$_POST['text_ad_id']);
+					$mysql['text_ad_id'] = $db->real_escape_string((string)($_POST['text_ad_id'] ?? '0'));
 					$sql = "SELECT text_ad_name FROM 202_text_ads WHERE text_ad_id = '".$mysql['text_ad_id']."'";
 					$result = $db->query($sql);
 					$row = $result->fetch_assoc();
@@ -286,7 +293,7 @@ $error = array();
 				}
 
 				if (isset($_POST['text_ad_id']) && !$get_tracker_row['text_ad_id']) {
-					$mysql['text_ad_id'] = $db->real_escape_string((string)$_POST['text_ad_id']);
+					$mysql['text_ad_id'] = $db->real_escape_string((string)($_POST['text_ad_id'] ?? '0'));
 					$sql = "SELECT text_ad_name FROM 202_text_ads WHERE text_ad_id = '".$mysql['text_ad_id']."'";
 					$result = $db->query($sql);
 					$row = $result->fetch_assoc();
@@ -331,7 +338,7 @@ $error = array();
 				$slack->push('tracking_link_ppc_account_changed', array('type' => $tracker_type, 'id' => $tracker_row['tracker_id'], 'old_account' => $get_tracker_row['ppc_account_name'], 'new_account' => $row['ppc_account_name'], 'user' => $user_row['username']));
 			}
 
-			if ($_POST['cost_type'] == 'cpc') {
+			if (isset($_POST['cost_type']) && $_POST['cost_type'] == 'cpc') {
 				if ($get_tracker_row['click_cpc'] == null) {
 					$slack->push('tracking_link_cost_type_changed', array('type' => $tracker_type, 'id' => $tracker_row['tracker_id'], 'old_type' => 'CPA', 'new_type' => 'CPC', 'user' => $user_row['username']));
 				} else {

--- a/tracking202/ajax/generate_tracking_link.php
+++ b/tracking202/ajax/generate_tracking_link.php
@@ -69,8 +69,8 @@ $error = array();
 
 //show tracking code
 
-	$mysql['landing_page_id'] = $db->real_escape_string((string)($_POST['landing_page_id'] ?? '0'));
-	$landing_page_sql = "SELECT * FROM `202_landing_pages` WHERE `landing_page_id`='".$mysql['landing_page_id']."'";
+	$input_landing_page_id = $db->real_escape_string((string)($_POST['landing_page_id'] ?? '0'));
+	$landing_page_sql = "SELECT * FROM `202_landing_pages` WHERE `landing_page_id`='".$input_landing_page_id."'";
 	$landing_page_result = $db->query($landing_page_sql) or record_mysql_error($landing_page_sql);
 	$landing_page_row = $landing_page_result->fetch_assoc();
 	

--- a/tracking202/ajax/generate_tracking_link.php
+++ b/tracking202/ajax/generate_tracking_link.php
@@ -148,13 +148,13 @@ $error = array();
 	$tracker_result = $db->query($tracker_sql) or record_mysql_error($tracker_sql);
 	
 	$tracker_row['tracker_id'] = $db->insert_id;
-	$mysql['tracker_id'] = $db->real_escape_string($tracker_row['tracker_id']);
+	$mysql['tracker_id'] = $db->real_escape_string((string)$tracker_row['tracker_id']);
 
-	if ($_POST['edit_tracker'] && $_POST['tracker_id'] && $get_tracker_result->num_rows > 0) {
-		$mysql['tracker_id_public'] = $db->real_escape_string($get_tracker_row['tracker_id_public']);
+	if (isset($_POST['edit_tracker']) && $_POST['edit_tracker'] && isset($_POST['tracker_id']) && $_POST['tracker_id'] && $get_tracker_result->num_rows > 0) {
+		$mysql['tracker_id_public'] = $db->real_escape_string((string)$get_tracker_row['tracker_id_public']);
 	} else {
 		$tracker_id_public = rand(1,9) . $tracker_row['tracker_id'] . rand(1,9);
-		$mysql['tracker_id_public'] = $db->real_escape_string($tracker_id_public);
+		$mysql['tracker_id_public'] = $db->real_escape_string((string)$tracker_id_public);
 	}
 	
 	$tracker_id_public = $mysql['tracker_id_public'];

--- a/tracking202/setup/get_trackers.php
+++ b/tracking202/setup/get_trackers.php
@@ -373,7 +373,7 @@ template_top('Get Trackers', NULL, NULL, NULL);  ?>
 						?>
 							<li>
 								<span class="small">Id:<?php echo $tracker_row['tracker_id']; ?> -
-									(<?php echo '<span class="filter_tracker_display_name">' . $display_name . '</span> - ' . date('m/d/y', $tracker_row['tracker_time']); ?>)</span> -
+									(<?php echo '<span class="filter_tracker_display_name">' . $display_name . '</span> - ' . date('m/d/y', (int)$tracker_row['tracker_time']); ?>)</span> -
 								<?php if ($tracker_row['landing_page_id'] != 0) { ?>
 									<a href="<?php echo $destination_url; ?>">link</a> -
 								<?php } else if ($tracker_row['rotator_id']) { ?>

--- a/tracking202/setup/get_trackers.php
+++ b/tracking202/setup/get_trackers.php
@@ -343,11 +343,13 @@ template_top('Get Trackers', NULL, NULL, NULL);  ?>
 
 							$vars_query = '';
 
-							$parameters = explode(',', $tracker_row['parameters']);
-							$placeholders = explode(',', $tracker_row['placeholders']);
+							$parameters = !empty($tracker_row['parameters']) ? explode(',', $tracker_row['parameters']) : array();
+							$placeholders = !empty($tracker_row['placeholders']) ? explode(',', $tracker_row['placeholders']) : array();
 
 							foreach ($parameters as $key => $value) {
-								$vars_query .= '&' . $value . '=' . $placeholders[$key];
+								if (isset($placeholders[$key])) {
+									$vars_query .= '&' . $value . '=' . $placeholders[$key];
+								}
 							}
 
 							if ($tracker_row['landing_page_id']) {


### PR DESCRIPTION
## Summary
- Fixed multiple PHP warnings and a fatal TypeError in `tracking202/ajax/generate_tracking_link.php`

## Errors Fixed

### Warnings:
```
Warning: Undefined array key "text_ad_id" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 61
Warning: Undefined array key "ppc_network_id" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 61
Warning: Undefined array key "ppc_account_id" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 61
Warning: Undefined array key "cpc" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 61
Warning: Undefined array key "click_cloaking" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 61
Warning: Undefined array key "cloaking_url" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 61
Warning: Undefined array key "landing_page_id" in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 65
Warning: Trying to access array offset on null in /var/www/html/tracking202/ajax/generate_tracking_link.php on line 86
```

### Fatal Error:
```
Fatal error: Uncaught TypeError: mysqli::real_escape_string(): Argument #1 ($string) must be of type string, null given
```

## Changes Made
1. Added `isset()` checks before accessing error array keys
2. Used null coalescing operator (`??`) to provide default values for:
   - All POST parameters that might be undefined
   - Database row values that might be null
3. Added proper isset() checks for conditional logic using POST values
4. Cast all values to string before passing to `mysqli::real_escape_string()`

## Test plan
- [ ] Generate a tracking link with all fields filled
- [ ] Generate a tracking link with minimal fields
- [ ] Edit an existing tracking link
- [ ] Verify no PHP warnings or errors in logs
- [ ] Confirm tracking links still generate correctly