### PR TITLE
Fix multiple number_format and round TypeErrors in DataEngine class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ phpstan.neon
 composer.json
 composer.json
 composer.lock
+vendor/
 composer.json
 docker-compose.yaml
+/vendor
+/vendor/ua-parser

--- a/202-config/class-dataengine.php
+++ b/202-config/class-dataengine.php
@@ -1728,7 +1728,7 @@ ORDER BY ppc_network_id , name , variable";
                         break;
                     case 'su_ratio':
 
-                        $html[$prepend . $key] = htmlentities(round($data_row, 2) . '%', ENT_QUOTES, 'UTF-8');
+                        $html[$prepend . $key] = htmlentities(round((float)$data_row, 2) . '%', ENT_QUOTES, 'UTF-8');
                         break;
 
                     case 'ctr':

--- a/202-config/class-dataengine.php
+++ b/202-config/class-dataengine.php
@@ -1724,7 +1724,7 @@ ORDER BY ppc_network_id , name , variable";
                     case 'clicks':
                     case 'leads':
                     case 'click_out':
-                        $html[$prepend . $key] = htmlentities(number_format($data_row), ENT_QUOTES, 'UTF-8');
+                        $html[$prepend . $key] = htmlentities(number_format((float)$data_row), ENT_QUOTES, 'UTF-8');
                         break;
                     case 'su_ratio':
 

--- a/202-config/class-dataengine.php
+++ b/202-config/class-dataengine.php
@@ -1745,7 +1745,7 @@ ORDER BY ppc_network_id , name , variable";
                         $html[$prepend . $key] = htmlentities(dollar_format($data_row, $currency_row['user_account_currency'], $cpv), ENT_QUOTES, 'UTF-8');
                         break;
                     case 'roi':
-                        $html[$prepend . $key] = htmlentities(number_format($data_row) . '%', ENT_QUOTES, 'UTF-8');
+                        $html[$prepend . $key] = htmlentities(number_format((float)($data_row ?? 0)) . '%', ENT_QUOTES, 'UTF-8');
                         break;
                     case 'click_time_from_disp':
                         $upper = array(


### PR DESCRIPTION
## Summary
- Fixed multiple TypeError issues in DataEngine class where numeric functions received wrong types
- Added proper type casting and null handling for PHP 8+ compatibility

## Issues Fixed
- Line 1727: number_format() receiving string instead of numeric type for clicks/leads/click_out
- Line 1731: round() receiving string instead of numeric type for su_ratio percentages  
- Line 1748: number_format() receiving null values for ROI calculations

## Changes Made
- Added explicit (float) casting before passing values to numeric functions
- Added null coalescing operator (?? 0) to handle null values gracefully
- Updated .gitignore to exclude vendor/ directory from version control

## Testing
- Verify reports load without TypeError exceptions
- Test keyword sorting and analysis functionality
- Confirm proper number formatting for all report types