### PR TITLE
Clarify web server requirements: support both Nginx and Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Since 2007, Prosper202 has helped marketers take control of their tracking with 
 
 - PHP 8.3+
 - MySQL 8.0+
-- Nginx with PHP-FPM
+- Web server: **Nginx with PHP-FPM (recommended for manual installs)** or **Apache** (as used in the official Docker image)
 - Composer
 - Go 1.22+ (optional, for the Go CLI)
 
@@ -95,7 +95,7 @@ Dependencies are automatically installed on container startup.
        }
 
        location ~ \.php$ {
-           fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+           fastcgi_pass unix:/path/to/php-fpm.sock; # or fastcgi_pass 127.0.0.1:9000; adjust to your PHP-FPM setup
            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
            include fastcgi_params;
        }


### PR DESCRIPTION
The requirements section previously listed only Nginx, but the Docker
setup uses Apache and .htaccess rewrite rules exist under api/v2 and
api/v3. Updated to note both options. Also replaced the hard-coded
Debian-specific PHP-FPM socket path with a generic placeholder.

https://claude.ai/code/session_01ACi54yAzYWEV7Jf7n3U21U