### PR TITLE
Add Apache vhost example to manual install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ Dependencies are automatically installed on container startup.
 
 5. Access the application in your browser.
 
+#### Apache Alternative
+
+If you prefer Apache over Nginx, point your document root at the project directory and ensure `mod_rewrite` is enabled with `AllowOverride All` so the `.htaccess` files in `api/v2/` and `api/v3/` can handle routing. Example virtual host:
+
+```apache
+<VirtualHost *:80>
+    ServerName your-domain.com
+    DocumentRoot /path/to/prosper202
+
+    <Directory /path/to/prosper202>
+        Options -Indexes +FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+```
+
+Enable the required module and reload:
+
+```bash
+sudo a2enmod rewrite
+sudo systemctl reload apache2
+```
+
 ## API v3
 
 REST API under `/api/v3/` with bearer token authentication. Covers all Prosper202 entities: campaigns, networks, traffic sources, trackers, landing pages, text ads, clicks, conversions, rotators, attribution models, users, and system operations.


### PR DESCRIPTION
The Requirements section mentions Apache as supported but the manual
install steps only showed Nginx. Add an Apache alternative with a
virtual host snippet and the mod_rewrite / AllowOverride prerequisites
needed for the existing .htaccess rewrite rules in api/v2 and api/v3.

https://claude.ai/code/session_01MSFE1f65w9kDdot5ciJPft