### PR TITLE
Sync v3 API docs with pre-release audit changes (PR #107)

### DIFF
--- a/documentation/api/02-campaigns.md
+++ b/documentation/api/02-campaigns.md
@@ -50,13 +50,17 @@ curl -X POST https://your-domain.com/api/v3/campaigns \
 
 `POST /campaigns/bulk-upsert` accepts an array of campaign objects. Requires an `Idempotency-Key` header.
 
+Rows without an `aff_campaign_id` (or `id`) are created and must include all
+required fields. Rows with an existing ID are updated and may send only the
+fields being changed.
+
 ```bash
 curl -X POST https://your-domain.com/api/v3/campaigns/bulk-upsert \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Idempotency-Key: unique-request-id" \
   -H "Content-Type: application/json" \
   -d '[
-    { "aff_campaign_name": "Campaign A", "aff_campaign_url": "https://..." },
-    { "aff_campaign_name": "Campaign B", "aff_campaign_url": "https://..." }
+    { "aff_campaign_name": "Campaign A", "aff_campaign_url": "https://...", "aff_campaign_payout": 1.50, "aff_network_id": 3 },
+    { "aff_campaign_name": "Campaign B", "aff_campaign_url": "https://...", "aff_campaign_payout": 2.00, "aff_network_id": 3 }
   ]'
 ```

--- a/documentation/api/02-campaigns.md
+++ b/documentation/api/02-campaigns.md
@@ -23,10 +23,10 @@ Manage campaigns.
 | `aff_campaign_url_3` | string | No | Alternate URL 3 (max 2048) |
 | `aff_campaign_url_4` | string | No | Alternate URL 4 (max 2048) |
 | `aff_campaign_url_5` | string | No | Alternate URL 5 (max 2048) |
-| `aff_campaign_payout` | decimal | No | Default payout amount |
+| `aff_campaign_payout` | decimal | Yes | Default payout amount |
 | `aff_campaign_currency` | string | No | Currency code (max 5) |
-| `aff_campaign_foreign_payout` | decimal | No | Foreign currency payout |
-| `aff_network_id` | integer | No | Associated network ID |
+| `aff_campaign_foreign_payout` | decimal | No | Foreign currency payout (default 0) |
+| `aff_network_id` | integer | Yes | Associated network ID |
 | `aff_campaign_cloaking` | integer | No | Cloaking enabled (0/1) |
 | `aff_campaign_rotate` | integer | No | Rotation enabled (0/1) |
 

--- a/documentation/api/03-affiliate-networks.md
+++ b/documentation/api/03-affiliate-networks.md
@@ -20,6 +20,8 @@ Manage networks.
 | `aff_network_name` | string | Yes | Network name (max 255) |
 | `dni_network_id` | integer | No | Direct Network Integration ID |
 
+Auto-generated on create: `aff_network_time` (unix timestamp).
+
 ## Example: Create Network
 
 ```bash

--- a/documentation/api/07-landing-pages.md
+++ b/documentation/api/07-landing-pages.md
@@ -18,9 +18,11 @@ Manage landing pages used between the traffic source and the destination.
 | ----- | ---- | -------- | ----------- |
 | `landing_page_url` | string | Yes | Landing page URL (max 2048) |
 | `aff_campaign_id` | integer | Yes | Campaign this page belongs to |
-| `landing_page_nickname` | string | No | Friendly name (max 255) |
+| `landing_page_nickname` | string | Yes | Friendly name (max 50) |
 | `leave_behind_page_url` | string | No | Leave-behind URL (max 2048) |
-| `landing_page_type` | integer | No | Page type identifier |
+| `landing_page_type` | integer | No | Page type identifier (default 0) |
+
+Auto-generated on create: `landing_page_time` (unix timestamp).
 
 ## Example
 

--- a/documentation/api/08-text-ads.md
+++ b/documentation/api/08-text-ads.md
@@ -16,13 +16,15 @@ Manage text ad creatives for tracking copy performance.
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `text_ad_name` | string | Yes | Ad name (max 255) |
-| `text_ad_headline` | string | No | Ad headline (max 500) |
-| `text_ad_description` | string | No | Ad description (max 2000) |
-| `text_ad_display_url` | string | No | Display URL (max 2048) |
-| `aff_campaign_id` | integer | No | Associated campaign |
-| `landing_page_id` | integer | No | Associated landing page |
-| `text_ad_type` | integer | No | Ad type identifier |
+| `text_ad_name` | string | Yes | Ad name (max 100) |
+| `text_ad_headline` | string | Yes | Ad headline (max 100) |
+| `text_ad_description` | string | Yes | Ad description (max 100) |
+| `text_ad_display_url` | string | Yes | Display URL (max 100) |
+| `aff_campaign_id` | integer | No | Associated campaign (default 0) |
+| `landing_page_id` | integer | No | Associated landing page (default 0) |
+| `text_ad_type` | integer | No | Ad type identifier (default 0) |
+
+Auto-generated on create: `text_ad_time` (unix timestamp).
 
 ## Example
 
@@ -33,6 +35,7 @@ curl -X POST https://your-domain.com/api/v3/text-ads \
   -d '{
     "text_ad_name": "Summer Sale Ad v2",
     "text_ad_headline": "50% Off This Weekend",
-    "text_ad_description": "Limited time offer on all products."
+    "text_ad_description": "Limited time offer on all products.",
+    "text_ad_display_url": "example.com/summer-sale"
   }'
 ```

--- a/documentation/api/10-conversions.md
+++ b/documentation/api/10-conversions.md
@@ -43,6 +43,12 @@ List, inspect, manually create, and delete conversions.
 | `transaction_id` | string | No | Deduplication key |
 | `conv_time` | integer | No | Unix timestamp (defaults to now) |
 
+Creates are idempotent on `transaction_id`: if a conversion with the same
+`transaction_id` already exists for the given `click_id`, the existing
+conversion is returned instead of recording a duplicate. Omitting
+`transaction_id` skips this check, so retried requests without one will
+record multiple conversions.
+
 ## Example
 
 ```bash

--- a/documentation/api/13-attribution.md
+++ b/documentation/api/13-attribution.md
@@ -71,7 +71,9 @@ Manage multi-touch attribution models, view snapshots, and schedule exports.
 | `format` | string | `csv` | Export format: `csv` or `xls` |
 | `webhook_url` | string | — | URL to notify when export completes |
 
-Export statuses: `queued`, `processing`, `completed`, `failed`.
+Export statuses: `pending`, `processing`, `completed`, `failed`. Newly
+scheduled exports start as `pending` and are picked up by the
+`202-cronjobs/attribution-export.php` cron worker.
 
 ## Attribution Model Types
 


### PR DESCRIPTION
PR #102 was written against code that predated the pre-release audit
fixes merged in PR #107, so several documented behaviors were stale at
merge time:

- Campaigns: aff_campaign_payout and aff_network_id are now required;
  aff_campaign_foreign_payout defaults to 0
- Landing pages: landing_page_nickname is required with max length 50
  (was optional/255); landing_page_type defaults to 0; document
  auto-set landing_page_time
- Text ads: headline, description, and display_url are now required;
  all text fields max length 100; FK/type fields default to 0;
  document auto-set text_ad_time; example includes required display_url
- Conversions: document transaction_id idempotency (replays return the
  existing conversion instead of double-counting)
- Attribution exports: status enum is pending/processing/completed/
  failed, not queued (queued was never a valid ExportStatus and the
  export cron only claims pending jobs)
- Affiliate networks: document auto-set aff_network_time

https://claude.ai/code/session_0146bK33QMx7Cn3hwyS6eMDK