### PR TITLE
Raise minimum PHP version gate to 8.3 to match the actual requirement

### DIFF
--- a/202-config/requirements.php
+++ b/202-config/requirements.php
@@ -109,7 +109,7 @@ info_top(); ?>
 	</thead>
 	<tbody>
                 <tr>
-                        <td>PHP >= 8.1 <strong>(PHP 8.3+ recommended for best performance)</strong></td>
+                        <td>PHP >= <?php echo PROSPER202_MIN_PHP_VERSION; ?></td>
                         <td><span class="label label-<?php if (isset($version_error['phpversion'])) {echo "important";} else {echo "primary";}?>" style="font-size: 100%;"><?php echo phpversion(); ?></span></td>
                 </tr>
 		<tr>

--- a/202-config/version.php
+++ b/202-config/version.php
@@ -34,7 +34,9 @@ if (!function_exists('prosper202_version_compare')) {
 }
 
 if (!defined('PROSPER202_MIN_PHP_VERSION')) {
-    define('PROSPER202_MIN_PHP_VERSION', '8.1.0');
+    // Must match composer.json's "php" requirement; the codebase uses PHP 8.3
+    // syntax (typed class constants), so older runtimes fail to parse it.
+    define('PROSPER202_MIN_PHP_VERSION', '8.3.0');
 }
 
 if (!function_exists('php_version_supported')) {


### PR DESCRIPTION
## Summary

`composer.json` requires `php >=8.3` and the codebase uses PHP 8.3 syntax (typed class constants), but the installer/upgrade gate (`PROSPER202_MIN_PHP_VERSION`) was still `8.1.0` — letting installs proceed on runtimes where the code fails to parse before any friendly error can be shown. Flagged during PR #100 review.

- Bump `PROSPER202_MIN_PHP_VERSION` to `8.3.0` (single source consumed by `index.php`, `202-Mobile/index.php`, `202-config/requirements.php`, and `202-config/upgrade.php`)
- Render the constant on the requirements page instead of a hardcoded "PHP >= 8.1" string, so the display can't drift again

## Testing

- `php -l` clean on both files
- Full PHPUnit suite passes (721 tests)

https://claude.ai/code/session_01A6ZSDNbsMMfTxMcQnvn7fL

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6ZSDNbsMMfTxMcQnvn7fL)_