### PR TITLE
Apache/Nginx click-server docs, working Docker stack, and installer hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env before running docker compose up.
+#
+# Generate a strong password, e.g.:
+#   echo "MYSQL_ROOT_PASSWORD=$(openssl rand -hex 16)" > .env
+# or run ./install.sh, which creates .env with a random password for you.
+MYSQL_ROOT_PASSWORD=
+
+# Controls composer install in the web container: development installs dev
+# dependencies, anything else installs --no-dev --optimize-autoloader.
+APP_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ phpstan.neon
 .env
 .env.*
 
-# Docker
-docker-compose.yaml
+# Docker (local overrides only; docker-compose.yaml and Dockerfile are tracked)
 docker-compose.staging.yml
 docker-compose.*.yml
 
@@ -25,7 +24,6 @@ composer.lock
 build/debug/
 build/logs/
 build/staging-config.php
-/build/
 
 # Development and documentation
 /docs/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ phpstan.neon
 # Environment / secrets
 .env
 .env.*
+!.env.example
 
 # Docker (local overrides only; docker-compose.yaml and Dockerfile are tracked)
 docker-compose.staging.yml

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -14,7 +14,6 @@ $success = false;
 $html = [
 	'user_email' => '',
 	'user_name' => '',
-	'user_pass' => '',
 	'user_api' => ''
 ];
 
@@ -68,8 +67,13 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		}
 
 		// Check password length only if password was provided
-		if (isset($_POST['user_pass']) && !empty($_POST['user_pass']) && (strlen((string) $_POST['user_pass']) < 6 || strlen((string) $_POST['user_pass']) > 35)) {
-			$error['user_pass'] .= '<div class="error">Your password must be at least 6 characters long</div>';
+		if (isset($_POST['user_pass']) && !empty($_POST['user_pass'])) {
+			$pass_length = strlen((string) $_POST['user_pass']);
+			if ($pass_length < 6) {
+				$error['user_pass'] .= '<div class="error">Your password must be at least 6 characters long</div>';
+			} elseif ($pass_length > 35) {
+				$error['user_pass'] .= '<div class="error">Your password must be no more than 35 characters long</div>';
+			}
 		}
 
 		// Check if passwords match only if both were provided
@@ -179,9 +183,9 @@ if (!$success) {
 	// Initialize $version_error array
 	$version_error = [];
 
-	$phpversion = phpversion();
-	if ($phpversion < 5.4) {
-		$version_error['phpversion'] = 'Prosper202 requires PHP 5.4, or newer.';
+	// Same floors as requirements.php — keep the two in sync
+	if (!php_version_supported()) {
+		$version_error['phpversion'] = 'Prosper202 requires PHP ' . PROSPER202_MIN_PHP_VERSION . ', or newer.';
 	}
 
 	// Get Database version
@@ -189,14 +193,12 @@ if (!$success) {
 	if (preg_match('/-(10\..+)-MariaDB/i', (string) $mysqlversion, $match)) {
 		// Support For MariaDB
 		$mysqlversion = $match[1];
-		$dbwording = "MariaDB >= 10.0.12";
-		if ((version_compare($mysqlversion, '10.0.12') < 0)) {
-			$version_error['mysqlversion'] = 'Prosper202 requires MariaDB 10.0.12, or newer.';
+		if ((version_compare($mysqlversion, '10.6') < 0)) {
+			$version_error['mysqlversion'] = 'Prosper202 requires MariaDB 10.6, or newer.';
 		}
 	} else {
-		$dbwording = "MySQL >= 5.6";
-		if ((version_compare($mysqlversion, '5.6') < 0)) {
-			$version_error['mysqlversion'] = 'Prosper202 requires MySQL 5.6, or newer.';
+		if ((version_compare($mysqlversion, '8.0') < 0)) {
+			$version_error['mysqlversion'] = 'Prosper202 requires MySQL 8.0, or newer.';
 		}
 	}
 
@@ -207,7 +209,8 @@ if (!$success) {
 	}
 
 	if ($version_error) {
-		header("Location: /202-config/requirements.php");
+		header("Location: " . get_absolute_url() . "202-config/requirements.php");
+		exit;
 	}
 
 	info_top(); ?>
@@ -353,10 +356,6 @@ if ($success) {
 		<div class="row" style="margin-bottom: 10px;">
 			<div class="col-xs-3"><span class="label label-default">Username:</span></div>
 			<div class="col-xs-9"><span class="label label-primary"><?php echo $html['user_name']; ?></span></div>
-		</div>
-		<div class="row" style="margin-bottom: 10px;">
-			<div class="col-xs-3"><span class="label label-default">Password:</span></div>
-			<div class="col-xs-9"><span class="label label-primary"><?php echo $html['user_pass']; ?></span></div>
 		</div>
 		<div class="row" style="margin-bottom: 10px;">
 			<div class="col-xs-3"><span class="label label-default">Login address:</span></div>

--- a/202-config/setup-config.php
+++ b/202-config/setup-config.php
@@ -20,8 +20,14 @@ if (!is_writable(substr(__DIR__, 0, -10) . '/')) {
 }
 
 
+// Escape a value for inclusion in a single-quoted PHP string in 202-config.php
+function escape_config_value(string $value): string
+{
+	return str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
+}
+
 // Check if 202-config.php has been created
-if (file_exists('../202-config.php')) {
+if (file_exists(substr(__DIR__, 0, -10) . '/202-config.php')) {
 	//_die("<p>The file '202-config.php' already exists. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href='install.php'>installing now</a>.</p>");
 	$re = '/(\$\w*) = \'(\w*)\';/i';
 
@@ -122,7 +128,7 @@ switch ($step) {
 				<div class="form-group" style="margin-bottom: 0px;">
 					<label for="dbname" class="col-xs-4 control-label" style="text-align:left"><strong>Database Name:</strong></label>
 					<div class="col-xs-8" style="margin-top: 5px;">
-						<input type="text" class="form-control input-sm" id="dbname" name="dbname" value="<?php echo ($odbname ?? 'prosper202'); ?>">
+						<input type="text" class="form-control input-sm" id="dbname" name="dbname" value="<?php echo htmlspecialchars($odbname ?? 'prosper202', ENT_QUOTES, 'UTF-8'); ?>">
 						<span class="help-block" style="font-size: 10px;">The name of the database you want to run Prosper202 in.</span>
 					</div>
 				</div>
@@ -130,7 +136,7 @@ switch ($step) {
 				<div class="form-group" style="margin-bottom: 0px;">
 					<label for="dbuser" class="col-xs-4 control-label" style="text-align:left"><strong>User Name:</strong></label>
 					<div class="col-xs-8" style="margin-top: 5px;">
-						<input type="text" class="form-control input-sm" id="dbuser" name="dbuser" value="<?php echo ($odbuser ?? 'root'); ?>">
+						<input type="text" class="form-control input-sm" id="dbuser" name="dbuser" value="<?php echo htmlspecialchars($odbuser ?? 'root', ENT_QUOTES, 'UTF-8'); ?>">
 						<span class="help-block" style="font-size: 10px;">Your MySQL username</span>
 					</div>
 				</div>
@@ -138,7 +144,7 @@ switch ($step) {
 				<div class="form-group" style="margin-bottom: 0px;">
 					<label for="dbpass" class="col-xs-4 control-label" style="text-align:left"><strong>Password:</strong></label>
 					<div class="col-xs-8" style="margin-top: 5px;">
-						<input type="text" class="form-control input-sm" id="dbpass" name="dbpass" value="<?php echo ($odbpass ?? 'root_password'); ?>">
+						<input type="password" class="form-control input-sm" id="dbpass" name="dbpass" value="<?php echo htmlspecialchars($odbpass ?? '', ENT_QUOTES, 'UTF-8'); ?>">
 						<span class="help-block" style="font-size: 10px;">...and MySQL password.</span>
 					</div>
 				</div>
@@ -146,7 +152,7 @@ switch ($step) {
 				<div class="form-group" style="margin-bottom: 0px;">
 					<label for="dbhost" class="col-xs-4 control-label" style="text-align:left"><strong>Database Host:</strong></label>
 					<div class="col-xs-8" style="margin-top: 5px;">
-						<input type="text" class="form-control input-sm" id="dbhost" name="dbhost" value="<?php echo ($odbhost ?? 'localhost'); ?>">
+						<input type="text" class="form-control input-sm" id="dbhost" name="dbhost" value="<?php echo htmlspecialchars($odbhost ?? 'localhost', ENT_QUOTES, 'UTF-8'); ?>">
 						<span class="help-block" style="font-size: 10px;">99% chance you won't need to change this value.</span>
 					</div>
 				</div>
@@ -154,7 +160,7 @@ switch ($step) {
 				<div class="form-group" style="margin-bottom: 0px;">
 					<label for="dbhost" class="col-xs-4 control-label" style="text-align:left"><strong>Reporting Database:</strong></label>
 					<div class="col-xs-8" style="margin-top: 5px;">
-						<input type="text" class="form-control input-sm" id="dbhostro" name="dbhostro" value="<?php echo ($odbhostro ?? 'localhost'); ?>">
+						<input type="text" class="form-control input-sm" id="dbhostro" name="dbhostro" value="<?php echo htmlspecialchars($odbhostro ?? 'localhost', ENT_QUOTES, 'UTF-8'); ?>">
 						<span class="help-block" style="font-size: 10px;">If you have a dedicated db for running reports, enter it here. If not, leave as localhost. </span>
 					</div>
 				</div>
@@ -162,7 +168,7 @@ switch ($step) {
 				<div class="form-group" style="margin-bottom: 0px;">
 					<label for="mchost" class="col-xs-4 control-label" style="text-align:left"><strong>Memcache Host:</strong></label>
 					<div class="col-xs-8" style="margin-top: 5px;">
-						<input type="text" class="form-control input-sm" id="mchost" name="mchost" value="<?php echo ($omchost ?? 'localhost'); ?>">
+						<input type="text" class="form-control input-sm" id="mchost" name="mchost" value="<?php echo htmlspecialchars($omchost ?? 'localhost', ENT_QUOTES, 'UTF-8'); ?>">
 						<span class="help-block" style="font-size: 10px;">If you don't know what this is, leave it alone.</span>
 					</div>
 				</div>
@@ -185,12 +191,12 @@ switch ($step) {
 
 	case 2:
 	case 2.2:
-		$dbname  = trim((string) $_POST['dbname']);
-		$dbuser   = trim((string) $_POST['dbuser']);
-		$dbpass = trim((string) $_POST['dbpass']);
-		$dbhost  = trim((string) $_POST['dbhost']);
-		$dbhostro  = trim((string) $_POST['dbhostro']);
-		$mchost  = trim((string) $_POST['mchost']);
+		$dbname  = trim((string) ($_POST['dbname'] ?? ''));
+		$dbuser   = trim((string) ($_POST['dbuser'] ?? ''));
+		$dbpass = trim((string) ($_POST['dbpass'] ?? ''));
+		$dbhost  = trim((string) ($_POST['dbhost'] ?? ''));
+		$dbhostro  = trim((string) ($_POST['dbhostro'] ?? ''));
+		$mchost  = trim((string) ($_POST['mchost'] ?? ''));
 
 		// Try to connect to the MySQL host server and gracefully handle mysqli strict mode
 		$db_error_msg = '';
@@ -229,22 +235,30 @@ switch ($step) {
 		//regex to find values in the config file
 		$re = '/(\$\w*) = \'(\w*)\';/i';
 
-		$handle = fopen(substr(__DIR__, 0, -10) . '/202-config.php', 'w');
+		$configPath = substr(__DIR__, 0, -10) . '/202-config.php';
+		$handle = fopen($configPath, 'w');
+		if ($handle === false) {
+			_die("<p>Could not open <code>202-config.php</code> for writing. Please check the directory permissions, or create the file manually from <code>202-config-sample.php</code>.</p>");
+		}
 
 		foreach ($configFile as $line) {
-			preg_match($re, $line, $matches);
+			if (!preg_match($re, $line, $matches)) {
+				fwrite($handle, $line);
+				continue;
+			}
 			match ($matches[1]) {
-                '$dbname' => fwrite($handle, str_replace("putyourdbnamehere", $dbname, $line)),
-                '$dbuser' => fwrite($handle, str_replace("'usernamehere'", "'$dbuser'", $line)),
-                '$dbpass' => fwrite($handle, str_replace("'yourpasswordhere'", "'$dbpass'", $line)),
-                '$dbhost' => fwrite($handle, str_replace("localhosthere", $dbhost, $line)),
-                '$dbhostro' => fwrite($handle, str_replace("localhostreplica", $dbhostro, $line)),
-                '$mchost' => fwrite($handle, str_replace("localhostmemcache", $mchost, $line)),
+                '$dbname' => fwrite($handle, str_replace("putyourdbnamehere", escape_config_value($dbname), $line)),
+                '$dbuser' => fwrite($handle, str_replace("usernamehere", escape_config_value($dbuser), $line)),
+                '$dbpass' => fwrite($handle, str_replace("yourpasswordhere", escape_config_value($dbpass), $line)),
+                '$dbhost' => fwrite($handle, str_replace("localhosthere", escape_config_value($dbhost), $line)),
+                '$dbhostro' => fwrite($handle, str_replace("localhostreplica", escape_config_value($dbhostro), $line)),
+                '$mchost' => fwrite($handle, str_replace("localhostmemcache", escape_config_value($mchost), $line)),
                 default => fwrite($handle, $line),
             };
 		}
 		fclose($handle);
-		chmod(substr(__DIR__, 0, -10) . '/202-config.php', 0666);
+		// Owner/group read only — this file holds database credentials
+		chmod($configPath, 0640);
 
 			_die("<p>All right sparky! You've made it through this part of the installation. Prosper202 can now communicate with your database. If you are ready, go ahead and <a class='btn btn-xs btn-p202' href=\"install.php\">run the install!</a></p>");
 	}

--- a/202-config/setup-config.php
+++ b/202-config/setup-config.php
@@ -26,43 +26,55 @@ function escape_config_value(string $value): string
 	return str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
 }
 
+// Inverse of escape_config_value(), for reading values back out of the file
+function unescape_config_value(string $value): string
+{
+	return strtr($value, ['\\\\' => '\\', "\\'" => "'"]);
+}
+
+// Matches "$var = 'value';" config lines. The value part accepts any
+// character, with \' and \\ treated as escape sequences, so hostnames with
+// dots/hyphens and escaped passwords written by this wizard round-trip.
+$config_line_re = '/(\$\w+) = \'((?:[^\'\\\\]|\\\\.)*)\';/';
+
 // Check if 202-config.php has been created
 if (file_exists(substr(__DIR__, 0, -10) . '/202-config.php')) {
 	//_die("<p>The file '202-config.php' already exists. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href='install.php'>installing now</a>.</p>");
-	$re = '/(\$\w*) = \'(\w*)\';/i';
-
 	$handle = fopen(substr(__DIR__, 0, -10) . '/202-config.php', 'r');
 	$old = [];
-	while (!feof($handle)) {
+	while ($handle !== false && !feof($handle)) {
 		$line = fgets($handle);
 		if ($line === false) {
 			continue;
 		}
 		$matches = [];
-			if (preg_match($re, $line, $matches)) {
+			if (preg_match($config_line_re, $line, $matches)) {
+			$value = unescape_config_value($matches[2]);
 			switch ($matches[1]) {
 			case '$dbname':
-				$odbname = $matches[2];
+				$odbname = $value;
 				break;
 			case '$dbuser':
-				$odbuser = $matches[2];
+				$odbuser = $value;
 				break;
 			case '$dbpass':
-				$odbpass = $matches[2];
+				$odbpass = $value;
 				break;
 			case '$dbhost':
-				$odbhost = $matches[2];
+				$odbhost = $value;
 				break;
 			case '$dbhostro':
-				$odbhostro = $matches[2];
+				$odbhostro = $value;
 				break;
 			case '$mchost':
-				$omchost = $matches[2];
+				$omchost = $value;
 				break;
 			}
 		}
 	}
-	fclose($handle);
+	if ($handle !== false) {
+		fclose($handle);
+	}
 }
 
 
@@ -232,9 +244,6 @@ switch ($step) {
 			<p><a href='setup-config.php?step=1' class='btn btn-sm btn-p202 btn-block'>Go back and enter your database credentials again!</a></p>
 		");
 		}
-		//regex to find values in the config file
-		$re = '/(\$\w*) = \'(\w*)\';/i';
-
 		$configPath = substr(__DIR__, 0, -10) . '/202-config.php';
 		$handle = fopen($configPath, 'w');
 		if ($handle === false) {
@@ -242,7 +251,7 @@ switch ($step) {
 		}
 
 		foreach ($configFile as $line) {
-			if (!preg_match($re, $line, $matches)) {
+			if (!preg_match($config_line_re, $line, $matches)) {
 				fwrite($handle, $line);
 				continue;
 			}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM php:8.3-apache
+
+# git/unzip for Composer; libmemcached for the optional memcached extension
+# used by 202-config/connect.php. Dev libs stay installed because the built
+# extensions link against their runtime counterparts.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        libmemcached-dev \
+        zlib1g-dev \
+        libssl-dev \
+    && pecl install memcached \
+    && docker-php-ext-enable memcached \
+    && docker-php-ext-install -j"$(nproc)" mysqli pdo_mysql opcache \
+    && rm -rf /var/lib/apt/lists/*
+
+# mod_rewrite plus the minimal override set the shipped .htaccess files need
+# (see the Apache notes in README.md)
+RUN a2enmod rewrite \
+    && { \
+        echo '<Directory /var/www/html>'; \
+        echo '    Options -Indexes +FollowSymLinks'; \
+        echo '    AllowOverride FileInfo Options=FollowSymLinks'; \
+        echo '    Require all granted'; \
+        echo '</Directory>'; \
+    } > /etc/apache2/conf-available/prosper202.conf \
+    && a2enconf prosper202
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+# The entrypoint runs composer as root inside the container
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+COPY build/scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /var/www/html
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # mod_rewrite plus the minimal override set the shipped .htaccess files need
-# (see the Apache notes in README.md)
+# (see the Apache notes in README.md). The dotfile deny matters here: the
+# compose bind mount puts the whole checkout — including .env and .git — in
+# the document root, and Apache only blocks .ht* by default.
 RUN a2enmod rewrite \
     && { \
         echo '<Directory /var/www/html>'; \
@@ -24,6 +26,10 @@ RUN a2enmod rewrite \
         echo '    AllowOverride FileInfo Options=FollowSymLinks'; \
         echo '    Require all granted'; \
         echo '</Directory>'; \
+        echo '# Deny dotfiles (.env, .git, ...) but keep /.well-known/ for ACME'; \
+        echo '<LocationMatch "/\.(?!well-known/)">'; \
+        echo '    Require all denied'; \
+        echo '</LocationMatch>'; \
     } > /etc/apache2/conf-available/prosper202.conf \
     && a2enconf prosper202
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ Dependencies are automatically installed on container startup.
 
 5. Access the application in your browser.
 
+#### Apache Alternative
+
+If you prefer Apache over Nginx, point your document root at the project directory and ensure `mod_rewrite` is enabled with `AllowOverride All` so the `.htaccess` files in `api/v2/` and `api/v3/` can handle routing. Example virtual host:
+
+```apache
+<VirtualHost *:80>
+    ServerName your-domain.com
+    DocumentRoot /path/to/prosper202
+
+    <Directory /path/to/prosper202>
+        Options -Indexes +FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+```
+
+Enable the required module and reload:
+
+```bash
+sudo a2enmod rewrite
+sudo systemctl reload apache2
+```
+
 ## API v3
 
 REST API under `/api/v3/` with bearer token authentication. Covers all Prosper202 entities: campaigns, networks, traffic sources, trackers, landing pages, text ads, clicks, conversions, rotators, attribution models, users, and system operations.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ This stack is a development configuration (PHP `display_errors` is on). For prod
            include fastcgi_params;
        }
 
-       location ~ /\. {
+       # Deny dotfiles (.git, .env, ...) but keep /.well-known/ reachable
+       # for ACME (Let's Encrypt) HTTP-01 validation
+       location ~ /\.(?!well-known/) {
            deny all;
        }
    }
@@ -157,8 +159,9 @@ If you prefer Apache over Nginx, point your document root at the project directo
         Require all granted
     </Directory>
 
-    # Deny dotfiles (.git, .env, ...), matching the Nginx example above
-    <LocationMatch "/\.">
+    # Deny dotfiles (.git, .env, ...) but keep /.well-known/ reachable for
+    # ACME (Let's Encrypt) HTTP-01 validation, matching the Nginx example above
+    <LocationMatch "/\.(?!well-known/)">
         Require all denied
     </LocationMatch>
 </VirtualHost>
@@ -217,8 +220,8 @@ This variant sets `AllowOverride None` and inlines the shipped `.htaccess` rules
         SetHandler "proxy:unix:/run/php/php8.3-fpm.sock|fcgi://localhost"
     </FilesMatch>
 
-    # Deny dotfiles (.git, .env, ...)
-    <LocationMatch "/\.">
+    # Deny dotfiles (.git, .env, ...) but keep /.well-known/ for ACME
+    <LocationMatch "/\.(?!well-known/)">
         Require all denied
     </LocationMatch>
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Because anyone can deploy this compose file as-is, it ships with no known creden
 - There is no default database password. `docker compose up` refuses to start until you set `MYSQL_ROOT_PASSWORD` (the value is baked into the database volume on first start; changing `.env` later won't change the actual MySQL password).
 - MySQL and memcached are not published on any host port — they are reachable only from the other containers.
 - phpMyAdmin does not start by default. It requires the `debug` profile and binds to `127.0.0.1` only, so it is never reachable from another machine.
+- The web container denies all dotfile requests (keeping `/.well-known/` for ACME), so `.env` and `.git` in the bind-mounted document root are not servable over port 8000.
 - The application itself is published on port 8000 with **no account until you finish the install wizard** — anyone who can reach the port before you do can claim the install. Complete the wizard immediately after `docker compose up`, especially on a machine with a public address.
 
 This stack is a development configuration (PHP `display_errors` is on). For production click servers, use the Manual Installation below with the tuned Nginx or Apache configs.

--- a/README.md
+++ b/README.md
@@ -74,13 +74,27 @@ Dependencies are automatically installed on container startup.
    # Edit 202-config.php with your database credentials
    ```
 
-3. Configure nginx to point to the project root. Example site configuration:
+3. Configure nginx to point to the project root. Example site configuration, tuned for click traffic (many small concurrent requests):
    ```nginx
+   # Reuse FastCGI connections to PHP-FPM instead of opening one per request
+   upstream php_fpm {
+       server unix:/path/to/php-fpm.sock; # or server 127.0.0.1:9000; adjust to your PHP-FPM setup
+       keepalive 16;
+   }
+
    server {
        listen 80;
        server_name your-domain.com;
        root /path/to/prosper202;
        index index.php index.html;
+
+       # Buffer access-log writes; under click bursts an unbuffered log
+       # costs one write() per hit
+       access_log /var/log/nginx/prosper202.access.log combined buffer=64k flush=5s;
+
+       # Cache the stat() results behind the try_files lookups
+       open_file_cache max=10000 inactive=30s;
+       open_file_cache_valid 60s;
 
        location / {
            try_files $uri $uri/ /index.php?$query_string;
@@ -95,7 +109,8 @@ Dependencies are automatically installed on container startup.
        }
 
        location ~ \.php$ {
-           fastcgi_pass unix:/path/to/php-fpm.sock; # or fastcgi_pass 127.0.0.1:9000; adjust to your PHP-FPM setup
+           fastcgi_pass php_fpm;
+           fastcgi_keep_conn on;
            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
            include fastcgi_params;
        }
@@ -105,6 +120,8 @@ Dependencies are automatically installed on container startup.
        }
    }
    ```
+
+   In `nginx.conf`, make sure `worker_processes auto;` is set and raise `worker_connections` (e.g. `4096`) if you expect sustained click volume. Concurrency is ultimately capped by PHP-FPM, so size `pm.max_children` in your FPM pool to match.
 
 4. Reload nginx:
    ```bash
@@ -141,6 +158,76 @@ The example assumes PHP is already hooked up — either mod_php (`sudo a2enmod p
 sudo a2enmod rewrite
 sudo systemctl restart apache2
 ```
+
+##### Apache tuned for click traffic
+
+The simple vhost above prioritizes working out of the box with the repo's `.htaccess` files. For a production click server, two things in it cost real throughput:
+
+- Any `AllowOverride` other than `None` makes Apache stat and re-parse `.htaccess` files in every directory along the request path, on every request.
+- mod_php forces the prefork MPM — one heavyweight process per connection. The event MPM with PHP-FPM handles click-burst concurrency far better (the same model as the Nginx setup).
+
+This variant sets `AllowOverride None` and inlines the shipped `.htaccess` rules into the vhost, so keep it in sync if those files change:
+
+```apache
+<VirtualHost *:80>
+    ServerName your-domain.com
+    DocumentRoot /path/to/prosper202
+
+    <Directory /path/to/prosper202>
+        Options -Indexes +FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    # Inlined from api/v2/.htaccess
+    <Directory /path/to/prosper202/api/v2>
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^ index.php [QSA,L]
+    </Directory>
+
+    # Inlined from api/v3/.htaccess
+    <Directory /path/to/prosper202/api/v3>
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteRule ^ index.php [QSA,L]
+    </Directory>
+
+    # Inlined from tracking202/update/reports/.htaccess
+    <Directory /path/to/prosper202/tracking202/update/reports>
+        RewriteEngine On
+        RewriteRule .* /202-404.php [L]
+    </Directory>
+
+    # PHP via FPM so the event MPM stays in place
+    <FilesMatch "\.php$">
+        SetHandler "proxy:unix:/run/php/php8.3-fpm.sock|fcgi://localhost"
+    </FilesMatch>
+
+    # Deny dotfiles (.git, .env, ...)
+    <LocationMatch "/\.">
+        Require all denied
+    </LocationMatch>
+
+    # Keep connections open across a visitor's click/redirect chain,
+    # but release them quickly so workers aren't pinned by idle clients
+    KeepAlive On
+    MaxKeepAliveRequests 1000
+    KeepAliveTimeout 2
+</VirtualHost>
+```
+
+Switch the MPM and PHP handler to match:
+
+```bash
+sudo a2dismod php8.3 mpm_prefork   # skip php8.3 if mod_php was never enabled
+sudo a2enmod mpm_event proxy_fcgi setenvif rewrite
+sudo a2enconf php8.3-fpm
+sudo systemctl restart apache2
+```
+
+As with Nginx, throughput is ultimately capped by PHP-FPM, so size `pm.max_children` in your FPM pool to your traffic; raise `MaxRequestWorkers` in `mpm_event.conf` alongside it.
 
 ## API v3
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Dependencies are automatically installed on container startup.
 - Application: `http://localhost:8000`
 - phpMyAdmin: `http://localhost:8080`
 
+The MySQL root password defaults to `root_password` for local development. To change it, set `MYSQL_ROOT_PASSWORD` in your environment or a `.env` file before the first `docker compose up` (the value is baked into the database volume on first start).
+
 ### Manual Installation
 
 1. Clone and install dependencies:

--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ The install script will:
 ```bash
 git clone https://github.com/tracking202/prosper202.git
 cd prosper202
+echo "MYSQL_ROOT_PASSWORD=$(openssl rand -hex 16)" > .env
 docker compose up -d
 ```
 
-Dependencies are automatically installed on container startup.
+Dependencies are automatically installed on container startup. Alternatively, run `./install.sh` and pick the Docker option — it generates the `.env` for you.
 
 - Application: `http://localhost:8000`
-- phpMyAdmin: `http://localhost:8080`
+- phpMyAdmin: `http://localhost:8080` (user `root`, password from your `.env`)
 
-The MySQL root password defaults to `root_password` for local development. To change it, set `MYSQL_ROOT_PASSWORD` in your environment or a `.env` file before the first `docker compose up` (the value is baked into the database volume on first start).
+There is intentionally no default database password — phpMyAdmin is exposed on port 8080, so a well-known default would be usable by anyone who can reach it. `docker compose up` refuses to start until `MYSQL_ROOT_PASSWORD` is set. Note the value is baked into the database volume on first start; changing `.env` later won't change the actual MySQL password.
 
 ### Manual Installation
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,18 @@ docker compose up -d
 Dependencies are automatically installed on container startup. Alternatively, run `./install.sh` and pick the Docker option — it generates the `.env` for you.
 
 - Application: `http://localhost:8000`
-- phpMyAdmin: `http://localhost:8080` (user `root`, password from your `.env`)
+- phpMyAdmin (optional): `docker compose --profile debug up -d`, then `http://127.0.0.1:8080` (user `root`, password from your `.env`)
 
-There is intentionally no default database password — phpMyAdmin is exposed on port 8080, so a well-known default would be usable by anyone who can reach it. `docker compose up` refuses to start until `MYSQL_ROOT_PASSWORD` is set. Note the value is baked into the database volume on first start; changing `.env` later won't change the actual MySQL password.
+#### Security defaults
+
+Because anyone can deploy this compose file as-is, it ships with no known credentials or unnecessarily exposed services:
+
+- There is no default database password. `docker compose up` refuses to start until you set `MYSQL_ROOT_PASSWORD` (the value is baked into the database volume on first start; changing `.env` later won't change the actual MySQL password).
+- MySQL and memcached are not published on any host port — they are reachable only from the other containers.
+- phpMyAdmin does not start by default. It requires the `debug` profile and binds to `127.0.0.1` only, so it is never reachable from another machine.
+- The application itself is published on port 8000 with **no account until you finish the install wizard** — anyone who can reach the port before you do can claim the install. Complete the wizard immediately after `docker compose up`, especially on a machine with a public address.
+
+This stack is a development configuration (PHP `display_errors` is on). For production click servers, use the Manual Installation below with the tuned Nginx or Apache configs.
 
 ### Manual Installation
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Dependencies are automatically installed on container startup.
 
 #### Apache Alternative
 
-If you prefer Apache over Nginx, point your document root at the project directory and ensure `mod_rewrite` is enabled with `AllowOverride All` so the `.htaccess` files in `api/v2/` and `api/v3/` can handle routing. Example virtual host:
+If you prefer Apache over Nginx, point your document root at the project directory and ensure `mod_rewrite` is enabled so the `.htaccess` files shipped in `api/v2/`, `api/v3/`, and `tracking202/update/reports/` can handle routing. Those files only need `AllowOverride FileInfo Options=FollowSymLinks` (`FileInfo` for the rewrite rules, `Options=FollowSymLinks` for the `Options +FollowSymLinks` line in the reports rules) — avoid `AllowOverride All`, which is broader than required. Example virtual host:
 
 ```apache
 <VirtualHost *:80>
@@ -124,17 +124,22 @@ If you prefer Apache over Nginx, point your document root at the project directo
 
     <Directory /path/to/prosper202>
         Options -Indexes +FollowSymLinks
-        AllowOverride All
+        AllowOverride FileInfo Options=FollowSymLinks
         Require all granted
     </Directory>
+
+    # Deny dotfiles (.git, .env, ...), matching the Nginx example above
+    <LocationMatch "/\.">
+        Require all denied
+    </LocationMatch>
 </VirtualHost>
 ```
 
-Enable the required module and reload:
+The example assumes PHP is already hooked up — either mod_php (`sudo a2enmod php8.3`) or PHP-FPM (`sudo a2enmod proxy_fcgi setenvif && sudo a2enconf php8.3-fpm`). Enable the rewrite module and restart:
 
 ```bash
 sudo a2enmod rewrite
-sudo systemctl reload apache2
+sudo systemctl restart apache2
 ```
 
 ## API v3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,44 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8000:80"
+    volumes:
+      - .:/var/www/html
+      - ./build/php/conf.d/error-reporting.ini:/usr/local/etc/php/conf.d/zz-error-reporting.ini:ro
+    environment:
+      APP_ENV: ${APP_ENV:-development}
+    depends_on:
+      db:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root_password}
+      MYSQL_DATABASE: prosper202
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p\"$${MYSQL_ROOT_PASSWORD}\""]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+
+  memcached:
+    image: memcached:1.6-alpine
+
+  phpmyadmin:
+    image: phpmyadmin:5
+    ports:
+      - "8080:80"
+    environment:
+      PMA_HOST: db
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  db_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,10 @@ services:
   db:
     image: mysql:8.0
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root_password}
+      # No default on purpose: a well-known root password would be usable by
+      # anyone who can reach phpMyAdmin on port 8080. Set it in .env (see
+      # .env.example) or let ./install.sh generate one.
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in .env — copy .env.example or run ./install.sh}
       MYSQL_DATABASE: prosper202
     volumes:
       - db_data:/var/lib/mysql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,9 +17,9 @@ services:
   db:
     image: mysql:8.0
     environment:
-      # No default on purpose: a well-known root password would be usable by
-      # anyone who can reach phpMyAdmin on port 8080. Set it in .env (see
-      # .env.example) or let ./install.sh generate one.
+      # No default on purpose: this file ships in an open-source repo, so any
+      # default would be a well-known credential on every deployment. Set it
+      # in .env (see .env.example) or let ./install.sh generate one.
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in .env — copy .env.example or run ./install.sh}
       MYSQL_DATABASE: prosper202
     volumes:
@@ -33,10 +33,15 @@ services:
   memcached:
     image: memcached:1.6-alpine
 
+  # Opt-in only (docker compose --profile debug up -d) and bound to loopback:
+  # this panel exposes MySQL root, so it must never listen on a public
+  # interface by default.
   phpmyadmin:
     image: phpmyadmin:5
+    profiles:
+      - debug
     ports:
-      - "8080:80"
+      - "127.0.0.1:8080:80"
     environment:
       PMA_HOST: db
     depends_on:

--- a/install.sh
+++ b/install.sh
@@ -1216,10 +1216,13 @@ show_summary() {
 
     if [ "$install_type" = "docker" ]; then
         lines+=("${ARROW} Application:  ${BOLD}http://localhost:8000${RESET}")
-        lines+=("${ARROW} phpMyAdmin:   ${BOLD}http://localhost:8080${RESET}")
         lines+=("")
-        lines+=("Credentials for phpMyAdmin:")
-        lines+=("  User: root | Password: MYSQL_ROOT_PASSWORD in .env")
+        lines+=("${WARN} Open the app and finish the install wizard now —")
+        lines+=("  until then anyone who can reach port 8000 can claim it.")
+        lines+=("")
+        lines+=("phpMyAdmin (optional, loopback only):")
+        lines+=("  docker compose --profile debug up -d")
+        lines+=("  http://127.0.0.1:8080 ${DIM}# root / MYSQL_ROOT_PASSWORD in .env${RESET}")
         lines+=("")
         lines+=("Useful commands:")
         lines+=("  docker compose logs -f    ${DIM}# View logs${RESET}")

--- a/install.sh
+++ b/install.sh
@@ -695,11 +695,11 @@ test_db_connection() {
     local pass="$3"
     local name="$4"
 
-    # Escape single quotes in credentials for PHP
-    host="${host//\'/\\\'}"
-    user="${user//\'/\\\'}"
-    pass="${pass//\'/\\\'}"
-    name="${name//\'/\\\'}"
+    # Escape backslashes then single quotes in credentials for PHP
+    host="${host//\\/\\\\}"; host="${host//\'/\\\'}"
+    user="${user//\\/\\\\}"; user="${user//\'/\\\'}"
+    pass="${pass//\\/\\\\}"; pass="${pass//\'/\\\'}"
+    name="${name//\\/\\\\}"; name="${name//\'/\\\'}"
 
     # Build PHP test script with exception handling for PHP 8+
     local test_script="error_reporting(0); mysqli_report(MYSQLI_REPORT_OFF);
@@ -740,11 +740,11 @@ create_database() {
     local pass="$3"
     local name="$4"
 
-    # Escape single quotes in credentials for PHP
-    host="${host//\'/\\\'}"
-    user="${user//\'/\\\'}"
-    pass="${pass//\'/\\\'}"
-    name="${name//\'/\\\'}"
+    # Escape backslashes then single quotes in credentials for PHP
+    host="${host//\\/\\\\}"; host="${host//\'/\\\'}"
+    user="${user//\\/\\\\}"; user="${user//\'/\\\'}"
+    pass="${pass//\\/\\\\}"; pass="${pass//\'/\\\'}"
+    name="${name//\\/\\\\}"; name="${name//\'/\\\'}"
 
     local create_script="error_reporting(0); mysqli_report(MYSQLI_REPORT_OFF);
 try {
@@ -925,9 +925,12 @@ start_docker_containers() {
     # Hide cursor
     tput civis 2>/dev/null || true
 
+    # Same default as docker-compose.yaml; both honor MYSQL_ROOT_PASSWORD
+    local db_root_pass="${MYSQL_ROOT_PASSWORD:-root_password}"
+
     while [ $attempt -lt $max_attempts ]; do
         # Try to connect to MySQL
-        if $compose_cmd exec -T db mysqladmin ping -h localhost -u root -proot_password &>/dev/null 2>&1; then
+        if $compose_cmd exec -T db mysqladmin ping -h localhost -u root -p"$db_root_pass" &>/dev/null 2>&1; then
             break
         fi
         ((attempt++))
@@ -970,7 +973,7 @@ start_docker_containers() {
     DB_HOST="db"
     DB_NAME="prosper202"
     DB_USER="root"
-    DB_PASS="root_password"
+    DB_PASS="$db_root_pass"
     DB_HOST_RO="db"
     MC_HOST="memcached"
 

--- a/install.sh
+++ b/install.sh
@@ -319,6 +319,15 @@ sed_in_place() {
     fi
 }
 
+# Hex only: safe to embed in .env, sed replacements, and PHP single quotes
+generate_db_password() {
+    if command -v openssl &>/dev/null; then
+        openssl rand -hex 16
+    elif [ -r /dev/urandom ]; then
+        od -vN16 -An -tx1 /dev/urandom | tr -d ' \n'
+    fi
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # SECTION 2: Detection Functions
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -899,6 +908,25 @@ start_docker_containers() {
         compose_cmd="docker-compose"
     fi
 
+    # Resolve the MySQL root password before compose up: environment first,
+    # then .env, otherwise generate one. docker-compose.yaml deliberately has
+    # no default — a well-known password would be reachable via phpMyAdmin.
+    local db_root_pass="${MYSQL_ROOT_PASSWORD:-}"
+    if [ -z "$db_root_pass" ] && [ -f "$SCRIPT_DIR/.env" ]; then
+        db_root_pass=$(grep -E '^MYSQL_ROOT_PASSWORD=' "$SCRIPT_DIR/.env" | tail -1 | cut -d= -f2-)
+    fi
+    if [ -z "$db_root_pass" ]; then
+        db_root_pass=$(generate_db_password)
+        if [ -z "$db_root_pass" ]; then
+            print_error "Could not generate a database password (no openssl or /dev/urandom)"
+            return 1
+        fi
+        printf 'MYSQL_ROOT_PASSWORD=%s\n' "$db_root_pass" >> "$SCRIPT_DIR/.env"
+        chmod 600 "$SCRIPT_DIR/.env" 2>/dev/null || true
+        print_success "Generated MySQL root password (saved to .env)"
+    fi
+    export MYSQL_ROOT_PASSWORD="$db_root_pass"
+
     # Build and start containers (build handles pulling base images)
     print_info "Building and starting containers..."
     $compose_cmd up -d --build > "$TMP_DIR/docker_output.log" 2>&1 &
@@ -924,9 +952,6 @@ start_docker_containers() {
 
     # Hide cursor
     tput civis 2>/dev/null || true
-
-    # Same default as docker-compose.yaml; both honor MYSQL_ROOT_PASSWORD
-    local db_root_pass="${MYSQL_ROOT_PASSWORD:-root_password}"
 
     while [ $attempt -lt $max_attempts ]; do
         # Try to connect to MySQL
@@ -1193,8 +1218,8 @@ show_summary() {
         lines+=("${ARROW} Application:  ${BOLD}http://localhost:8000${RESET}")
         lines+=("${ARROW} phpMyAdmin:   ${BOLD}http://localhost:8080${RESET}")
         lines+=("")
-        lines+=("Default credentials for phpMyAdmin:")
-        lines+=("  User: root | Password: root_password")
+        lines+=("Credentials for phpMyAdmin:")
+        lines+=("  User: root | Password: MYSQL_ROOT_PASSWORD in .env")
         lines+=("")
         lines+=("Useful commands:")
         lines+=("  docker compose logs -f    ${DIM}# View logs${RESET}")


### PR DESCRIPTION
Supersedes #99 (includes its Apache vhost docs with the review feedback addressed).

## Docs (README)

- **Apache example** narrowed from `AllowOverride All` to `AllowOverride FileInfo Options=FollowSymLinks` — the minimal set the shipped `.htaccess` files need, including the `Options +FollowSymLinks` line in `tracking202/update/reports/.htaccess` that `FileInfo` alone would break with a 500. Resolves the Copilot review comment on #99.
- Added a **high-traffic Apache variant** (`AllowOverride None` with the `.htaccess` rules inlined into the vhost, event MPM + PHP-FPM instead of mod_php/prefork, keepalive tuned for click chains).
- **Tuned the Nginx example** for click traffic: FastCGI keepalive upstream pool, buffered access log, `open_file_cache`, and notes on the worker/`pm.max_children` knobs that cap concurrency.

## Docker (was broken for fresh clones)

The README quick start and `install.sh --docker` depended on a `docker-compose.yaml` that was **gitignored** — fresh clones had no Docker path at all. Now shipped:

- `Dockerfile`: php:8.3-apache with mysqli/pdo_mysql/opcache/memcached, mod_rewrite with the minimal AllowOverride, Composer, existing entrypoint.
- `docker-compose.yaml`: web on 8000, MySQL 8 with healthcheck, memcached — matching what `install.sh` and the README already promised.

### Security defaults (open-source posture: shipped defaults are everyone's deployment)

- **No default MySQL root password.** Compose refuses to start until `MYSQL_ROOT_PASSWORD` is set; `install.sh` generates a random one into `.env` (chmod 600) so the zero-friction flow survives. `.env.example` is tracked.
- **phpMyAdmin is opt-in** (`--profile debug`) **and loopback-only** (`127.0.0.1:8080`) — it exposes MySQL root and must never listen publicly by default.
- MySQL and memcached publish no host ports.
- README documents the posture, including the unclaimed-installer window on port 8000.

## Web install wizard hardening (`202-config/`)

- `setup-config.php`: escape backslashes/quotes when writing credentials into `202-config.php` (a quote in the DB password used to produce a parse-erroring config — round-trip tested); guard unchecked `preg_match`/`fopen`; `chmod 0640` instead of world-writable `0666`; DB password field is `type="password"` with no prefilled default; HTML-escape prefilled values.
- `install.php`: drop stale PHP 5.4 / MySQL 5.6 checks in favor of the floors `requirements.php` enforces; add missing `exit` after the requirements redirect; accurate min/max password messages; remove the always-empty Password row from the success screen.
- `install.sh`: escape backslashes (not just quotes) when interpolating credentials into `php -r`; Docker path honors `MYSQL_ROOT_PASSWORD`.

## Verification

- Repo PHP lint: 554 files clean; `bash -n` on install.sh.
- `docker compose config` validates; fails fast with an actionable error when `MYSQL_ROOT_PASSWORD` is unset; default service list excludes phpMyAdmin.
- Escaping round-trip tested with hostile passwords (`pa'ss\wo'rd\` etc.) through both the PHP wizard path and the bash installer path.
- Not verified: an actual image build (sandbox has no Docker daemon) — worth watching the first real `docker compose up -d --build`.

https://claude.ai/code/session_01SPqzawJiAgm3onbbUzF1fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPqzawJiAgm3onbbUzF1fk)_