### PR TITLE
Add release packaging that bundles vendor/ and CLI binaries

### DIFF
--- a/.claude/skills/onboard-prosper202/SKILL.md
+++ b/.claude/skills/onboard-prosper202/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: onboard-prosper202
+description: >-
+  Onboard a freshly installed Prosper202 ClickServer. Use when the user wants to
+  "onboard Prosper202", "set up Prosper202", "create my first tracking link",
+  "fill in basic settings", or finish post-install configuration. Interviews the
+  user, then drives the Go CLI (go-cli/p202) to set preferences and build a first
+  working tracker. Requires a completed install and the user's REST API key.
+allowed-tools: Bash(.claude/skills/onboard-prosper202/scripts/find-cli.sh), Bash(make -C go-cli build), Bash(go-cli/p202 *), Bash(go-cli/dist/*/p202 *), Read, Write
+---
+
+# Onboard Prosper202
+
+Guide a new user from a finished install to their first working tracking link by
+driving the Go CLI. Be conversational: ask for what you need, confirm each entity
+you create, and end by handing them a tracking URL.
+
+## 0. Locate the CLI
+
+Run the helper to get a usable `p202` binary path (it prefers the release-bundled
+binary, falls back to a local build, and builds from source if Go is present):
+
+```bash
+.claude/skills/onboard-prosper202/scripts/find-cli.sh
+```
+
+Use the printed path as `P202` in the steps below. If it fails, tell the user the
+CLI binary is missing and Go isn't installed to build it, then stop.
+
+## 1. Connect
+
+Ask the user for:
+- **Install URL** (default `http://localhost:8000`).
+- **REST API key** — shown once on the install success screen, or generated under
+  **Account → REST API Keys**. This is the local `202_api_keys` Bearer key, NOT the
+  my.tracking202 install key.
+
+```bash
+$P202 config set-url "<url>"
+$P202 config set-key "<api-key>"
+$P202 config test          # hits /api/v3/system/health — must succeed before continuing
+```
+
+If `config test` fails, recheck the URL/key with the user and retry. Do not proceed
+until it passes.
+
+## 2. Basic settings
+
+Ask for their tracking domain, currency, and whether they want the daily email,
+then apply them (you need their numeric **user id**, shown on the success screen;
+otherwise ask):
+
+```bash
+$P202 user prefs update <user_id> \
+  --user_tracking_domain="<domain>" \
+  --user_account_currency="<USD|EUR|...>" \
+  --user_daily_email="<on|off>"
+```
+
+## 3. First working tracker
+
+Create the entities in order, parsing the `--json` output to capture each new ID
+for the next call. See `cli-guide.md` in this skill for the full flag reference.
+
+```bash
+$P202 ppc-network  create --ppc_network_name="Google Ads" --json
+$P202 ppc-account  create --ppc_account_name="<acct>" --ppc_network_id=<id> --json
+$P202 aff-network  create --aff_network_name="<network>" --json
+$P202 campaign     create --aff_campaign_name="<offer>" --aff_campaign_url="<offer url>" --aff_network_id=<id> --json
+# optional pre-sell page:
+$P202 landing-page create --landing_page_url="<lp url>" --aff_campaign_id=<id> --json
+$P202 tracker      create --aff_campaign_id=<id> --ppc_account_id=<id> [--landing_page_id=<id>] --json
+$P202 tracker      get-url <tracker_id>
+```
+
+`tracker create-with-url` does the create + URL fetch in one call if you prefer.
+
+## 4. Confirm
+
+```bash
+$P202 dashboard
+```
+
+Present the tracking URL (and landing-page code, if any) and tell the user to put
+the tracking URL in their traffic source. Keep a short summary of every ID you
+created.
+
+## Notes
+- Always pass `--json` on create/read so you can parse IDs reliably; never guess an
+  ID — read it back from the response.
+- If a flag name is uncertain, run `$P202 <resource> create --help` to confirm
+  before calling it.
+- If `config test` works but a create fails with an auth error, the key likely
+  lacks scope — have the user generate a fresh key under Account → REST API Keys.

--- a/.claude/skills/onboard-prosper202/cli-guide.md
+++ b/.claude/skills/onboard-prosper202/cli-guide.md
@@ -1,0 +1,56 @@
+# p202 CLI reference (onboarding subset)
+
+Verified against the Go CLI in `go-cli/`. Run any command with `--help` to see the
+full flag list; add `--json` for machine-parseable output.
+
+## Config
+| Command | Purpose |
+|---------|---------|
+| `p202 config set-url <url>` | Set the Prosper202 instance URL |
+| `p202 config set-key <api-key>` | Set the REST API (Bearer) key |
+| `p202 config test` | Verify connectivity (`/api/v3/system/health`) |
+| `p202 config show` | Show current config |
+
+## System
+| Command | Purpose |
+|---------|---------|
+| `p202 system health` | Health check (no auth) |
+| `p202 system version` | API version |
+| `p202 system cron` | Cron status |
+
+## Preferences
+`p202 user prefs update <user_id> [flags]`
+
+- `--user_tracking_domain` — tracking domain
+- `--user_account_currency` — 3-letter currency code
+- `--user_daily_email` — `on`/`off`
+- `--user_slack_incoming_webhook` — Slack webhook URL
+- `--ipqs_api_key` — IPQS fraud key
+
+`p202 user prefs get <user_id>` reads them back.
+
+## Entities (create)
+Each supports `create` and `--json`. Required flags in **bold**.
+
+| Resource | Key flags |
+|----------|-----------|
+| `ppc-network` | **`--ppc_network_name`** |
+| `ppc-account` | **`--ppc_account_name`**, `--ppc_network_id`, `--ppc_account_default` |
+| `aff-network` | **`--aff_network_name`**, `--aff_network_postback_url`, `--aff_network_postback_append`, `--dni_network_id` |
+| `campaign` | **`--aff_campaign_name`**, **`--aff_campaign_url`**, `--aff_network_id`, `--aff_campaign_payout`, `--aff_campaign_cpc`, `--aff_campaign_currency`, `--aff_campaign_url_2..5`, `--aff_campaign_postback_url` |
+| `landing-page` | **`--landing_page_url`**, `--aff_campaign_id`, `--landing_page_nickname`, `--landing_page_type`, `--leave_behind_page_url` |
+| `tracker` | **`--aff_campaign_id`**, `--ppc_account_id`, `--landing_page_id`, `--text_ad_id`, `--rotator_id`, `--click_cpc`, `--click_cpa` |
+
+## Tracker URL
+- `p202 tracker get-url <id>` — tracking URL for an existing tracker.
+- `p202 tracker create-with-url [tracker flags]` — create and return the URL in one call.
+
+## Reporting
+- `p202 dashboard [--period today|yesterday|last7|last30|last90] [--json]`
+- `p202 report breakdown` / `p202 analytics` — grouped stats.
+
+## Authentication model
+The CLI authenticates with `Authorization: Bearer <key>` where `<key>` is a row in
+the local `202_api_keys` table — generated on the install success screen or under
+**Account → REST API Keys**. It is distinct from `p202_customer_api_key` (the paid
+my.tracking202 install key).

--- a/.claude/skills/onboard-prosper202/scripts/find-cli.sh
+++ b/.claude/skills/onboard-prosper202/scripts/find-cli.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Print the path to a usable p202 binary, building it if necessary.
+# Resolution order:
+#   1. release-bundled binary for this platform (go-cli/dist/<os>-<arch>/p202)
+#   2. a locally built binary (go-cli/p202)
+#   3. build from source with `make -C go-cli build` (requires Go)
+set -euo pipefail
+
+# scripts -> onboard-prosper202 -> skills -> .claude -> repo root
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CLI_DIR="$ROOT/go-cli"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+    x86_64|amd64) arch=amd64 ;;
+    aarch64|arm64) arch=arm64 ;;
+esac
+
+bundled="$CLI_DIR/dist/${os}-${arch}/p202"
+if [ -x "$bundled" ]; then
+    echo "$bundled"
+    exit 0
+fi
+
+if [ -x "$CLI_DIR/p202" ]; then
+    echo "$CLI_DIR/p202"
+    exit 0
+fi
+
+if command -v go >/dev/null 2>&1; then
+    make -C "$CLI_DIR" build >&2
+    echo "$CLI_DIR/p202"
+    exit 0
+fi
+
+echo "Error: no p202 binary found and Go is not installed to build one." >&2
+echo "Either use a release zip (it bundles go-cli/dist/<platform>/p202) or install Go." >&2
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,21 @@ jobs:
         with:
           go-version: '1.22'   # matches go-cli/go.mod
 
+      - name: Verify tag matches version.php
+        # On a tag push, the GitHub Release is named after the tag while the zip
+        # and CLI binaries are stamped from 202-config/version.php. RELEASING.md
+        # requires these to match; enforce it so pushing v1.9.60 without bumping
+        # version.php can't publish a v1.9.60 release containing a 1.9.59 zip.
+        # Skipped for workflow_dispatch (no release is created there).
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          version="$(php -r 'require "202-config/version.php"; echo PROSPER202_VERSION;')"
+          if [ "v${version}" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match 202-config/version.php (v${version}). Bump version.php to ${GITHUB_REF_NAME#v} (or retag) so the release name and artifact agree." >&2
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} matches version.php (v${version})."
+
       - name: Build release artifact
         id: build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
         run: |
           bash build/scripts/package-release.sh
           zip_path="$(ls dist/prosper202-*.zip)"
+          sha256="$(sha256sum "${zip_path}" | cut -d' ' -f1)"
           echo "zip_path=${zip_path}" >> "$GITHUB_OUTPUT"
-          echo "sha256=$(sha256sum "${zip_path}" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize release artifact
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+# Build a self-contained release zip and publish it to GitHub Releases.
+#
+# The heavy lifting lives in build/scripts/package-release.sh — this workflow
+# only provisions the toolchain that script preflights for (php, composer, go,
+# git, zip), runs it on a version tag, and attaches the artifact. Release logic
+# is never duplicated in YAML.
+#
+# Flow: bump 202-config/version.php -> git tag vX.Y.Z -> git push --tags
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # create the Release and upload the zip asset
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # package-release.sh uses `git archive HEAD`
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'   # matches composer.json "php": ">=8.3"
+          tools: composer
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'   # matches go-cli/go.mod
+
+      - name: Build release artifact
+        id: build
+        run: |
+          bash build/scripts/package-release.sh
+          zip_path="$(ls dist/prosper202-*.zip)"
+          echo "zip_path=${zip_path}" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(sha256sum "${zip_path}" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize release artifact
+        if: always()
+        run: |
+          zip_path="${{ steps.build.outputs.zip_path }}"
+          {
+            echo "### Release Artifact"
+            echo ""
+            if [ -n "${zip_path}" ] && [ -f "${zip_path}" ]; then
+              echo "| Item | Value |"
+              echo "| --- | --- |"
+              echo "| Artifact | \`$(basename "${zip_path}")\` |"
+              echo "| Size | $(du -h "${zip_path}" | cut -f1) |"
+              echo "| SHA256 | \`${{ steps.build.outputs.sha256 }}\` |"
+            else
+              echo "> ❌ Build did not produce a zip. Review the job log above."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/prosper202-*.zip
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish GitHub Release
+        # Only publish on a tag push. A workflow_dispatch run from a branch has
+        # no release tag, so it builds + summarizes the artifact (per
+        # RELEASING.md) without invoking action-gh-release, which would fail.
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: dist/prosper202-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ build/debug/
 build/logs/
 build/staging-config.php
 
+# Release artifacts (build/scripts/package-release.sh output)
+/dist/
+
 # Development and documentation
 /docs/
 phpstan-errors.txt

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,10 @@ task-plan-*
 multi-touch-qa-runbook.md
 
 # IDE and editor files
-.claude/
+# Ignore local Claude settings but keep version-controlled skills shipped with
+# the repo (e.g. the onboarding skill).
+.claude/*
+!.claude/skills/
 .github/copilot-instructions.md
 CLAUDE.local.md
 CLAUDE.md

--- a/202-account/index.php
+++ b/202-account/index.php
@@ -10,6 +10,39 @@ template_top();  ?>
 <div class="row home">
 	<div class="col-xs-7">
 		<div class="row">
+			<div class="col-xs-12" id="p202-getting-started" style="display:none;">
+				<h6 class="h6-home">Get Started <span class="glyphicon glyphicon-flag home-icons"></span>
+					<a href="#" id="p202-gs-dismiss" class="pull-right" style="text-decoration:none;color:#999;" title="Dismiss">&times;</a>
+				</h6>
+				<div style="padding: 5px 0 12px;">
+					<small>Three steps to your first tracking link:</small>
+					<ol style="margin-top: 6px;">
+						<li><a href="<?php echo get_absolute_url(); ?>tracking202/setup/ppc_accounts.php">Add a traffic source</a> &mdash; where your clicks come from</li>
+						<li><a href="<?php echo get_absolute_url(); ?>tracking202/setup/aff_campaigns.php">Create a campaign</a> &mdash; the offer you promote</li>
+						<li><a href="<?php echo get_absolute_url(); ?>tracking202/setup/get_trackers.php">Generate a tracking link</a> and put it in your traffic source</li>
+					</ol>
+					<small>Prefer hands-free? Ask Claude to <strong>&ldquo;onboard Prosper202&rdquo;</strong> and it will set this up for you.</small>
+				</div>
+			</div>
+			<script>
+			(function () {
+				try {
+					var card = document.getElementById('p202-getting-started');
+					if (!card) return;
+					if (localStorage.getItem('p202_getting_started_dismissed') !== '1') {
+						card.style.display = '';
+					}
+					var x = document.getElementById('p202-gs-dismiss');
+					if (x) {
+						x.addEventListener('click', function (e) {
+							e.preventDefault();
+							localStorage.setItem('p202_getting_started_dismissed', '1');
+							card.style.display = 'none';
+						});
+					}
+				} catch (err) {}
+			})();
+			</script>
 			<?php if (isset($_SESSION['user_pref_ad_settings']) && $_SESSION['user_pref_ad_settings'] != 'hide_all') { ?>
 				<div class="col-xs-12">
 					<h6 class="h6-home">Special Offers <span class="glyphicon glyphicon-tags home-icons"></span></h6>

--- a/202-config/connect.php
+++ b/202-config/connect.php
@@ -171,11 +171,24 @@ if (file_exists(ROOT_PATH  . '202-config.php')) {
     die();
 }
 include_once(ROOT_PATH  . '202-config.php');
-// Load Composer autoloader if available for PSR-4 classes.
+// Composer dependencies provide the PSR-4 classes used by tracking, install,
+// and the API. A missing vendor/ almost always means the app was deployed from
+// a raw git clone without running `composer install`. Fail loudly with guidance
+// instead of silently limping on to a confusing "Class not found" fatal deeper
+// in the request (CLAUDE.md #4: no silent fallbacks).
 $autoloadPath = ROOT_PATH . 'vendor/autoload.php';
-if (file_exists($autoloadPath)) {
-    require_once $autoloadPath;
+if (!file_exists($autoloadPath)) {
+    http_response_code(500);
+    die('<h2>Prosper202: dependencies are missing</h2>'
+        . '<p>The <code>vendor/</code> folder was not found, so required libraries '
+        . 'cannot be loaded.</p><ul>'
+        . '<li><strong>Shared hosting / no terminal:</strong> download the official '
+        . 'release zip &mdash; it already bundles <code>vendor/</code> &mdash; and upload '
+        . 'that instead of a raw <code>git clone</code>.</li>'
+        . '<li><strong>Have a terminal:</strong> run <code>composer install</code> in the '
+        . 'Prosper202 directory.</li></ul>');
 }
+require_once $autoloadPath;
 include_once(CONFIG_PATH . '/sessions.php');
 include_once(CONFIG_PATH . '/functions-tracking202.php');
 include_once(CONFIG_PATH . '/functions.php');

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -14,7 +14,9 @@ $success = false;
 $html = [
 	'user_email' => '',
 	'user_name' => '',
-	'user_api' => ''
+	'user_api' => '',
+	'rest_api_key' => '',
+	'user_id' => 0
 ];
 
 // Initialize $error array elements to prevent undefined array key warnings
@@ -146,6 +148,26 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$sql = "UPDATE 202_users_pref SET auto_cron = '1' WHERE user_id = '" . $mysql['user_id'] . "'";
 				$result = _mysqli_query($sql);
 			}
+
+			// Generate a REST API v3 key for the new admin so the CLI and the
+			// Claude onboarding agent can authenticate right away. This is the
+			// local 202_api_keys Bearer key, distinct from the my.tracking202
+			// install key (p202_customer_api_key) collected above.
+			$rest_api_key = bin2hex(random_bytes(32));
+			$apikey_stmt = $db->prepare("INSERT INTO 202_api_keys (user_id, api_key, created_at) VALUES (?, ?, ?)");
+			if ($apikey_stmt === false) {
+				$rest_api_key = '';
+			} else {
+				$apikey_created_at = time();
+				$apikey_stmt->bind_param('isi', $user_id, $rest_api_key, $apikey_created_at);
+				if (!$apikey_stmt->execute()) {
+					// Don't surface a key we failed to persist.
+					$rest_api_key = '';
+				}
+				$apikey_stmt->close();
+			}
+			$html['rest_api_key'] = htmlentities($rest_api_key, ENT_QUOTES, 'UTF-8');
+			$html['user_id'] = (int) $user_id;
 
 			// Add null check before accessing array offset on line 120
 				if (isset($mysql['user_timezone'])) {
@@ -362,7 +384,35 @@ if ($success) {
 			<div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', get_absolute_url(), $_SERVER['SERVER_NAME'] . get_absolute_url()); ?></small></div>
 		</div>
 
-		<p><small>Were you expecting more steps? Sorry thats it!</small></p>
+		<?php
+		// Build the absolute base URL for the cron line and CLI connection hints.
+		$scheme = (isset($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) === 'on') ? 'https' : 'http';
+		$base_url = $scheme . '://' . $_SERVER['SERVER_NAME'] . get_absolute_url();
+		$cron_line = '* * * * * curl -s "' . $base_url . '202-cronjobs/index.php" >/dev/null 2>&1';
+		?>
+
+		<h6 style="margin-top: 20px;">Keep background jobs running (cron)</h6>
+		<small>Reports, attribution and emails run on a schedule. If you used Docker this is already handled by the <code>cron</code> service. Otherwise, add this one line to your crontab (<code>crontab -e</code>):</small>
+		<pre style="white-space: pre-wrap; word-break: break-all; font-size: 11px;"><?php echo htmlspecialchars($cron_line, ENT_QUOTES, 'UTF-8'); ?></pre>
+
+		<?php if ($html['rest_api_key'] !== '') { ?>
+		<h6 style="margin-top: 20px;">Connect the CLI / Claude onboarding (optional)</h6>
+		<small>Use this REST API key with the <code>p202</code> CLI or the Claude <code>/onboard-prosper202</code> skill to finish setup hands-free. <strong>Copy it now</strong> — for security it isn't shown again (you can always generate a new one under Account &rarr; REST API Keys).</small>
+		<div class="row" style="margin-top: 8px; margin-bottom: 6px;">
+			<div class="col-xs-3"><span class="label label-default">API URL:</span></div>
+			<div class="col-xs-9"><small><code><?php echo htmlspecialchars($base_url . 'api/v3', ENT_QUOTES, 'UTF-8'); ?></code></small></div>
+		</div>
+		<div class="row" style="margin-bottom: 6px;">
+			<div class="col-xs-3"><span class="label label-default">User ID:</span></div>
+			<div class="col-xs-9"><small><code><?php echo (int) $html['user_id']; ?></code></small></div>
+		</div>
+		<div class="row" style="margin-bottom: 6px;">
+			<div class="col-xs-3"><span class="label label-default">API key:</span></div>
+			<div class="col-xs-9"><small><code style="word-break: break-all;"><?php echo $html['rest_api_key']; ?></code></small></div>
+		</div>
+		<?php } ?>
+
+		<p style="margin-top: 15px;"><small>Were you expecting more steps? Sorry thats it!</small></p>
 	</div>
 <?php info_bottom();
 }

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -158,8 +158,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			if ($apikey_stmt === false) {
 				$rest_api_key = '';
 			} else {
+				// $user_id is a string when read back via SELECT on the
+				// INSERT IGNORE existing-user path; bind it as a real int.
+				$apikey_user_id = (int) $user_id;
 				$apikey_created_at = time();
-				$apikey_stmt->bind_param('isi', $user_id, $rest_api_key, $apikey_created_at);
+				$apikey_stmt->bind_param('isi', $apikey_user_id, $rest_api_key, $apikey_created_at);
 				if (!$apikey_stmt->execute()) {
 					// Don't surface a key we failed to persist.
 					$rest_api_key = '';

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -389,8 +389,14 @@ if ($success) {
 
 		<?php
 		// Build the absolute base URL for the cron line and CLI connection hints.
+		// Prefer the Host header so a non-default port (e.g. Docker's :8000) or
+		// vhost is preserved — SERVER_NAME drops the port, and inside a container
+		// SERVER_PORT is the internal 80, not the mapped port the user sees. The
+		// value is output through htmlspecialchars below, so a forged Host can't
+		// inject markup.
 		$scheme = (isset($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) === 'on') ? 'https' : 'http';
-		$base_url = $scheme . '://' . $_SERVER['SERVER_NAME'] . get_absolute_url();
+		$host = (string) ($_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? 'localhost');
+		$base_url = $scheme . '://' . $host . get_absolute_url();
 		$cron_line = '* * * * * curl -s "' . $base_url . '202-cronjobs/index.php" >/dev/null 2>&1';
 		?>
 
@@ -402,8 +408,8 @@ if ($success) {
 		<h6 style="margin-top: 20px;">Connect the CLI / Claude onboarding (optional)</h6>
 		<small>Use this REST API key with the <code>p202</code> CLI or the Claude <code>/onboard-prosper202</code> skill to finish setup hands-free. <strong>Copy it now</strong> — for security it isn't shown again (you can always generate a new one under Account &rarr; REST API Keys).</small>
 		<div class="row" style="margin-top: 8px; margin-bottom: 6px;">
-			<div class="col-xs-3"><span class="label label-default">API URL:</span></div>
-			<div class="col-xs-9"><small><code><?php echo htmlspecialchars($base_url . 'api/v3', ENT_QUOTES, 'UTF-8'); ?></code></small></div>
+			<div class="col-xs-3"><span class="label label-default">Instance URL:</span></div>
+			<div class="col-xs-9"><small><code><?php echo htmlspecialchars(rtrim($base_url, '/'), ENT_QUOTES, 'UTF-8'); ?></code></small> &mdash; use with <code>p202 config set-url</code> (the CLI appends <code>/api/v3</code> itself)</div>
 		</div>
 		<div class="row" style="margin-bottom: 6px;">
 			<div class="col-xs-3"><span class="label label-default">User ID:</span></div>

--- a/202-config/setup-config.php
+++ b/202-config/setup-config.php
@@ -221,11 +221,12 @@ switch ($step) {
 
 		//if it could not connect, error
 		if (!$connect) {
-			$db_error_msg = mysqli_connect_error();
-			$db_error_no = mysqli_connect_errno();
+			$db_error_msg = htmlspecialchars((string) mysqli_connect_error(), ENT_QUOTES, 'UTF-8');
+			$db_error_no = (int) mysqli_connect_errno();
+			$dbhost_html = htmlspecialchars($dbhost, ENT_QUOTES, 'UTF-8');
 
 			_die("<h6>Error establishing a database connection</h6>
-			<p><small>This either means that the username and password information is incorrect or we can't contact the database server at <code>$dbhost</code>. This could mean your host's database server is down.</small></p>
+			<p><small>This either means that the username and password information is incorrect or we can't contact the database server at <code>$dbhost_html</code>. This could mean your host's database server is down.</small></p>
 			<p><strong style='color: red;'>MySQL Error ($db_error_no): $db_error_msg</strong></p>
 			<small>
 			<ul>
@@ -255,9 +256,11 @@ switch ($step) {
 		}
 		if ($create_error !== '') {
 			$dbname_html = htmlspecialchars($dbname, ENT_QUOTES, 'UTF-8');
+			$dbhost_html = htmlspecialchars($dbhost, ENT_QUOTES, 'UTF-8');
+			$dbuser_html = htmlspecialchars($dbuser, ENT_QUOTES, 'UTF-8');
 			$create_error_html = htmlspecialchars($create_error, ENT_QUOTES, 'UTF-8');
 			_die("<h6>Could not create the database</h6>
-			<p><small>We connected to <code>$dbhost</code> as <code>$dbuser</code>, but the database <code>$dbname_html</code> does not exist and we couldn't create it. On shared hosting you usually have to create the database yourself first (for example cPanel &rarr; <em>MySQL Databases</em>), then come back and re-run this step.</small></p>
+			<p><small>We connected to <code>$dbhost_html</code> as <code>$dbuser_html</code>, but the database <code>$dbname_html</code> does not exist and we couldn't create it. On shared hosting you usually have to create the database yourself first (for example cPanel &rarr; <em>MySQL Databases</em>), then come back and re-run this step.</small></p>
 			<p><strong style='color: red;'>MySQL Error: $create_error_html</strong></p>
 			<p><a href='setup-config.php?step=1' class='btn btn-sm btn-p202 btn-block'>Go back and check your database details</a></p>
 		");

--- a/202-config/setup-config.php
+++ b/202-config/setup-config.php
@@ -210,40 +210,59 @@ switch ($step) {
 		$dbhostro  = trim((string) ($_POST['dbhostro'] ?? ''));
 		$mchost  = trim((string) ($_POST['mchost'] ?? ''));
 
-		// Try to connect to the MySQL host server and gracefully handle mysqli strict mode
-		$db_error_msg = '';
-		$db_error_no = 0;
-		try {
-			$connect = mysqli_connect($dbhost, $dbuser, $dbpass, $dbname);
-		} catch (mysqli_sql_exception $e) {
-			$connect = false;
-			$db_error_msg = $e->getMessage();
-			$db_error_no = (int) $e->getCode();
-		}
+		// Probe the connection with return values rather than exceptions so we
+		// can distinguish "host/credentials wrong" from "database not created
+		// yet" and try to create the database ourselves.
+		mysqli_report(MYSQLI_REPORT_OFF);
+
+		// First connect to the server WITHOUT a database, so a missing database
+		// isn't mistaken for bad credentials.
+		$connect = mysqli_connect($dbhost, $dbuser, $dbpass);
 
 		//if it could not connect, error
 		if (!$connect) {
-			// Fall back to mysqli helper if the exception didn't capture the message
-			if ($db_error_msg === '') {
-				$db_error_msg = mysqli_connect_error();
-				$db_error_no = mysqli_connect_errno();
-			}
+			$db_error_msg = mysqli_connect_error();
+			$db_error_no = mysqli_connect_errno();
 
 			_die("<h6>Error establishing a database connection</h6>
 			<p><small>This either means that the username and password information is incorrect or we can't contact the database server at <code>$dbhost</code>. This could mean your host's database server is down.</small></p>
-			<p><strong style='color: red;'>MySQL Error ($db_error_no): $db_error_msg</strong></p> 
+			<p><strong style='color: red;'>MySQL Error ($db_error_no): $db_error_msg</strong></p>
 			<small>
-			<ul> 
+			<ul>
 				<li>Are you sure you have the correct username and password?</li>
 				<li>Are you sure that you have typed the correct hostname?</li>
-				<li>Are you sure that you have typed the correct database name?</li>
 				<li>Are you sure that the database server is running?</li>
 			</ul>
-			</small> 
+			</small>
 			<p><small>If you're unsure what these terms mean you should probably contact your host. If you still need help, please visit the <a href='http://support.tracking202.com/how-to-set-up-and-use-prosper202-pro/installing-prosper202?utm_source=db-install-error'>Prosper202 Support Site</a>.</small> </p>
 			<p><a href='setup-config.php?step=1' class='btn btn-sm btn-p202 btn-block'>Go back and enter your database credentials again!</a></p>
 		");
 		}
+
+		// Host + credentials are good. Select the database; if it doesn't exist
+		// yet, try to create it. On shared hosting the account often lacks the
+		// CREATE privilege (the DB must be made in the control panel first), so
+		// fail gracefully with that guidance. Check every return value.
+		$create_error = '';
+		if (!mysqli_select_db($connect, $dbname)) {
+			$dbname_quoted = str_replace('`', '``', $dbname);
+			$create_sql = "CREATE DATABASE IF NOT EXISTS `$dbname_quoted` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+			if (!mysqli_query($connect, $create_sql)) {
+				$create_error = mysqli_error($connect);
+			} elseif (!mysqli_select_db($connect, $dbname)) {
+				$create_error = mysqli_error($connect) ?: 'could not select the database after creating it';
+			}
+		}
+		if ($create_error !== '') {
+			$dbname_html = htmlspecialchars($dbname, ENT_QUOTES, 'UTF-8');
+			$create_error_html = htmlspecialchars($create_error, ENT_QUOTES, 'UTF-8');
+			_die("<h6>Could not create the database</h6>
+			<p><small>We connected to <code>$dbhost</code> as <code>$dbuser</code>, but the database <code>$dbname_html</code> does not exist and we couldn't create it. On shared hosting you usually have to create the database yourself first (for example cPanel &rarr; <em>MySQL Databases</em>), then come back and re-run this step.</small></p>
+			<p><strong style='color: red;'>MySQL Error: $create_error_html</strong></p>
+			<p><a href='setup-config.php?step=1' class='btn btn-sm btn-p202 btn-block'>Go back and check your database details</a></p>
+		");
+		}
+
 		$configPath = substr(__DIR__, 0, -10) . '/202-config.php';
 		$handle = fopen($configPath, 'w');
 		if ($handle === false) {

--- a/202-config/setup.php
+++ b/202-config/setup.php
@@ -34,12 +34,10 @@ if (is_installed() === true) {
     exit;
 }
 
-// If the paid API key was already captured, jump straight to the admin step;
-// otherwise start at the requirements screen which leads into the key step.
-if (isset($_COOKIE['user_api']) && $_COOKIE['user_api'] !== '') {
-    header('Location: ' . get_absolute_url() . '202-config/install.php');
-    exit;
-}
-
+// Always start at the requirements screen so the server checks (PHP version and
+// extensions, MySQL version, curl) run before account creation — install.php
+// performs none of those. A stale user_api cookie must not let the user skip the
+// gate, so we no longer short-circuit to install.php. requirements.php ->
+// get_apikey.php -> install.php are chained by the buttons on each page.
 header('Location: ' . get_absolute_url() . '202-config/requirements.php');
 exit;

--- a/202-config/setup.php
+++ b/202-config/setup.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+/**
+ * Unified setup entry point.
+ *
+ * A fresh install (Docker, shared-hosting upload, or local) lands here and is
+ * forwarded to whichever step still needs doing, so the user follows one linear
+ * path instead of hunting for the right page:
+ *
+ *   1. Database      -> 202-config/setup-config.php   (no 202-config.php yet)
+ *   2. Requirements  -> 202-config/requirements.php   (server checks)
+ *   3. API key       -> 202-config/get_apikey.php     (linked from requirements)
+ *   4. Admin account -> 202-config/install.php        (creates the account)
+ *
+ * Steps 2->3->4 are already chained by the buttons on those pages; this router
+ * just picks the correct starting point and skips steps already completed.
+ */
+require_once(__DIR__ . '/functions.php');
+
+// Step 1: without 202-config.php we can't reach the database yet — collect the
+// database credentials (and auto-create the database) in the config wizard.
+if (!file_exists(__DIR__ . '/../202-config.php')) {
+    header('Location: ' . get_absolute_url() . '202-config/setup-config.php');
+    exit;
+}
+
+// Config exists, so pull in the full bootstrap (this also enforces the
+// vendor/ dependency preflight in connect.php).
+require_once(__DIR__ . '/connect.php');
+
+// Already finished? Go to login.
+if (is_installed() === true) {
+    header('Location: ' . get_absolute_url() . '202-login.php');
+    exit;
+}
+
+// If the paid API key was already captured, jump straight to the admin step;
+// otherwise start at the requirements screen which leads into the key step.
+if (isset($_COOKIE['user_api']) && $_COOKIE['user_api'] !== '') {
+    header('Location: ' . get_absolute_url() . '202-config/install.php');
+    exit;
+}
+
+header('Location: ' . get_absolute_url() . '202-config/requirements.php');
+exit;

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ zip**, not a `git clone` — the release already bundles all PHP dependencies
 > Maintainers build this zip with `build/scripts/package-release.sh` (see
 > [Building a release](#building-a-release)).
 
+> **Coming soon:** a one-click install via Softaculous/Installatron, so you can
+> install Prosper202 straight from your hosting control panel with no upload step.
+> It is packaged from the same release zip; until it lands in those catalogs, use
+> the download-and-upload steps above.
+
 ### From source
 
 #### Quick Install

--- a/README.md
+++ b/README.md
@@ -352,6 +352,11 @@ build/scripts/package-release.sh
 The version comes from `202-config/version.php`, the single source of truth, and is
 passed through to the Go build so the CLI's `--version` matches the zip name.
 
+Tagged releases (`v*`) are built and published automatically by the
+[`Release` workflow](.github/workflows/release.yml). For the full maintainer
+process — versioning, tagging, CI, local builds, and troubleshooting — see
+**[RELEASING.md](RELEASING.md)**.
+
 ## Configuration
 
 - **Main config**: `202-config.php` (created from `202-config-sample.php`)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,33 @@ Since 2007, Prosper202 has helped marketers take control of their tracking with 
 
 ## Installation
 
-### Quick Install
+There are two tracks. Pick by what you have access to:
+
+| You have… | Use | What you do |
+|-----------|-----|-------------|
+| Shared/cPanel hosting, **no terminal** | **Download & upload** (below) | Upload a pre-built zip, click through the wizard |
+| A terminal (VPS, local, Docker) | **From source** (below) | `git clone` + `./install.sh` or Docker |
+
+### Download & Upload (no terminal)
+
+For shared hosting (cPanel/Plesk) where you can't run Composer. Use the **release
+zip**, not a `git clone` — the release already bundles all PHP dependencies
+(`vendor/`) and the Go CLI binaries, so nothing needs to be compiled on the server.
+
+1. Download `prosper202-<version>.zip` from the
+   [Releases page](https://github.com/tracking202/prosper202/releases).
+2. Upload and extract it into your web root (cPanel **File Manager → Upload →
+   Extract**, or FTP).
+3. Browse to your site. The setup wizard runs automatically and walks you through
+   every step — it checks requirements, **creates the database for you**, validates
+   your API key, and creates your admin account. No config file editing, no terminal.
+
+> Maintainers build this zip with `build/scripts/package-release.sh` (see
+> [Building a release](#building-a-release)).
+
+### From source
+
+#### Quick Install
 
 ```bash
 git clone https://github.com/tracking202/prosper202.git
@@ -45,8 +71,9 @@ The install script will:
 - Check for PHP and Composer (installs Composer if missing)
 - Install PHP dependencies
 - Create config file from sample
+- Test/create the database and print the cron line to add
 
-### Docker
+#### Docker
 
 ```bash
 git clone https://github.com/tracking202/prosper202.git
@@ -72,7 +99,7 @@ Because anyone can deploy this compose file as-is, it ships with no known creden
 
 This stack is a development configuration (PHP `display_errors` is on). For production click servers, use the Manual Installation below with the tuned Nginx or Apache configs.
 
-### Manual Installation
+#### Manual Installation
 
 1. Clone and install dependencies:
    ```bash
@@ -305,6 +332,20 @@ cd go-cli && make test
 ```bash
 ./scripts/php-lint.sh
 ```
+
+### Building a release
+
+Produce the self-contained zip used by the [Download & Upload](#download--upload-no-terminal)
+track. It bundles `vendor/` (Composer `--no-dev`) and cross-built Go CLI binaries so
+end users need no Composer or Go toolchain:
+
+```bash
+build/scripts/package-release.sh
+# -> dist/prosper202-<version>.zip  (+ printed SHA256)
+```
+
+The version comes from `202-config/version.php`, the single source of truth, and is
+passed through to the Go build so the CLI's `--version` matches the zip name.
 
 ## Configuration
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,8 +50,8 @@ This is the normal path. CI builds and publishes; you only tag.
 
    ```bash
    git checkout main && git pull
-   git tag v2.0.0          # must match version.php's 2.0.0
-   git push origin v2.0.0
+   git tag v1.9.59          # must match version.php (currently 1.9.59)
+   git push origin v1.9.59
    ```
 
 3. **Let CI do the rest.** The [`Release` workflow](.github/workflows/release.yml)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,113 @@
+# Releasing Prosper202
+
+This guide is for **maintainers** cutting a new Prosper202 release. End users
+never run any of this — they download the finished zip from the
+[Releases page](https://github.com/tracking202/prosper202/releases) (see the
+"Download & Upload" track in the [README](README.md)).
+
+> Audience note: this is the engineering release process. The commercial
+> upgrade *policy* (pricing, free-after-six-months) lives in
+> [`documentation/setting-up-prosper202-pro/999-prosper202-release-cycle.md`](documentation/setting-up-prosper202-pro/999-prosper202-release-cycle.md).
+
+## What a release is
+
+A release is a single self-contained zip, `prosper202-<version>.zip`, that
+bundles everything a server needs to run with **no terminal, no Composer, and
+no Go toolchain**:
+
+- All tracked source (clean `git archive` of the tag — no `.git`, no dev cruft).
+- `vendor/` built with `composer install --no-dev --optimize-autoloader`.
+- Pre-built Go CLI binaries for all six targets (linux/darwin/windows ×
+  amd64/arm64) under `go-cli/dist/`.
+
+That is the "download the release, not the git clone" promise: shared-hosting
+users upload the zip and the browser wizard does the rest.
+
+## The single source of truth: `202-config/version.php`
+
+The version lives in **one** place — the `$version_string` in
+[`202-config/version.php`](202-config/version.php). Everything downstream reads
+from it:
+
+- `build/scripts/package-release.sh` reads it to name the zip.
+- It passes that version into the Go build (`make ... VERSION=<version>`), so
+  the CLI's `--version` matches the zip.
+- It defines `PROSPER202_VERSION` used throughout the app and the upgrade check.
+
+The format is validated (`MAJOR.MINOR.PATCH` with an optional `-suffix`); an
+invalid string throws on load. **Always bump this file first** — never tag a
+release without bumping it, or the zip name and the in-app version will disagree.
+
+## Standard release flow (automated)
+
+This is the normal path. CI builds and publishes; you only tag.
+
+1. **Bump the version.** Edit `$version_string` in `202-config/version.php`,
+   commit it (e.g. `chore: release vX.Y.Z`), and push to the default branch via
+   the usual PR process.
+
+2. **Tag and push the tag.** The tag must be `v` + the exact version you set:
+
+   ```bash
+   git checkout main && git pull
+   git tag v2.0.0          # must match version.php's 2.0.0
+   git push origin v2.0.0
+   ```
+
+3. **Let CI do the rest.** The [`Release` workflow](.github/workflows/release.yml)
+   fires on `v*` tags. It:
+   - provisions PHP 8.3 + Composer and Go 1.22 (matching `composer.json` and
+     `go-cli/go.mod`),
+   - runs `build/scripts/package-release.sh` (no build logic is duplicated in
+     YAML),
+   - writes a job summary with the artifact name, size, and SHA256, and
+   - publishes a GitHub Release for the tag with the zip attached and
+     auto-generated release notes.
+
+4. **Verify on the Releases page.** Confirm `prosper202-<version>.zip` is
+   attached and the version in the filename matches the tag. Download it, unzip,
+   and spot-check that `vendor/autoload.php` and `go-cli/dist/linux-amd64/p202`
+   exist.
+
+> No GitHub secrets are required — the workflow uses the auto-provided
+> `GITHUB_TOKEN` (with `contents: write`) to create the release and upload the
+> asset.
+
+### Re-running a release
+
+You can also trigger the workflow manually from the Actions tab
+(`workflow_dispatch`) — useful for testing the build without cutting a tag,
+though a manual run won't create a Release unless it was started from a tag ref.
+To redo a botched release, delete the GitHub Release and the tag, fix the issue,
+and re-tag.
+
+## Building locally (fallback / testing)
+
+To produce the exact same artifact on your own machine — for testing, or if CI
+is unavailable:
+
+```bash
+build/scripts/package-release.sh
+# -> dist/prosper202-<version>.zip   (+ printed SHA256)
+```
+
+Prerequisites (the script preflights for these and fails loudly if any is
+missing): `php`, `composer`, `go`, `git`, `zip`. The script exports the current
+`HEAD`, so commit your changes first — uncommitted edits won't be included.
+
+## Troubleshooting
+
+- **`required tool(s) not installed: …`** — install the named tool. Locally you
+  need the full set above; in CI this means a `setup-*` step is missing or
+  failed.
+- **`composer install did not produce vendor/autoload.php`** — a dependency or
+  platform constraint failed. Run the `composer install --no-dev` line by hand
+  to see the real error.
+- **Go build fails** — confirm `go version` is ≥ 1.22 and that
+  `make -C go-cli all` succeeds on its own. Cross-compiles use
+  `CGO_ENABLED=0`, so no C toolchain is needed.
+- **Zip name doesn't match the tag** — you tagged without bumping
+  `202-config/version.php`. Delete the tag, bump the file, re-tag.
+- **`fail_on_unmatched_files`** trips when the build produced no zip — read the
+  "Build release artifact" step log; the publish step is working as intended by
+  refusing to create an empty release.

--- a/build/scripts/docker-entrypoint.sh
+++ b/build/scripts/docker-entrypoint.sh
@@ -22,7 +22,7 @@ fi
 # is safe to run on every container start. A real failure (missing sample,
 # unwritable target) would otherwise boot the container with broken DB config,
 # so let `set -e` surface it loudly instead of swallowing it.
-if [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+if [ -n "${MYSQL_ROOT_PASSWORD:-}" ]; then
     php build/scripts/write-config.php
 fi
 

--- a/build/scripts/docker-entrypoint.sh
+++ b/build/scripts/docker-entrypoint.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
 set -e
 
+cd /var/www/html
+
 # Install composer dependencies if vendor directory is missing or empty
-if [ ! -d "/var/www/html/vendor" ] || [ ! -f "/var/www/html/vendor/autoload.php" ]; then
+if [ ! -d "vendor" ] || [ ! -f "vendor/autoload.php" ]; then
     echo "Installing Composer dependencies..."
-    cd /var/www/html
-    
+
     if [ "$APP_ENV" = "development" ] || [ "$APP_ENV" = "dev" ]; then
         composer install --no-interaction
     else
         composer install --no-dev --no-interaction --optimize-autoloader
     fi
-    
+
     echo "Composer dependencies installed."
+fi
+
+# Self-write 202-config.php from the sample using the DB credentials passed in
+# by docker-compose, so the setup wizard opens with the database step already
+# done. write-config.php is a no-op when 202-config.php already exists, so this
+# is safe to run on every container start.
+if [ -n "$MYSQL_ROOT_PASSWORD" ]; then
+    php build/scripts/write-config.php || echo "Skipping config generation."
 fi
 
 # Execute the main command (Apache)

--- a/build/scripts/docker-entrypoint.sh
+++ b/build/scripts/docker-entrypoint.sh
@@ -19,9 +19,11 @@ fi
 # Self-write 202-config.php from the sample using the DB credentials passed in
 # by docker-compose, so the setup wizard opens with the database step already
 # done. write-config.php is a no-op when 202-config.php already exists, so this
-# is safe to run on every container start.
+# is safe to run on every container start. A real failure (missing sample,
+# unwritable target) would otherwise boot the container with broken DB config,
+# so let `set -e` surface it loudly instead of swallowing it.
 if [ -n "$MYSQL_ROOT_PASSWORD" ]; then
-    php build/scripts/write-config.php || echo "Skipping config generation."
+    php build/scripts/write-config.php
 fi
 
 # Execute the main command (Apache)

--- a/build/scripts/package-release.sh
+++ b/build/scripts/package-release.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Package a self-contained Prosper202 release zip.
+#
+# The artifact bundles Composer dependencies (vendor/) and pre-built Go CLI
+# binaries, so shared-hosting and one-click-installer users can deploy with no
+# Composer, no Go toolchain, and no terminal at all.
+#
+#   "Download the release, not the git clone."
+#
+# Usage: build/scripts/package-release.sh
+# Output: dist/prosper202-<version>.zip  (+ a printed SHA256)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- tooling preflight: fail loudly and early, never half-build an artifact ---
+missing=""
+for tool in php composer go git zip; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        missing="$missing $tool"
+    fi
+done
+if [ -n "$missing" ]; then
+    echo "Error: required tool(s) not installed:$missing" >&2
+    exit 1
+fi
+
+# --- version: single source of truth is 202-config/version.php ---
+VERSION="$(php -r 'require "202-config/version.php"; echo PROSPER202_VERSION;')"
+if [ -z "$VERSION" ]; then
+    echo "Error: could not read PROSPER202_VERSION from 202-config/version.php" >&2
+    exit 1
+fi
+echo "Packaging Prosper202 v${VERSION}"
+
+DIST_DIR="$REPO_ROOT/dist"
+STAGE_ROOT="$(mktemp -d)"
+STAGE="$STAGE_ROOT/prosper202"
+trap 'rm -rf "$STAGE_ROOT"' EXIT
+
+mkdir -p "$DIST_DIR" "$STAGE"
+
+# --- 1. clean export of tracked files only (no .git, no vendor/, no dist/) ---
+echo "==> Exporting tracked files..."
+git archive --format=tar HEAD | tar -x -C "$STAGE"
+
+# --- 2. bake production Composer deps into vendor/ ---
+echo "==> Installing Composer dependencies (--no-dev)..."
+composer install --no-dev --optimize-autoloader --no-interaction \
+    --working-dir="$STAGE"
+if [ ! -f "$STAGE/vendor/autoload.php" ]; then
+    echo "Error: composer install did not produce vendor/autoload.php" >&2
+    exit 1
+fi
+
+# --- 3. cross-build the Go CLI; stage binaries under go-cli/dist ---
+# VERSION is passed through so the CLI's -X main.version matches the zip name.
+echo "==> Building Go CLI for all platforms..."
+make -C "$REPO_ROOT/go-cli" all VERSION="$VERSION"
+mkdir -p "$STAGE/go-cli/dist"
+cp -R "$REPO_ROOT/go-cli/dist/." "$STAGE/go-cli/dist/"
+
+# --- 4. strip dev-only cruft from the shipped artifact ---
+echo "==> Stripping dev artifacts..."
+rm -rf "$STAGE/.github" "$STAGE/build/logs" "$STAGE/build/debug"
+
+# --- 5. zip + checksum ---
+ZIP_PATH="$DIST_DIR/prosper202-${VERSION}.zip"
+rm -f "$ZIP_PATH"
+echo "==> Creating $ZIP_PATH ..."
+( cd "$STAGE_ROOT" && zip -rq "$ZIP_PATH" prosper202 )
+
+echo ""
+echo "Release artifact ready:"
+echo "  $ZIP_PATH"
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$ZIP_PATH"
+elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$ZIP_PATH"
+fi

--- a/build/scripts/package-release.sh
+++ b/build/scripts/package-release.sh
@@ -55,12 +55,14 @@ if [ ! -f "$STAGE/vendor/autoload.php" ]; then
     exit 1
 fi
 
-# --- 3. cross-build the Go CLI; stage binaries under go-cli/dist ---
-# VERSION is passed through so the CLI's -X main.version matches the zip name.
+# --- 3. cross-build the Go CLI from the STAGED (archived) source ---
+# Build inside $STAGE, not $REPO_ROOT, so the binaries match the exact source
+# bundled in the zip — a dirty working tree can't ship binaries whose behavior
+# diverges from the shipped source. The Makefile writes to its own dist/, so the
+# binaries land directly under $STAGE/go-cli/dist. VERSION is passed through so
+# the CLI's -X main.version matches the zip name. It also keeps $REPO_ROOT clean.
 echo "==> Building Go CLI for all platforms..."
-make -C "$REPO_ROOT/go-cli" all VERSION="$VERSION"
-mkdir -p "$STAGE/go-cli/dist"
-cp -R "$REPO_ROOT/go-cli/dist/." "$STAGE/go-cli/dist/"
+make -C "$STAGE/go-cli" all VERSION="$VERSION"
 
 # --- 4. strip dev-only cruft from the shipped artifact ---
 echo "==> Stripping dev artifacts..."

--- a/build/scripts/write-config.php
+++ b/build/scripts/write-config.php
@@ -48,15 +48,32 @@ if ($content === false) {
     exit(1);
 }
 
+// Single-pass replacement: strtr substitutes every token at once and never
+// re-scans text it just inserted, so a credential value that happens to contain
+// another placeholder token can't be double-substituted.
+$map = [];
 foreach ($replacements as $token => $value) {
-    $content = str_replace($token, $escape((string) $value), $content);
+    $map[$token] = $escape((string) $value);
 }
+$content = strtr($content, $map);
 
 if (file_put_contents($target, $content) === false) {
     fwrite(STDERR, "Error: could not write {$target}\n");
     exit(1);
 }
-// Owner/group read only — this file holds database credentials.
+// 202-config.php holds DB credentials, so keep it non-world-readable. But this
+// script runs from the Docker entrypoint as root, while Apache serves requests
+// as www-data — a root-owned 0640 file is unreadable by the web server and would
+// 500 every page. Hand the file to the web user so it can read its own config;
+// if ownership can't be transferred (user missing, or not running as root), fall
+// back to world-readable so the app still boots instead of breaking silently.
 chmod($target, 0640);
+$webUser  = getenv('APACHE_RUN_USER') ?: 'www-data';
+$webGroup = getenv('APACHE_RUN_GROUP') ?: $webUser;
+if (@chown($target, $webUser)) {
+    @chgrp($target, $webGroup);
+} else {
+    chmod($target, 0644);
+}
 
 echo "Wrote 202-config.php (db host={$dbHost}).\n";

--- a/build/scripts/write-config.php
+++ b/build/scripts/write-config.php
@@ -61,19 +61,24 @@ if (file_put_contents($target, $content) === false) {
     fwrite(STDERR, "Error: could not write {$target}\n");
     exit(1);
 }
-// 202-config.php holds DB credentials, so keep it non-world-readable. But this
-// script runs from the Docker entrypoint as root, while Apache serves requests
-// as www-data — a root-owned 0640 file is unreadable by the web server and would
-// 500 every page. Hand the file to the web user so it can read its own config;
-// if ownership can't be transferred (user missing, or not running as root), fall
-// back to world-readable so the app still boots instead of breaking silently.
+// 202-config.php holds DB credentials, so it must stay non-world-readable (0640)
+// AND be readable by the web server. This script runs from the Docker entrypoint
+// as root while Apache serves as www-data, so a root-owned file is unreadable by
+// the web server and would 500 every page — hand ownership to the web user.
+// chown succeeds when running as root, or as a no-op when we already ARE the web
+// user (chowning a file to its own owner). If it fails for any other reason we
+// fail loudly rather than weaken permissions on a credentials file: a silent
+// 0644 would expose DB credentials and mask a misconfigured image.
 chmod($target, 0640);
 $webUser  = getenv('APACHE_RUN_USER') ?: 'www-data';
 $webGroup = getenv('APACHE_RUN_GROUP') ?: $webUser;
 if (@chown($target, $webUser)) {
     @chgrp($target, $webGroup);
 } else {
-    chmod($target, 0644);
+    fwrite(STDERR, "Error: could not give 202-config.php to the web user '{$webUser}'. "
+        . "Run this as root (the Docker entrypoint does), or chown the file to '{$webUser}' "
+        . "yourself. Refusing to relax permissions on a file containing DB credentials.\n");
+    exit(1);
 }
 
 echo "Wrote 202-config.php (db host={$dbHost}).\n";

--- a/build/scripts/write-config.php
+++ b/build/scripts/write-config.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+/**
+ * Generate 202-config.php from 202-config-sample.php using values supplied by
+ * the environment. The Docker entrypoint calls this so the container wires its
+ * own database connection — the wizard then opens with the DB step already done,
+ * no file editing required.
+ *
+ * This mirrors the line rewrite in 202-config/setup-config.php: it reuses the
+ * exact same placeholder tokens that live in 202-config-sample.php, and the same
+ * single-quote escaping, so the two stay in sync. It is a no-op (exit 0) if
+ * 202-config.php already exists, making it safe to run on every container start.
+ */
+
+$root   = dirname(__DIR__, 2) . '/';   // build/scripts -> repo root
+$sample = $root . '202-config-sample.php';
+$target = $root . '202-config.php';
+
+if (file_exists($target)) {
+    fwrite(STDERR, "202-config.php already exists; leaving it untouched.\n");
+    exit(0);
+}
+if (!file_exists($sample)) {
+    fwrite(STDERR, "Error: 202-config-sample.php not found at {$sample}\n");
+    exit(1);
+}
+
+// Escape a value for inclusion in a single-quoted PHP string (same rule as
+// escape_config_value() in 202-config/setup-config.php).
+$escape = static fn (string $value): string =>
+    str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
+
+$dbHost = getenv('DB_HOST') ?: 'db';
+
+// Placeholder token in 202-config-sample.php => value from the environment.
+$replacements = [
+    'putyourdbnamehere' => getenv('MYSQL_DATABASE') ?: 'prosper202',
+    'usernamehere'      => getenv('DB_USER') ?: 'root',
+    'yourpasswordhere'  => getenv('MYSQL_ROOT_PASSWORD') ?: '',
+    'localhosthere'     => $dbHost,
+    'localhostreplica'  => getenv('DB_HOST_RO') ?: $dbHost,
+    'localhostmemcache' => getenv('MC_HOST') ?: 'memcached',
+];
+
+$content = file_get_contents($sample);
+if ($content === false) {
+    fwrite(STDERR, "Error: could not read {$sample}\n");
+    exit(1);
+}
+
+foreach ($replacements as $token => $value) {
+    $content = str_replace($token, $escape((string) $value), $content);
+}
+
+if (file_put_contents($target, $content) === false) {
+    fwrite(STDERR, "Error: could not write {$target}\n");
+    exit(1);
+}
+// Owner/group read only — this file holds database credentials.
+chmod($target, 0640);
+
+echo "Wrote 202-config.php (db host={$dbHost}).\n";

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,13 @@ services:
       - ./build/php/conf.d/error-reporting.ini:/usr/local/etc/php/conf.d/zz-error-reporting.ini:ro
     environment:
       APP_ENV: ${APP_ENV:-development}
+      # Passed through so the entrypoint can self-write 202-config.php and the
+      # wizard opens with the database step already done. Must match the db
+      # service below.
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in .env — copy .env.example or run ./start.sh}
+      MYSQL_DATABASE: prosper202
+      DB_HOST: db
+      MC_HOST: memcached
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,22 @@ services:
   memcached:
     image: memcached:1.6-alpine
 
+  # Runs the scheduled jobs so the user never has to touch the host crontab.
+  # 202-cronjobs/index.php has its own file-lock and frequency tiers, so polling
+  # it once a minute is safe. busybox wget (built into alpine) avoids any extra
+  # install step; failures while the web container is still booting are ignored.
+  cron:
+    image: alpine:3.20
+    restart: unless-stopped
+    depends_on:
+      web:
+        condition: service_started
+    command: >
+      sh -c 'while true; do
+               wget -q -O /dev/null http://web/202-cronjobs/index.php || true;
+               sleep 60;
+             done'
+
   # Opt-in only (docker compose --profile debug up -d) and bound to loopback:
   # this panel exposes MySQL root, so it must never listen on a public
   # interface by default.

--- a/go-cli/Makefile
+++ b/go-cli/Makefile
@@ -1,5 +1,7 @@
 BINARY := p202
-VERSION := 2.0.0
+# Fallback only — the release build overrides this with VERSION from
+# 202-config/version.php (the single source of truth). Keep it in sync.
+VERSION := 1.9.59
 BUILD_DIR := dist
 
 PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64

--- a/index.php
+++ b/index.php
@@ -3,14 +3,17 @@ declare(strict_types=1);
 //if the 202-config.php doesn't exist, we need to build one
 if ( !file_exists( __DIR__ . '/202-config.php') ) {
 	
+	require_once(__DIR__ . '/202-config/version.php');
 	require_once(__DIR__ . '/202-config/functions.php');
         //check to make sure this user has the required PHP version
         if (!php_version_supported()) {
                 _die("<center><small>Prosper202 requires PHP " . PROSPER202_MIN_PHP_VERSION . " or greater to run. Your server does not meet the <a href='http://prosper.tracking202.com/apps/about/requirements/'>minimum requirements to run Prosper202</a>. Please upgrade PHP or sign up with one of our <a href='http://prosper.tracking202.com/apps/hosting/'>recommended hosting providers</a>.</small></center>");
         }
 	
-	//require the 202-config.php file
-	_die("<center><small>There doesn't seem to be a <code>202-config.php</code> file. I need this before we can get started. <br/>Need more help? <a href=\"http://prosper202.com/apps/about/contact/\">Contact Us</a>. You can <a href='".get_absolute_url()."202-config/setup-config.php'>create a <code>202-config.php</code> file through a web interface</a>, but this doesn't work for all server setups. The safest way is to manually create the file.</small></center>");
+	//no 202-config.php yet — send the user straight into the setup wizard,
+	//which collects the database details and can create the database for them.
+	header('location: ' . get_absolute_url() . '202-config/setup.php');
+	exit;
 
 
 } else {
@@ -19,7 +22,7 @@ if ( !file_exists( __DIR__ . '/202-config.php') ) {
 
 	if (  is_installed() == false) {
 		
-		header('location: '.get_absolute_url().'202-config/requirements.php');
+		header('location: '.get_absolute_url().'202-config/setup.php');
 	 
 	} else {
 		

--- a/install.sh
+++ b/install.sh
@@ -1237,6 +1237,10 @@ show_summary() {
         lines+=("  2. Open the application in your browser")
         lines+=("     Complete the setup wizard to create your admin account")
         lines+=("")
+        lines+=("  3. Keep background jobs running — add this to your crontab")
+        lines+=("     (${DIM}crontab -e${RESET}; replace the URL with your site):")
+        lines+=("     ${BOLD}* * * * * curl -s \"http://your-domain/202-cronjobs/index.php\" >/dev/null 2>&1${RESET}")
+        lines+=("")
         if [ -f "$SCRIPT_DIR/202-config.php" ]; then
             lines+=("  ${CHECK} Config file: 202-config.php")
         fi

--- a/start.sh
+++ b/start.sh
@@ -14,12 +14,27 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 1
 fi
 
+# Generate a 32-char hex secret from whatever's available. openssl isn't
+# guaranteed to be installed, and under `set -o pipefail` a `tr </dev/urandom |
+# head` pipe would fail (head closes early -> SIGPIPE), so read a fixed number of
+# bytes with head first, then format.
+gen_secret() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 16
+    elif [ -r /dev/urandom ]; then
+        head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'
+    else
+        echo "Error: need 'openssl' or a readable /dev/urandom to generate a DB password." >&2
+        exit 1
+    fi
+}
+
 # Generate .env with a random DB password on first run. The password is baked
 # into the database volume on first start, so we never overwrite an existing one.
 if [ ! -f .env ]; then
     echo "Creating .env with a generated database password..."
     {
-        echo "MYSQL_ROOT_PASSWORD=$(openssl rand -hex 16)"
+        echo "MYSQL_ROOT_PASSWORD=$(gen_secret)"
         echo "APP_ENV=development"
     } > .env
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# One command from a clean checkout to a running Prosper202 with the database
+# step already wired — no .env editing, no manual config file.
+#
+#   ./start.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: Docker is not installed. See the README 'From source' track for" >&2
+    echo "the non-Docker install.sh path, or the 'Download & Upload' track." >&2
+    exit 1
+fi
+
+# Generate .env with a random DB password on first run. The password is baked
+# into the database volume on first start, so we never overwrite an existing one.
+if [ ! -f .env ]; then
+    echo "Creating .env with a generated database password..."
+    {
+        echo "MYSQL_ROOT_PASSWORD=$(openssl rand -hex 16)"
+        echo "APP_ENV=development"
+    } > .env
+fi
+
+docker compose up -d --build
+
+cat <<'EOF'
+
+Prosper202 is starting up.
+
+  Open:  http://localhost:8000
+
+The setup wizard opens with the database step already done — just create your
+admin account to finish.
+
+SECURITY: the app is reachable before any account exists. Anyone who can reach
+port 8000 before you finish the wizard can claim the install. Complete the
+wizard now, especially on a machine with a public address.
+EOF


### PR DESCRIPTION
Shared-hosting users often have no terminal to run composer install, yet
202-config/connect.php requires vendor/autoload.php on every request. Ship a
self-contained release zip instead:

- build/scripts/package-release.sh: git-archive export + composer install
  --no-dev + cross-built Go CLI binaries, zipped to dist/prosper202-<ver>.zip.
  Version comes from 202-config/version.php (single source of truth) and is
  passed to the Go build so the CLI --version matches.
- connect.php: replace the silent autoload skip with an explicit, dependency-
  free error directing users to the release zip or composer install.
- README: lead the install section with a no-terminal Download & Upload track
  vs a From source track; document the release build.
- gitignore the dist/ artifact.