### PR TITLE
Harden installer account creation: transactions + prepared statements

### DIFF
--- a/202-config/Database/DataSeeder.php
+++ b/202-config/Database/DataSeeder.php
@@ -126,6 +126,15 @@ final readonly class DataSeeder
      */
     public function seedDefaultChartData(): void
     {
+        // Idempotent: an install retry re-runs install_databases() before any user is
+        // committed, and 202_charts has no unique key, so skip if the default chart
+        // row already exists. Otherwise each retry duplicates it and dashboard joins
+        // (which read by user_id) would see two default charts.
+        $existing = _mysqli_query("SELECT 1 FROM `" . TableRegistry::CHARTS . "` WHERE `user_id` = 1 LIMIT 1");
+        if ($existing instanceof \mysqli_result && $existing->num_rows > 0) {
+            return;
+        }
+
         $sql = "INSERT INTO `" . TableRegistry::CHARTS . "` (`user_id`, `data`, `chart_time_range`) VALUES
             (1, 'a:3:{i:0;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:6:\"clicks\";}i:1;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:9:\"click_out\";}i:2;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:5:\"leads\";}}', 'days')";
         _mysqli_query($sql);
@@ -145,6 +154,13 @@ final readonly class DataSeeder
      */
     public function seedVersion(string $version): void
     {
+        // Idempotent: 202_version is read as a single row (e.g. functions-upgrade.php),
+        // so don't add a second row when an install retry re-runs the seed step.
+        $existing = _mysqli_query("SELECT 1 FROM " . TableRegistry::VERSION . " LIMIT 1");
+        if ($existing instanceof \mysqli_result && $existing->num_rows > 0) {
+            return;
+        }
+
         $escapedVersion = $this->connection->real_escape_string($version);
         $sql = "INSERT INTO " . TableRegistry::VERSION . " SET version='{$escapedVersion}'";
         _mysqli_query($sql);

--- a/202-config/Database/DataSeeder.php
+++ b/202-config/Database/DataSeeder.php
@@ -25,7 +25,8 @@ final readonly class DataSeeder
         $this->seedRoles();
         $this->seedPermissions();
         $this->seedRolePermissions();
-        $this->seedDefaultChartData();
+        // The default chart is per-user and created with the committed user_id by
+        // the installer (install.php), not seeded here with a hard-coded id.
         $this->seedClicksTotal();
     }
 
@@ -118,25 +119,6 @@ final readonly class DataSeeder
             (2, 22), (2, 23),
             (3, 12), (3, 14), (3, 15), (3, 22),
             (4, 12)";
-        _mysqli_query($sql);
-    }
-
-    /**
-     * Seed default chart data.
-     */
-    public function seedDefaultChartData(): void
-    {
-        // Idempotent: an install retry re-runs install_databases() before any user is
-        // committed, and 202_charts has no unique key, so skip if the default chart
-        // row already exists. Otherwise each retry duplicates it and dashboard joins
-        // (which read by user_id) would see two default charts.
-        $existing = _mysqli_query("SELECT 1 FROM `" . TableRegistry::CHARTS . "` WHERE `user_id` = 1 LIMIT 1");
-        if ($existing instanceof \mysqli_result && $existing->num_rows > 0) {
-            return;
-        }
-
-        $sql = "INSERT INTO `" . TableRegistry::CHARTS . "` (`user_id`, `data`, `chart_time_range`) VALUES
-            (1, 'a:3:{i:0;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:6:\"clicks\";}i:1;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:9:\"click_out\";}i:2;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:5:\"leads\";}}', 'days')";
         _mysqli_query($sql);
     }
 

--- a/202-config/functions-install-helpers.php
+++ b/202-config/functions-install-helpers.php
@@ -98,3 +98,68 @@ if (!function_exists('install_validate_account')) {
         return $errors;
     }
 }
+
+if (!function_exists('install_encode_response')) {
+    /**
+     * Encode an install AJAX payload to JSON. On a json_encode() failure (e.g. a
+     * value containing malformed UTF-8) it returns an explicit error body rather
+     * than an empty one (CLAUDE.md #4).
+     *
+     * @param  array<string,mixed> $payload
+     * @return array{ok:bool,body:string}
+     */
+    function install_encode_response(array $payload): array
+    {
+        $json = json_encode($payload);
+        if ($json === false) {
+            return [
+                'ok'   => false,
+                'body' => '{"success":false,"retryable":true,"errors":{"general":"<div class=\"error\">The server hit an unexpected error encoding its response. Please try again.</div>"}}',
+            ];
+        }
+
+        return ['ok' => true, 'body' => $json];
+    }
+}
+
+if (!function_exists('render_install_success')) {
+    /**
+     * Render the post-install success panel (the .main block) so it can be swapped
+     * into the page over AJAX or printed directly on the no-JS path. The base URL
+     * and server name are injected (no globals) so the markup can be unit-tested.
+     *
+     * $html['user_name'] is expected pre-escaped; $serverName is escaped here.
+     * $warnings are developer-authored, safe HTML strings.
+     *
+     * @param array<string,string> $html
+     * @param list<string>         $warnings
+     */
+    function render_install_success(array $html, array $warnings, string $base, string $serverName): void
+    {
+        $safeServerName = htmlentities($serverName, ENT_QUOTES, 'UTF-8');
+        ?>
+        <div class="main col-xs-7 install">
+            <center><img src="<?php echo $base; ?>202-img/prosper202.png"></center>
+            <h6>Success!</h6>
+            <small>Prosper202 has been installed. Now you can <a href="<?php echo $base; ?>202-login.php">log in</a>.</small><br></br>
+            <div class="row" style="margin-bottom: 10px;">
+                <div class="col-xs-3"><span class="label label-default">Username:</span></div>
+                <div class="col-xs-9"><span class="label label-primary"><?php echo $html['user_name']; ?></span></div>
+            </div>
+            <div class="row" style="margin-bottom: 10px;">
+                <div class="col-xs-3"><span class="label label-default">Login address:</span></div>
+                <div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', $base, $safeServerName . $base); ?></small></div>
+            </div>
+            <?php if ($warnings) { ?>
+                <div style="margin: 12px 0; padding: 8px 12px; border: 1px solid #faebcc; background: #fcf8e3; color: #8a6d3b; border-radius: 4px; font-size: 12px;">
+                    <strong>You're all set — a couple of optional steps need a quick follow-up:</strong>
+                    <ul style="margin: 6px 0 0 18px;">
+                        <?php foreach ($warnings as $w) { echo '<li>' . $w . '</li>'; } ?>
+                    </ul>
+                </div>
+            <?php } ?>
+            <p><small>Were you expecting more steps? Sorry thats it!</small></p>
+        </div>
+        <?php
+    }
+}

--- a/202-config/functions-install-helpers.php
+++ b/202-config/functions-install-helpers.php
@@ -58,8 +58,13 @@ if (!function_exists('install_validate_account')) {
         $email = (string) ($post['user_email'] ?? '');
         $name  = (string) ($post['user_name'] ?? '');
 
-        // Mirrors check_email_address() (filter_var FILTER_VALIDATE_EMAIL).
-        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+        // Prefer the shared check_email_address() in production so the email rule
+        // can't drift from the rest of the app (CLAUDE.md #5); fall back to the
+        // identical filter_var only when this helper is loaded in isolation (tests).
+        $emailValid = function_exists('check_email_address')
+            ? (bool) check_email_address($email)
+            : filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+        if (!$emailValid) {
             $errors['user_email'] = '<div class="error">Please enter a valid email address</div>';
         }
 
@@ -128,8 +133,9 @@ if (!function_exists('render_install_success')) {
      * into the page over AJAX or printed directly on the no-JS path. The base URL
      * and server name are injected (no globals) so the markup can be unit-tested.
      *
-     * $html['user_name'] is expected pre-escaped; $serverName is escaped here.
-     * $warnings are developer-authored, safe HTML strings.
+     * $html['user_name'] is expected pre-escaped and $base is a trusted internal
+     * URL (get_absolute_url()); both are emitted as-is. Only $serverName is escaped
+     * here. $warnings are developer-authored, safe HTML strings.
      *
      * @param array<string,string> $html
      * @param list<string>         $warnings

--- a/202-config/functions-install-helpers.php
+++ b/202-config/functions-install-helpers.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pure, dependency-free helpers for the installer.
+ *
+ * These are kept in their own file (rather than inline in install.php, which runs
+ * the whole install on include) so the field rules, CSRF check and account
+ * validation can be unit-tested in isolation.
+ */
+
+if (!function_exists('install_default_rules')) {
+    /**
+     * Single source of truth for the install field rules, shared by the server-side
+     * validation and injected into the client-side JS so the two can't drift.
+     *
+     * @return array{username_min:int,username_max:int,password_min:int,password_max:int}
+     */
+    function install_default_rules(): array
+    {
+        return [
+            'username_min' => 4,
+            'username_max' => 20,
+            'password_min' => 6,
+            'password_max' => 35,
+        ];
+    }
+}
+
+if (!function_exists('install_csrf_ok')) {
+    /**
+     * Constant-time CSRF token comparison. An empty expected token (no token ever
+     * issued for this session) never matches.
+     */
+    function install_csrf_ok(string $expected, string $submitted): bool
+    {
+        return $expected !== '' && hash_equals($expected, $submitted);
+    }
+}
+
+if (!function_exists('install_validate_account')) {
+    /**
+     * Validate the install account form. Returns a map of field => HTML error string
+     * ('' when the field is valid), matching the markup install.php renders inline.
+     *
+     * Mirrors the original inline checks exactly, including the empty()/isset()
+     * password semantics, so extracting them changed no behavior.
+     *
+     * @param  array<string,mixed> $post  raw $_POST
+     * @param  array{username_min:int,username_max:int,password_min:int,password_max:int} $rules
+     * @return array{user_email:string,user_name:string,user_pass:string}
+     */
+    function install_validate_account(array $post, array $rules): array
+    {
+        $errors = ['user_email' => '', 'user_name' => '', 'user_pass' => ''];
+
+        $email = (string) ($post['user_email'] ?? '');
+        $name  = (string) ($post['user_name'] ?? '');
+
+        // Mirrors check_email_address() (filter_var FILTER_VALIDATE_EMAIL).
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            $errors['user_email'] = '<div class="error">Please enter a valid email address</div>';
+        }
+
+        if ($name === '') {
+            $errors['user_name'] = '<div class="error">You must type in your desired username</div>';
+        }
+        if (!ctype_alnum($name)) {
+            $errors['user_name'] .= '<div class="error">Your username may only contain alphanumeric characters</div>';
+        }
+        if (strlen($name) < $rules['username_min'] || strlen($name) > $rules['username_max']) {
+            $errors['user_name'] .= '<div class="error">Your username must be between ' . $rules['username_min'] . ' and ' . $rules['username_max'] . ' characters long</div>';
+        }
+
+        // Preserve the original isset()/empty() password semantics.
+        $hasPass   = isset($post['user_pass']) && !empty($post['user_pass']);
+        $hasVerify = isset($post['verify_user_pass']) && !empty($post['verify_user_pass']);
+
+        if (!$hasPass) {
+            $errors['user_pass'] = '<div class="error">You must type in your desired password</div>';
+        }
+        if (!$hasVerify) {
+            $errors['user_pass'] .= '<div class="error">You must verify your password</div>';
+        }
+        if ($hasPass) {
+            $len = strlen((string) $post['user_pass']);
+            if ($len < $rules['password_min']) {
+                $errors['user_pass'] .= '<div class="error">Your password must be at least ' . $rules['password_min'] . ' characters long</div>';
+            } elseif ($len > $rules['password_max']) {
+                $errors['user_pass'] .= '<div class="error">Your password must be no more than ' . $rules['password_max'] . ' characters long</div>';
+            }
+        }
+        if (isset($post['user_pass'], $post['verify_user_pass']) && $post['user_pass'] != $post['verify_user_pass']) {
+            $errors['user_pass'] .= '<div class="error">Your passwords did not match, please try again</div>';
+        }
+
+        return $errors;
+    }
+}

--- a/202-config/functions-install-helpers.php
+++ b/202-config/functions-install-helpers.php
@@ -164,7 +164,7 @@ if (!function_exists('render_install_success')) {
                     </ul>
                 </div>
             <?php } ?>
-            <p><small>Were you expecting more steps? Sorry thats it!</small></p>
+            <p><small>Were you expecting more steps? Sorry, that's it!</small></p>
         </div>
         <?php
     }

--- a/202-config/functions-install.php
+++ b/202-config/functions-install.php
@@ -51,7 +51,9 @@ class INSTALL
      * This method creates all 70+ database tables required by Prosper202
      * and populates them with initial seed data (roles, permissions, etc.).
      *
-     * @throws RuntimeException If database connection fails
+     * @throws RuntimeException If the database connection fails or any table
+     *                          fails to create (a partial schema is never
+     *                          reported as a successful install).
      */
     public function install_databases(): void
     {
@@ -69,11 +71,16 @@ class INSTALL
         $installer = new SchemaInstaller($db);
         $result = $installer->install();
 
-        // Log any errors (but don't fail - matches original behavior)
+        // Surface real schema failures instead of silently continuing. Every
+        // CREATE TABLE uses IF NOT EXISTS, so re-running over an existing or
+        // partial schema does not register an error here — only genuine failures
+        // (permissions, syntax, disk) populate $result->errors, and those must
+        // abort the install rather than leave a half-built schema reported as success.
         if ($result->hasErrors()) {
             foreach ($result->errors as $error) {
                 error_log('INSTALL::install_databases() - ' . $error);
             }
+            throw new RuntimeException('Schema installation failed: ' . implode('; ', $result->errors));
         }
 
         // Seed initial data

--- a/202-config/functions-tracking202.php
+++ b/202-config/functions-tracking202.php
@@ -3075,6 +3075,9 @@ function callAutoCron($endpoint)
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     // Will return the response, if false it print the response
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    // Bound the wait so a slow/unreachable service can't hang the caller (e.g. install)
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
     // Execute
     $result = curl_exec($ch);
 
@@ -3106,6 +3109,9 @@ function registerDailyEmail($time, $timezone, $hash)
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     // Will return the response, if false it print the response
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    // Bound the wait so a slow/unreachable service can't hang the caller (e.g. install)
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
     // Execute
     $result = curl_exec($ch);
 

--- a/202-config/functions-upgrade.php
+++ b/202-config/functions-upgrade.php
@@ -28,7 +28,8 @@ if (!function_exists('_upgrade_query_run')) {
      */
     function _upgrade_query_run($conn, string $sql, callable $sleeper, callable $onExhausted, int $maxAttempts = 4)
     {
-        $transientCodes = [1205, 1213]; // lock wait timeout, deadlock
+        $maxAttempts    = max(1, $maxAttempts); // always make at least one attempt
+        $transientCodes = [1205, 1213];         // lock wait timeout, deadlock
 
         for ($attempt = 1; ; $attempt++) {
             $errno = 0;

--- a/202-config/functions-upgrade.php
+++ b/202-config/functions-upgrade.php
@@ -6,6 +6,89 @@ declare(strict_types=1);
 if (!class_exists('DataEngine')) {
     include_once(__DIR__ . '/class-dataengine.php');
 }
+
+if (!function_exists('_upgrade_query')) {
+    /**
+     * Resilient query runner for the upgrade path.
+     *
+     * Runs the same global-$db query that _mysqli_query() does, but transparently
+     * retries transient lock-wait (1205) / deadlock (1213) errors — the failures a
+     * live, loaded server produces mid-migration — with exponential backoff. For
+     * those two errors the statement provably did not apply (the lock was never
+     * granted / the work was rolled back), so re-running the identical SQL is safe
+     * even when the statement isn't idempotent.
+     *
+     * Every other outcome preserves _mysqli_query()'s contract exactly (the
+     * mysqli_result, or false), so the upgrade's intentional "ignore an
+     * already-applied step" calls keep behaving as before. A transient error that
+     * never clears stops with a clear, resumable message instead of silently
+     * skipping a migration step.
+     *
+     * Only autocommit statements flow through here; the one explicit-transaction
+     * block (the 1.9.57 migration) calls $connection->query() directly, so a
+     * per-statement retry never runs inside an open transaction.
+     *
+     * @param  string|mixed $sql
+     * @return \mysqli_result|bool
+     */
+    function _upgrade_query($sql)
+    {
+        global $db;
+
+        $conn = ($db instanceof \mysqli) ? $db : $db->getConnection();
+        $sql  = (string) $sql;
+
+        $maxAttempts    = 4;            // 1 attempt + up to 3 retries
+        $transientCodes = [1205, 1213]; // lock wait timeout, deadlock
+
+        for ($attempt = 1; ; $attempt++) {
+            $errno = 0;
+            $error = '';
+
+            try {
+                $result = @$conn->query($sql);
+            } catch (\mysqli_sql_exception $e) {
+                // Covers environments that also enable MYSQLI_REPORT_ERROR.
+                $result = false;
+                $errno  = (int) $e->getCode();
+                $error  = $e->getMessage();
+            }
+
+            if ($result !== false) {
+                return $result;
+            }
+
+            if ($errno === 0) {
+                $errno = (int) $conn->errno;
+                $error = (string) $conn->error;
+            }
+
+            $isTransient = in_array($errno, $transientCodes, true);
+
+            // Transient with attempts left: back off and re-run the same statement.
+            if ($isTransient && $attempt < $maxAttempts) {
+                error_log('Prosper202 upgrade: transient DB error ' . $errno . ' (' . $error
+                    . '); retry ' . $attempt . ' of ' . ($maxAttempts - 1));
+                sleep(2 ** ($attempt - 1)); // 1s, 2s, 4s
+                continue;
+            }
+
+            // Transient but exhausted: the server stayed locked. Stop loudly — the
+            // upgrade is built to resume (IF [NOT] EXISTS / existence guards), so a
+            // re-run picks up where this left off.
+            if ($isTransient) {
+                error_log('Prosper202 upgrade: persistent transient DB error ' . $errno . ': ' . $error);
+                _die("<h6>Upgrade paused</h6>
+                    <small>The database stayed locked after several retries, which usually means the server is busy right now. Please re-run the upgrade in a few minutes — it resumes where it left off. <a href='" . get_absolute_url() . "202-login.php'>Back to login</a></small>");
+            }
+
+            // Non-transient failure: preserve _mysqli_query()'s legacy contract so the
+            // upgrade's "ignore already-applied" steps behave exactly as before.
+            return false;
+        }
+    }
+}
+
 class PROSPER202
 {
 
@@ -61,7 +144,7 @@ class UPGRADE
 
         //Try to disable mysql strict mode
         $sql = "SET session sql_mode= ''";
-        $result = _mysqli_query($sql);
+        $result = _upgrade_query($sql);
 
         $partition_start = time();
         $partition_end = strtotime('+3 years', $partition_start);
@@ -69,7 +152,7 @@ class UPGRADE
         $p_count = 0;
 
         $sql = "SELECT PLUGIN_NAME as Name, PLUGIN_STATUS as Status FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_TYPE='STORAGE ENGINE' AND PLUGIN_NAME='partition' AND PLUGIN_STATUS='ACTIVE'";
-        $result = _mysqli_query($sql);
+        $result = _upgrade_query($sql);
 
         if ($result->num_rows != 1) {
             $mysql_partitioning_fail = 1;
@@ -86,11 +169,11 @@ class UPGRADE
             $sql = "CREATE TABLE IF NOT EXISTS `202_version` (
 					  `version` varchar(50) NOT NULL
 					) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // drop the old table
             $sql = "DROP TABLE `202_sort_landings`";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // create the new landing page sorting table
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_landing_pages` (
@@ -125,11 +208,11 @@ class UPGRADE
 				  KEY `sort_landing_page_net` (`sort_landing_page_net`),
 				  KEY `sort_landing_page_roi` (`sort_landing_page_roi`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // this is now up to 1.0.3
             $sql = "INSERT INTO 202_version SET version='1.0.3'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // now set the new mysql version
             $prosper202_version = '1.0.3';
@@ -138,21 +221,21 @@ class UPGRADE
         // upgrade from 1.0.3 to 1.0.4
         if ($prosper202_version == '1.0.3') {
             $sql = "UPDATE 202_version SET version='1.0.4'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.0.4';
         }
 
         // upgrade from 1.0.4 to 1.0.5
         if ($prosper202_version == '1.0.4') {
             $sql = "UPDATE 202_version SET version='1.0.5'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.0.5';
         }
 
         // upgrade from 1.0.5 to 1.0.6
         if ($prosper202_version == '1.0.5') {
             $sql = "UPDATE 202_version SET version='1.0.6'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.0.6';
         }
 
@@ -160,159 +243,159 @@ class UPGRADE
         if ($prosper202_version == '1.0.6') {
 
             // this is upgrading things to BIGINT
-            $result = _mysqli_query("ALTER TABLE `202_clicks` 			CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL");
-            $result = _mysqli_query("ALTER TABLE `202_clicks_advance` 	CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL , 
+            $result = _upgrade_query("ALTER TABLE `202_clicks` 			CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL");
+            $result = _upgrade_query("ALTER TABLE `202_clicks_advance` 	CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL , 
 																			CHANGE `keyword_id` `keyword_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL");
-            $result = _mysqli_query(" ALTER TABLE `202_clicks_counter` 	CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
-            $result = _mysqli_query(" ALTER TABLE `202_clicks_record` 	CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL  ");
-            $result = _mysqli_query(" ALTER TABLE `202_clicks_site` 		CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL ,
+            $result = _upgrade_query(" ALTER TABLE `202_clicks_counter` 	CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
+            $result = _upgrade_query(" ALTER TABLE `202_clicks_record` 	CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_clicks_site` 		CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `click_referer_site_url_id` `click_referer_site_url_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `click_landing_site_url_id` `click_landing_site_url_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `click_outbound_site_url_id` `click_outbound_site_url_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `click_cloaking_site_url_id` `click_cloaking_site_url_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `click_redirect_site_url_id` `click_redirect_site_url_id` BIGINT UNSIGNED NOT NULL ");
-            $result = _mysqli_query(" ALTER TABLE `202_clicks_spy` 		CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL  ");
-            $result = _mysqli_query(" ALTER TABLE `202_ips` 			CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
-            $result = _mysqli_query(" ALTER TABLE `202_keywords` 		CHANGE `keyword_id` `keyword_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
-            $result = _mysqli_query(" ALTER TABLE `202_last_ips` 		CHANGE `ip_id` `ip_id` BIGINT NOT NULL  ");
-            $result = _mysqli_query(" ALTER TABLE `202_mysql_errors` 	CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL ,
+            $result = _upgrade_query(" ALTER TABLE `202_clicks_spy` 		CHANGE `click_id` `click_id` BIGINT UNSIGNED NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_ips` 			CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
+            $result = _upgrade_query(" ALTER TABLE `202_keywords` 		CHANGE `keyword_id` `keyword_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
+            $result = _upgrade_query(" ALTER TABLE `202_last_ips` 		CHANGE `ip_id` `ip_id` BIGINT NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_mysql_errors` 	CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL ,
 																			CHANGE `site_id` `site_id` BIGINT UNSIGNED NOT NULL ");
-            $result = _mysqli_query(" ALTER TABLE `202_site_domains` 	CHANGE `site_domain_id` `site_domain_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
-            $result = _mysqli_query(" ALTER TABLE `202_site_urls` 		CHANGE `site_url_id` `site_url_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT ,
+            $result = _upgrade_query(" ALTER TABLE `202_site_domains` 	CHANGE `site_domain_id` `site_domain_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT  ");
+            $result = _upgrade_query(" ALTER TABLE `202_site_urls` 		CHANGE `site_url_id` `site_url_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT ,
 																			CHANGE `site_domain_id` `site_domain_id` BIGINT UNSIGNED NOT NULL ");
-            $result = _mysqli_query(" ALTER TABLE `202_sort_ips` CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL  ");
-            $result = _mysqli_query(" ALTER TABLE `202_sort_keywords` CHANGE `keyword_id` `keyword_id` BIGINT UNSIGNED NOT NULL  ");
-            $result = _mysqli_query(" ALTER TABLE `202_sort_referers` CHANGE `referer_id` `referer_id` BIGINT UNSIGNED NOT NULL  ");
-            $result = _mysqli_query(" ALTER TABLE `202_users` CHANGE `user_last_login_ip_id` `user_last_login_ip_id` BIGINT UNSIGNED NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_sort_ips` CHANGE `ip_id` `ip_id` BIGINT UNSIGNED NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_sort_keywords` CHANGE `keyword_id` `keyword_id` BIGINT UNSIGNED NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_sort_referers` CHANGE `referer_id` `referer_id` BIGINT UNSIGNED NOT NULL  ");
+            $result = _upgrade_query(" ALTER TABLE `202_users` CHANGE `user_last_login_ip_id` `user_last_login_ip_id` BIGINT UNSIGNED NOT NULL  ");
 
             // mysql version set to 1.1.0 now
             $sql = "UPDATE 202_version SET version='1.1.0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.1.0';
         }
 
         // upgrade from 1.1.0 to 1.1.1
         if ($prosper202_version == '1.1.0') {
             $sql = "UPDATE 202_version SET version='1.1.1'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.1.1';
         }
 
         // upgrade from 1.1.1 to 1.1.2
         if ($prosper202_version == '1.1.1') {
             $sql = "UPDATE 202_version SET version='1.1.2'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.1.2';
         }
 
         // upgrade from 1.1.2 to 1.2.0
         if ($prosper202_version == '1.1.2') {
 
-            $result = _mysqli_query("	 CREATE TABLE IF NOT EXISTS `202_rotations` (
+            $result = _upgrade_query("	 CREATE TABLE IF NOT EXISTS `202_rotations` (
 										  `aff_campaign_id` mediumint(8) unsigned NOT NULL,
 										  `rotation_num` tinyint(4) NOT NULL,
 										  PRIMARY KEY (`aff_campaign_id`)
 										) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
-            $result = _mysqli_query("	INSERT INTO 202_browsers SET browser_id = '9', browser_name = 'Chrome'");
-            $result = _mysqli_query("	INSERT INTO 202_browsers SET browser_id = '10', browser_name = 'Mobile'");
-            $result = _mysqli_query("	INSERT INTO 202_browsers SET browser_id = '11', browser_name = 'Console'");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_clicks` CHANGE  `click_cpc`  `click_cpc` DECIMAL( 7, 5 ) NOT NULL ");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_trackers` CHANGE  `click_cpc`  `click_cpc` DECIMAL( 7, 5 ) NOT NULL ");
+            $result = _upgrade_query("	INSERT INTO 202_browsers SET browser_id = '9', browser_name = 'Chrome'");
+            $result = _upgrade_query("	INSERT INTO 202_browsers SET browser_id = '10', browser_name = 'Mobile'");
+            $result = _upgrade_query("	INSERT INTO 202_browsers SET browser_id = '11', browser_name = 'Console'");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_clicks` CHANGE  `click_cpc`  `click_cpc` DECIMAL( 7, 5 ) NOT NULL ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_trackers` CHANGE  `click_cpc`  `click_cpc` DECIMAL( 7, 5 ) NOT NULL ");
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_users_pref` ADD  `user_cpc_or_cpv` CHAR( 3 ) NOT NULL DEFAULT  'cpc' AFTER  `user_pref_chart` ; ");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_users_pref` ADD  `user_keyword_searched_or_bidded` VARCHAR( 255 ) NOT NULL DEFAULT  'searched' AFTER  `user_cpc_or_cpv` ; ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_users_pref` ADD  `user_cpc_or_cpv` CHAR( 3 ) NOT NULL DEFAULT  'cpc' AFTER  `user_pref_chart` ; ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_users_pref` ADD  `user_keyword_searched_or_bidded` VARCHAR( 255 ) NOT NULL DEFAULT  'searched' AFTER  `user_cpc_or_cpv` ; ");
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_aff_campaigns` ADD  `aff_campaign_url_2` TEXT NOT NULL AFTER  `aff_campaign_url` ,
+            $result = _upgrade_query(" 	ALTER TABLE  `202_aff_campaigns` ADD  `aff_campaign_url_2` TEXT NOT NULL AFTER  `aff_campaign_url` ,
 										ADD  `aff_campaign_url_3` TEXT NOT NULL AFTER  `aff_campaign_url_2` ,
 										ADD  `aff_campaign_url_4` TEXT NOT NULL AFTER  `aff_campaign_url_3` ,
 										ADD  `aff_campaign_url_5` TEXT NOT NULL AFTER  `aff_campaign_url_4` ;");
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_aff_campaigns` CHANGE  `aff_campaign_url`  `aff_campaign_url` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_aff_campaigns` CHANGE  `aff_campaign_url`  `aff_campaign_url` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL");
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_aff_campaigns` ADD  `aff_campaign_rotate` TINYINT( 1 ) NOT NULL DEFAULT  '0' AFTER  `aff_campaign_time` ;");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_aff_campaigns` ADD  `aff_campaign_rotate` TINYINT( 1 ) NOT NULL DEFAULT  '0' AFTER  `aff_campaign_time` ;");
 
-            $result = _mysqli_query(" 	ALTER TABLE`202_sort_breakdowns` CHANGE `sort_breakdown_avg_cpc` `sort_breakdown_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
+            $result = _upgrade_query(" 	ALTER TABLE`202_sort_breakdowns` CHANGE `sort_breakdown_avg_cpc` `sort_breakdown_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
 										CHANGE `sort_breakdown_cost` `sort_breakdown_cost` DECIMAL( 13, 5 ) NOT NULL ,
 										CHANGE `sort_breakdown_net` `sort_breakdown_net` DECIMAL( 13, 5 ) NOT NULL;");
 
-            $result = _mysqli_query(" 	ALTER TABLE`202_sort_ips` CHANGE `sort_ip_avg_cpc` `sort_ip_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
+            $result = _upgrade_query(" 	ALTER TABLE`202_sort_ips` CHANGE `sort_ip_avg_cpc` `sort_ip_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
 										CHANGE `sort_ip_cost` `sort_ip_cost` DECIMAL( 13, 5 ) NOT NULL ,
 										CHANGE `sort_ip_net` `sort_ip_net` DECIMAL( 13, 5 ) NOT NULL;");
 
-            $result = _mysqli_query(" 	ALTER TABLE`202_sort_keywords` CHANGE `sort_keyword_avg_cpc` `sort_keyword_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
+            $result = _upgrade_query(" 	ALTER TABLE`202_sort_keywords` CHANGE `sort_keyword_avg_cpc` `sort_keyword_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
 										CHANGE `sort_keyword_cost` `sort_keyword_cost` DECIMAL( 13, 5 ) NOT NULL ,
 										CHANGE `sort_keyword_net` `sort_keyword_net` DECIMAL( 13, 5 ) NOT NULL;");
 
-            $result = _mysqli_query("   ALTER TABLE`202_sort_landing_pages` CHANGE `sort_landing_page_avg_cpc` `sort_landing_page_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
+            $result = _upgrade_query("   ALTER TABLE`202_sort_landing_pages` CHANGE `sort_landing_page_avg_cpc` `sort_landing_page_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
 										CHANGE `sort_landing_page_cost` `sort_landing_page_cost` DECIMAL( 13, 5 ) NOT NULL ,
 										CHANGE `sort_landing_page_net` `sort_landing_page_net` DECIMAL( 13, 5 ) NOT NULL;");
 
-            $result = _mysqli_query(" 	ALTER TABLE`202_sort_referers` CHANGE `sort_referer_avg_cpc` `sort_referer_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
+            $result = _upgrade_query(" 	ALTER TABLE`202_sort_referers` CHANGE `sort_referer_avg_cpc` `sort_referer_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
 										CHANGE `sort_referer_cost` `sort_referer_cost` DECIMAL( 13, 5 ) NOT NULL ,
 										CHANGE `sort_referer_net` `sort_referer_net` DECIMAL( 13, 5 ) NOT NULL;");
 
-            $result = _mysqli_query(" 	ALTER TABLE`202_sort_text_ads` CHANGE `sort_text_ad_avg_cpc` `sort_text_ad_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
+            $result = _upgrade_query(" 	ALTER TABLE`202_sort_text_ads` CHANGE `sort_text_ad_avg_cpc` `sort_text_ad_avg_cpc` DECIMAL( 7, 5 ) NOT NULL ,
 										CHANGE `sort_text_ad_cost` `sort_text_ad_cost` DECIMAL( 13, 5 ) NOT NULL ,
 										CHANGE `sort_text_ad_net` `sort_text_ad_net` DECIMAL( 13, 5 ) NOT NULL; ");
 
             $sql = "UPDATE 202_version SET version='1.2.0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.2.0';
         }
 
         // upgrade from 1.2.0 to 1,2,1
         if ($prosper202_version == '1.2.0') {
             $sql = "UPDATE 202_version SET version='1.2.1'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.2.1';
         }
 
         // upgrade from 1.2.1 to 1.3.0
         if ($prosper202_version == '1.2.1') {
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_users` ADD  `user_api_key` VARCHAR( 255 ) NOT NULL AFTER  `user_pass_time` ; ");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_users` ADD  `user_stats202_app_key` VARCHAR( 255 ) NOT NULL AFTER  `user_api_key` ; ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_users` ADD  `user_api_key` VARCHAR( 255 ) NOT NULL AFTER  `user_pass_time` ; ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_users` ADD  `user_stats202_app_key` VARCHAR( 255 ) NOT NULL AFTER  `user_api_key` ; ");
             $sql = "UPDATE 202_version SET version='1.3.0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.3.0';
         }
 
         // upgrade from 1.3.0 to 1.3.1
         if ($prosper202_version == '1.3.0') {
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_clicks_spy` ENGINE = InnoDB ");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_last_ips` ENGINE = InnoDB ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_clicks_spy` ENGINE = InnoDB ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_last_ips` ENGINE = InnoDB ");
 
             $sql = "UPDATE 202_version SET version='1.3.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.3.1';
         }
 
         // upgrade from 1.3.1 to 1.3.2
         if ($prosper202_version == '1.3.1') {
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_clicks_spy` ENGINE = InnoDB ");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_last_ips` ENGINE = InnoDB ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_clicks_spy` ENGINE = InnoDB ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_last_ips` ENGINE = InnoDB ");
 
             $sql = "UPDATE 202_version SET version='1.3.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.3.2';
         }
 
         // upgrade from 1.3.2 to 1.4
         if ($prosper202_version == '1.3.2') {
 
-            $result = _mysqli_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_tracking_domain` varchar(255) NOT NULL DEFAULT '';");
-            $result = _mysqli_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_1` tinyint(3);");
-            $result = _mysqli_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_2` tinyint(3);");
-            $result = _mysqli_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_3` tinyint(3);");
-            $result = _mysqli_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_4` tinyint(3);");
+            $result = _upgrade_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_tracking_domain` varchar(255) NOT NULL DEFAULT '';");
+            $result = _upgrade_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_1` tinyint(3);");
+            $result = _upgrade_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_2` tinyint(3);");
+            $result = _upgrade_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_3` tinyint(3);");
+            $result = _upgrade_query("	ALTER TABLE 202_users_pref ADD COLUMN `user_pref_group_4` tinyint(3);");
 
-            $result = _mysqli_query("	UPDATE 202_aff_campaigns SET aff_campaign_url=CONCAT(aff_campaign_url,'[[subid]]') ");
+            $result = _upgrade_query("	UPDATE 202_aff_campaigns SET aff_campaign_url=CONCAT(aff_campaign_url,'[[subid]]') ");
 
-            $result = _mysqli_query(" 	CREATE TABLE `202_clicks_tracking` (
+            $result = _upgrade_query(" 	CREATE TABLE `202_clicks_tracking` (
 										  `click_id` bigint(20) unsigned NOT NULL,
 										  `c1` varchar(255) NOT NULL DEFAULT '',
 										  `c2` varchar(255) NOT NULL DEFAULT '',
@@ -322,49 +405,49 @@ class UPGRADE
 										) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
             $sql = "UPDATE 202_version SET version='1.4'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.4';
         }
 
         // upgrade from 1.4 to 1.4.1
         if ($prosper202_version == '1.4') {
-            $result = _mysqli_query(" 	CREATE TABLE `202_tracking_c1` (
+            $result = _upgrade_query(" 	CREATE TABLE `202_tracking_c1` (
 										  `c1_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 										  `c1` varchar(50) NOT NULL,
 										  PRIMARY KEY (`c1_id`),
 										  UNIQUE KEY `c1` (`c1`(191))
 										) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
-            $result = _mysqli_query(" 	CREATE TABLE `202_tracking_c2` (
+            $result = _upgrade_query(" 	CREATE TABLE `202_tracking_c2` (
 										  `c2_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 										  `c2` varchar(50) NOT NULL,
 										  PRIMARY KEY (`c2_id`),
 										  UNIQUE KEY `c2` (`c2`(191))
 										) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
-            $result = _mysqli_query(" 	CREATE TABLE `202_tracking_c3` (
+            $result = _upgrade_query(" 	CREATE TABLE `202_tracking_c3` (
 										  `c3_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 										  `c3` varchar(50) NOT NULL,
 										  PRIMARY KEY (`c3_id`),
 										  UNIQUE KEY `c3` (`c3`(191))
 										) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
-            $result = _mysqli_query(" 	CREATE TABLE `202_tracking_c4` (
+            $result = _upgrade_query(" 	CREATE TABLE `202_tracking_c4` (
 										  `c4_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 										  `c4` varchar(50) NOT NULL,
 										  PRIMARY KEY (`c4_id`),
 										  UNIQUE KEY `c4` (`c4`(191))
 										) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
             $sql = "UPDATE 202_version SET version='1.4.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.4.1';
         }
 
         // upgrade from 1.4.1 to 1.4.2
         if ($prosper202_version == '1.4.1') {
-            $result = _mysqli_query(" 	 DROP TABLE `202_clicks_tracking`; ");
+            $result = _upgrade_query(" 	 DROP TABLE `202_clicks_tracking`; ");
 
-            $result = _mysqli_query(" 	 CREATE TABLE `202_clicks_tracking` (
+            $result = _upgrade_query(" 	 CREATE TABLE `202_clicks_tracking` (
 										  `click_id` bigint(20) unsigned NOT NULL,
 										  `c1_id` bigint(20) NOT NULL,
 										  `c2_id` bigint(20) NOT NULL,
@@ -374,18 +457,18 @@ class UPGRADE
 										) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
             $sql = "UPDATE 202_version SET version='1.4.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.4.2';
         }
 
         // upgrade from 1.4.2 to 1.4.3
         if ($prosper202_version == '1.4.2') {
 
-            $result = _mysqli_query(" 	ALTER TABLE  `202_clicks_spy` ENGINE = InnoDB ");
-            $result = _mysqli_query(" 	ALTER TABLE  `202_last_ips` ENGINE = InnoDB ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_clicks_spy` ENGINE = InnoDB ");
+            $result = _upgrade_query(" 	ALTER TABLE  `202_last_ips` ENGINE = InnoDB ");
 
             $sql = "UPDATE 202_version SET version='1.4.3'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.4.3';
         }
 
@@ -393,7 +476,7 @@ class UPGRADE
         if ($prosper202_version == '1.4.3') {
 
             $sql = "UPDATE 202_version SET version='1.5'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.5';
         }
 
@@ -401,30 +484,30 @@ class UPGRADE
         if ($prosper202_version == '1.5') {
 
             $sql = "UPDATE 202_version SET version='1.5.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.5.1';
         }
 
         // upgrade from 1.5.1 to 1.6
         if ($prosper202_version == '1.5.1') {
 
-            $result = _mysqli_query("CREATE TABLE IF NOT EXISTS `202_alerts` (
+            $result = _upgrade_query("CREATE TABLE IF NOT EXISTS `202_alerts` (
 			  `prosper_alert_id` int(11) NOT NULL,
 			  `prosper_alert_seen` tinyint(1) NOT NULL,
 			  UNIQUE KEY `prosper_alert_id` (`prosper_alert_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
-            $result = _mysqli_query("CREATE TABLE IF NOT EXISTS `202_offers` (
+            $result = _upgrade_query("CREATE TABLE IF NOT EXISTS `202_offers` (
 				  `user_id` mediumint(8) unsigned NOT NULL,
 				  `offer_id` mediumint(10) unsigned NOT NULL,
 				  `offer_seen` tinyint(1) NOT NULL DEFAULT '1',
 				  UNIQUE KEY `user_id` (`user_id`,`offer_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
-            $result = _mysqli_query("ALTER TABLE  `202_cronjobs` ENGINE = InnoDB;");
+            $result = _upgrade_query("ALTER TABLE  `202_cronjobs` ENGINE = InnoDB;");
 
             $sql = "UPDATE 202_version SET version='1.6'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.6';
         }
 
@@ -432,7 +515,7 @@ class UPGRADE
         if ($prosper202_version == '1.6') {
 
             $sql = "UPDATE 202_version SET version='1.6.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.6.1';
         }
 
@@ -440,7 +523,7 @@ class UPGRADE
         if ($prosper202_version == '1.6.1') {
 
             $sql = "UPDATE 202_version SET version='1.6.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.6.2';
         }
 
@@ -448,7 +531,7 @@ class UPGRADE
         if ($prosper202_version == '1.6.2') {
 
             $sql = "UPDATE 202_version SET version='1.7'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7';
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_pixel_types` (
@@ -457,7 +540,7 @@ class UPGRADE
   			  PRIMARY KEY (`pixel_type_id`) ,
   		      UNIQUE INDEX `pixel_type_UNIQUE` (`pixel_type` ASC) 
   			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_ppc_account_pixels` (
  			  `pixel_id` mediumint(8) unsigned NOT NULL auto_increment,
@@ -466,36 +549,36 @@ class UPGRADE
   			  `ppc_account_id` mediumint(8) unsigned NOT NULL,
   			  PRIMARY KEY  (`pixel_id`)
  			  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_clicks_total` (
 			  `click_count` int(20) unsigned NOT NULL default '0',
  			  PRIMARY KEY  (`click_count`)
 			  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT IGNORE INTO `202_pixel_types` (`pixel_type`) VALUES 
 			  ('Image'),
 			  ('Iframe'),
 			  ('Javascript'),
 			  ('Postback')";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT IGNORE INTO `202_platforms` (`platform_name`) VALUES 
 			  ('Mobile'),
 			  ('Tablet');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT IGNORE INTO `202_clicks_total` (`click_count`) VALUES
 		(0);";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
         }
 
         // upgrade from 1.7 beta to 1.7.1 beta
         if ($prosper202_version == '1.7') {
 
             $sql = "UPDATE 202_version SET version='1.7.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7.1';
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_keywords_lpctr` (
   			  `sort_keyword_id` int(10) unsigned NOT NULL auto_increment,
@@ -518,7 +601,7 @@ class UPGRADE
 			  KEY `keyword_id` (`keyword_id`),
 			  KEY `sort_keyword_clicks` (`sort_keyword_clicks`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_text_ads_lpctr` (
   `sort_text_ad_id` int(10) unsigned NOT NULL auto_increment,
@@ -550,7 +633,7 @@ class UPGRADE
   KEY `sort_keyword_net` (`sort_text_ad_net`),
   KEY `sort_keyword_roi` (`sort_text_ad_roi`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_referers_lpctr` (
   `sort_referer_id` int(10) unsigned NOT NULL auto_increment,
@@ -582,23 +665,23 @@ class UPGRADE
   KEY `sort_keyword_net` (`sort_referer_net`),
   KEY `sort_keyword_roi` (`sort_referer_roi`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_tracking_c1` CHANGE COLUMN `c1` `c1` VARCHAR(350) NOT NULL  ;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_tracking_c2` CHANGE COLUMN `c2` `c2` VARCHAR(350) NOT NULL  ;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_tracking_c3` CHANGE COLUMN `c3` `c3` VARCHAR(350) NOT NULL  ;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_tracking_c4` CHANGE COLUMN `c4` `c4` VARCHAR(350) NOT NULL  ;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
         }
 
         // upgrade from 1.7.1 to 1.7.2 beta
         if ($prosper202_version == '1.7.1') {
 
             $sql = "UPDATE 202_version SET version='1.7.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7.2';
         }
 
@@ -606,39 +689,39 @@ class UPGRADE
         if ($prosper202_version == '1.7.2') {
 
             $sql = "UPDATE 202_version SET version='1.7.3'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7.3';
             $sql = "ALTER TABLE `202_users` MODIFY COLUMN `user_timezone` VARCHAR(50) NOT NULL default 'Pacific/Pitcairn';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "UPDATE `202_users` SET user_timezone='Pacific/Pitcairn' WHERE user_id=1";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_sort_breakdowns`" . " ADD `sort_breakdown_click_throughs` mediumint(8) unsigned NOT NULL AFTER `sort_breakdown_clicks`," . " ADD `sort_breakdown_ctr` decimal(10,2) NOT NULL AFTER `sort_breakdown_click_throughs`," . " ADD KEY `sort_breakdown_click_throughs` (`sort_breakdown_click_throughs`)," . " ADD KEY `sort_breakdown_ctr` (`sort_breakdown_ctr`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_clicks_spy` ADD INDEX (`click_id`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "INSERT INTO `202_pixel_types` (`pixel_type`) VALUES ('Raw')";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `cache_time` VARCHAR(4) NOT NULL default '0';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
         }
 
         // upgrade from 1.7.3 to 1.7.4
         if ($prosper202_version == '1.7.3') {
 
             $sql = "UPDATE 202_version SET version='1.7.4'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7.4';
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `cb_key` VARCHAR(250) NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `cb_verified` tinyint(1) NOT NULL default '0';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
         }
 
         // upgrade from 1.7.4 to 1.7.5
         if ($prosper202_version == '1.7.4') {
 
             $sql = "UPDATE 202_version SET version='1.7.5'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7.5';
         }
 
@@ -646,17 +729,17 @@ class UPGRADE
         if ($prosper202_version == '1.7.5') {
 
             $sql = "UPDATE 202_version SET version='1.7.6'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.7.6';
             $sql = "ALTER TABLE `202_users` ADD COLUMN `clickserver_api_key` VARCHAR(250) NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
         }
 
         // upgrade from 1.7.6 to 1.8.0
         if ($prosper202_version == '1.7.6') {
 
             $sql = "UPDATE 202_version SET version='1.8.0'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.0';
         }
 
@@ -664,7 +747,7 @@ class UPGRADE
         if ($prosper202_version == '1.8.0') {
 
             $sql = "UPDATE 202_version SET version='1.8.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.1';
         }
 
@@ -672,7 +755,7 @@ class UPGRADE
         if ($prosper202_version == '1.8.1') {
 
             $sql = "UPDATE 202_version SET version='1.8.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.2';
         }
 
@@ -680,21 +763,21 @@ class UPGRADE
         if ($prosper202_version == '1.8.2') {
 
             $sql = "DROP TABLE IF EXISTS 202_locations";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "DROP TABLE IF EXISTS 202_locations_country";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "DROP TABLE IF EXISTS 202_locations_city";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "DROP TABLE IF EXISTS 202_locations_block";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "DROP TABLE IF EXISTS 202_locations_coordinates";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "DROP TABLE IF EXISTS 202_locations_region";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_clicks_advance` ADD COLUMN `country_id` bigint(20) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $sql = "ALTER TABLE `202_clicks_advance` ADD COLUMN `city_id` bigint(20) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_locations_city` (
 				  `city_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -702,7 +785,7 @@ class UPGRADE
 				  `city_name` varchar(50) NOT NULL DEFAULT '',
 				  PRIMARY KEY (`city_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_locations_country` (
 				  `country_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -710,7 +793,7 @@ class UPGRADE
 				  `country_name` varchar(50) NOT NULL DEFAULT '',
 				  PRIMARY KEY (`country_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_sort_cities` (
 			  `sort_city_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -729,7 +812,7 @@ class UPGRADE
 			  `sort_city_roi` decimal(10,2) NOT NULL,
 			  PRIMARY KEY (`sort_city_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_sort_countries` (
 				  `sort_country_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -747,14 +830,14 @@ class UPGRADE
 				  `sort_country_roi` decimal(10,2) NOT NULL,
 				  PRIMARY KEY (`sort_country_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_locations_isp` (
 				  `isp_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 				  `isp_name` varchar(50) NOT NULL DEFAULT '',
 				  PRIMARY KEY (`isp_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_sort_isps` (
 				  `sort_isp_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -772,45 +855,45 @@ class UPGRADE
 				  `sort_isp_roi` decimal(10,2) NOT NULL,
 				  PRIMARY KEY (`sort_isp_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_clicks_advance` ADD COLUMN `isp_id` bigint(20) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `maxmind_isp` tinyint(1) NOT NULL default '0';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_isp_id` tinyint(3) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_device_id` tinyint(3) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_browser_id` tinyint(3) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_platform_id` tinyint(3) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_api_keys` (
 				  `user_id` mediumint(8) unsigned NOT NULL,
 				  `api_key` varchar(250) NOT NULL DEFAULT '',
 				  `created_at` int(10) NOT NULL
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "TRUNCATE TABLE 202_browsers;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "TRUNCATE TABLE 202_platforms;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_device_types` (
 			  `type_id` tinyint(1) unsigned NOT NULL,
 			  `type_name` varchar(50) NOT NULL,
 			  PRIMARY KEY (`type_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_device_types` (`type_id`, `type_name`)
 				VALUES
@@ -818,7 +901,7 @@ class UPGRADE
 					(2, 'Mobile'),
 					(3, 'Tablet'),
 					(4, 'Bot');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_device_models` (
 			  `device_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -826,16 +909,16 @@ class UPGRADE
 			  `device_type` tinyint(1) NOT NULL,
 			  PRIMARY KEY (`device_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_clicks_advance` ADD COLUMN `device_id` bigint(20) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_clicks` ADD COLUMN `click_bot` tinyint(1) NOT NULL default '0';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_clicks_spy` ADD COLUMN `click_bot` tinyint(1) NOT NULL default '0';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_sort_devices` (
 			  `sort_device_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -853,7 +936,7 @@ class UPGRADE
 			  `sort_device_roi` decimal(10,2) NOT NULL,
 			  PRIMARY KEY (`sort_device_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_browsers` (
 			  `sort_browser_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -871,7 +954,7 @@ class UPGRADE
 			  `sort_browser_roi` decimal(10,2) NOT NULL,
 			  PRIMARY KEY (`sort_browser_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_platforms` (
 			  `sort_platform_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -889,23 +972,23 @@ class UPGRADE
 			  `sort_platform_roi` decimal(10,2) NOT NULL,
 			  PRIMARY KEY (`sort_platform_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users` ADD COLUMN `install_hash` varchar(255) NOT NULL,
 										  ADD COLUMN `user_hash` varchar(255) NOT NULL,
 										  ADD COLUMN `modal_status` int(1) NOT NULL,
 										  ADD COLUMN `vip_perks_status` int(1) NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $hash = md5(uniqid((string)random_int(0, mt_getrandmax()), TRUE));
             // $user_hash = intercomHash($hash); // Removed intercomHash call
             $user_hash = ''; // Default empty value
 
             $sql = "UPDATE 202_users SET install_hash='" . $hash . "', user_hash='" . $user_hash . "' WHERE user_id='1'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.8.2.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.2.1';
         }
 
@@ -913,7 +996,7 @@ class UPGRADE
         if ($prosper202_version == '1.8.2.1') {
 
             $sql = "ALTER TABLE `202_clicks_advance` ADD COLUMN `region_id` bigint(20) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_locations_region` (
 				  `region_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -921,7 +1004,7 @@ class UPGRADE
 				  `region_name` varchar(50) NOT NULL,
 				  PRIMARY KEY (`region_id`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_regions` (
 			  `sort_regions_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -940,13 +1023,13 @@ class UPGRADE
 			  `sort_region_roi` decimal(10,2) NOT NULL,
 			  PRIMARY KEY (`sort_regions_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_region_id` tinyint(3) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.8.2.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.2.2';
         }
 
@@ -964,7 +1047,7 @@ class UPGRADE
   			  `default_campaign` int(11) DEFAULT NULL,
 			  PRIMARY KEY (`id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_rotator_rules` (
 			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -974,7 +1057,7 @@ class UPGRADE
 			  `value` text NOT NULL,
 			  PRIMARY KEY (`id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_rotator_clicks` (
 			  `click_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -986,7 +1069,7 @@ class UPGRADE
 			  PRIMARY KEY (`click_id`),
 			  KEY `rotator_id` (`rotator_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sort_rotators` (
 			  `sort_rotator_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1006,37 +1089,37 @@ class UPGRADE
 			  `type` varchar(50) NOT NULL DEFAULT '',
 			  PRIMARY KEY (`sort_rotator_id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_clicks` ADD COLUMN `rotator_id` mediumint(0) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "DROP TABLE IF EXISTS 202_sort_browsers, 202_sort_cities, 202_sort_countries, 202_sort_devices, 202_sort_ips, 202_sort_isps, 202_sort_keywords, 202_sort_keywords_lpctr, 202_sort_landing_pages, 202_sort_platforms, 202_sort_referers, 202_sort_referers_lpctr, 202_sort_regions, 202_sort_text_ads, 202_sort_text_ads_lpctr;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.8.3'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.3';
         }
 
         // upgrade from 1.8.3 to 1.8.3.1
         if ($prosper202_version == '1.8.3') {
             $sql = "UPDATE 202_version SET version='1.8.3.1'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.3.1';
         }
 
         // upgrade from 1.8.3.1 to 1.8.3.2
         if ($prosper202_version == '1.8.3.1') {
             $sql = "UPDATE 202_version SET version='1.8.3.2'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.3.2';
         }
 
         // upgrade from 1.8.3.2 to 1.8.3.3
         if ($prosper202_version == '1.8.3.2') {
             $sql = "UPDATE 202_version SET version='1.8.3.3'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.3.3';
         }
 
@@ -1044,16 +1127,16 @@ class UPGRADE
         if ($prosper202_version == '1.8.3.3') {
 
             $sql = "ALTER TABLE `202_clicks` MODIFY `rotator_id` int(10) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_clicks` ADD COLUMN `rule_id` int(10) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_trackers` ADD COLUMN `rotator_id` int(11) unsigned NOT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "DROP TABLE IF EXISTS 202_sort_rotators, 202_rotator_rules, 202_rotator_clicks, 202_rotators;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_rotators` (
 			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1063,7 +1146,7 @@ class UPGRADE
 			  `default_campaign` int(11) DEFAULT NULL,
 			  PRIMARY KEY (`id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_rotator_rules` (
 			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1074,7 +1157,7 @@ class UPGRADE
 			  `redirect_campaign` int(11) DEFAULT NULL,
 			  PRIMARY KEY (`id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_rotator_rules_criteria` (
 			  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1085,7 +1168,7 @@ class UPGRADE
 			  `value` text NOT NULL,
 			  PRIMARY KEY (`id`)
 			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "SELECT  CONCAT('ALTER TABLE ', table_name, ' ENGINE=InnoDB;') AS sql_statements
 			FROM    information_schema.tables AS tb
@@ -1093,63 +1176,63 @@ class UPGRADE
 			AND     `ENGINE` = 'MyISAM'
 			AND     `TABLE_TYPE` = 'BASE TABLE'
 			ORDER BY table_name DESC;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             while ($row = $result->fetch_assoc()) {
-                _mysqli_query($row['sql_statements']);
+                _upgrade_query($row['sql_statements']);
             }
 
             $sql = "UPDATE 202_version SET version='1.8.4'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.4';
         }
 
         // upgrade from 1.8.4 to 1.8.5
         if ($prosper202_version == '1.8.4') {
             $sql = "UPDATE 202_version SET version='1.8.5'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.5';
         }
 
         // upgrade from 1.8.5 to 1.8.6
         if ($prosper202_version == '1.8.5') {
             $sql = "UPDATE 202_version SET version='1.8.6'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.6';
         }
 
         // upgrade from 1.8.6 to 1.8.7
         if ($prosper202_version == '1.8.6') {
             $sql = "UPDATE 202_version SET version='1.8.7'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.7';
         }
 
         // upgrade from 1.8.7 to 1.8.8
         if ($prosper202_version == '1.8.7') {
             $sql = "UPDATE 202_version SET version='1.8.8'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.8';
         }
 
         // upgrade from 1.8.8 to 1.8.9
         if ($prosper202_version == '1.8.8') {
             $sql = "UPDATE 202_version SET version='1.8.9'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.9';
         }
 
         // upgrade from 1.8.9 to 1.8.10
         if ($prosper202_version == '1.8.9') {
             $sql = "UPDATE 202_version SET version='1.8.10'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.10';
         }
 
         //upgrade from 1.8.10 to 1.8.11
         if ($prosper202_version == '1.8.10') {
             $sql = "UPDATE 202_version SET version='1.8.11'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.8.11';
         }
 
@@ -1169,10 +1252,10 @@ class UPGRADE
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 
 
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users ENGINE = InnoDB";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_dataengine` (
               `user_id` mediumint(8) unsigned NOT NULL,
@@ -1221,7 +1304,7 @@ class UPGRADE
               KEY `user_id` (`user_id`,`click_time`),
               KEY `dataenginejob` (`click_time`,`ppc_network_id`,`aff_network_id`,`keyword_id`,`click_referer_site_url_id`,`country_id`,`region_id`,`city_id`,`browser_id`,`device_id`,`platform_id`,`ip_id`,`c1_id`,`c2_id`,`c3_id`,`c4_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             if (!$mysql_partitioning_fail) {
                 $partition_time = $partition_start;
@@ -1235,7 +1318,7 @@ class UPGRADE
                 }
                 $p_count += 1;
                 $sql .= "PARTITION p" . $p_count . " VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */;";
-                $result = _mysqli_query($sql);
+                $result = _upgrade_query($sql);
             }
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_google` (
@@ -1248,48 +1331,48 @@ class UPGRADE
           `utm_content_id` bigint(20) unsigned NOT NULL,
           PRIMARY KEY (`click_id`,`gclid`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_utm_campaign` (
   `utm_campaign_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `utm_campaign` varchar(350) NOT NULL DEFAULT '',
   PRIMARY KEY (`utm_campaign_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_utm_content` (
   `utm_content_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `utm_content` varchar(350) NOT NULL DEFAULT '',
   PRIMARY KEY (`utm_content_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_utm_medium` (
   `utm_medium_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `utm_medium` varchar(350) NOT NULL DEFAULT '',
   PRIMARY KEY (`utm_medium_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_utm_source` (
   `utm_source_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `utm_source` varchar(350) NOT NULL DEFAULT '',
   PRIMARY KEY (`utm_source_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_utm_term` (
   `utm_term_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `utm_term` varchar(350) NOT NULL DEFAULT '',
   PRIMARY KEY (`utm_term_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_referer_data` varchar(10) NOT NULL DEFAULT 'browser';";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.0'; ";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.0';
         }
 
@@ -1297,19 +1380,19 @@ class UPGRADE
         if ($prosper202_version == '1.9.0') {
 
             $sql = "ALTER TABLE `202_rotator_rules` ADD COLUMN `redirect_lp` int(11) DEFAULT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_rotator_rules` ADD COLUMN `auto_monetizer` tinyint(1) DEFAULT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_rotators` ADD COLUMN `default_lp` int(11) DEFAULT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_rotators` ADD COLUMN `auto_monetizer` tinyint(1) DEFAULT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.1'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.1';
         }
 
@@ -1317,7 +1400,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.1') {
 
             $sql = "UPDATE 202_version SET version='1.9.2'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.2';
         }
 
@@ -1325,14 +1408,14 @@ class UPGRADE
         if ($prosper202_version == '1.9.2') {
 
             $sql = "ALTER TABLE `202_trackers` ADD COLUMN `click_cpa` decimal(7,5) DEFAULT NULL;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_cpa_trackers` (
               `click_id` bigint(20) unsigned NOT NULL,
               `tracker_id_public` int(11) unsigned NOT NULL,
               KEY `tracker_id` (`tracker_id_public`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE  IF NOT EXISTS `202_conversion_logs` (
               `conv_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1350,7 +1433,7 @@ class UPGRADE
               KEY `user_id` (`user_id`),
               KEY `campaign_id` (`campaign_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE  IF NOT EXISTS `202_dataengine_job` (
               `time_from` int(10) unsigned NOT NULL DEFAULT '0',
@@ -1358,10 +1441,10 @@ class UPGRADE
               `processing` tinyint(1) NOT NULL DEFAULT '0',
               `processed` tinyint(1) NOT NULL DEFAULT '0'
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "TRUNCATE TABLE 202_dataengine";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $de = new DataEngine();
             // DataEngine has two declarations: the full class (class-dataengine.php, loaded
@@ -1374,7 +1457,7 @@ class UPGRADE
             }
 
             $sql = "UPDATE 202_version SET version='1.9.3'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.3';
         }
 
@@ -1382,7 +1465,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.3') {
 
             $sql = "DROP TABLE 202_charts";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_charts` (
               `user_id` mediumint(8) unsigned NOT NULL,
@@ -1390,12 +1473,12 @@ class UPGRADE
               `chart_time_range` varchar(255) NOT NULL DEFAULT '',
               KEY `user_id` (`user_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_charts` (`user_id`, `data`, `chart_time_range`)
                    VALUES
                    (1, 'a:3:{i:0;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:6:\"clicks\";}i:1;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:9:\"click_out\";}i:2;a:2:{s:11:\"campaign_id\";s:1:\"0\";s:10:\"value_type\";s:5:\"leads\";}}', 'days');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
 
             $sql = "ALTER TABLE `202_users` 
@@ -1403,10 +1486,10 @@ class UPGRADE
             ADD COLUMN `user_lname` varchar(50) DEFAULT NULL,
             ADD COLUMN `user_active` int(1) NOT NULL DEFAULT '1',
             ADD COLUMN `user_deleted` int(1) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.4'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.4';
         }
 
@@ -1414,19 +1497,19 @@ class UPGRADE
         if ($prosper202_version == '1.9.4') {
 
             $sql = "ALTER TABLE 202_users ENGINE = INNODB";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users_pref 
                     ADD COLUMN `user_pref_cloak_referer` varchar(11) DEFAULT 'origin',
                     ADD COLUMN `user_slack_incoming_webhook` text NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_permissions` (
               `permission_id` int(11) NOT NULL AUTO_INCREMENT,
               `permission_description` varchar(50) NOT NULL,
               PRIMARY KEY (`permission_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_permissions` (`permission_id`, `permission_description`)
                     VALUES
@@ -1451,14 +1534,14 @@ class UPGRADE
                         (19, 'access_to_api_integrations'),
                         (20, 'access_to_settings'),
                         (21, 'remove_tracker');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_roles` (
               `role_id` int(11) NOT NULL AUTO_INCREMENT,
               `role_name` varchar(50) NOT NULL,
               PRIMARY KEY (`role_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_roles` (`role_id`, `role_name`)
                     VALUES
@@ -1467,7 +1550,7 @@ class UPGRADE
                         (3, 'Campaign manager'),
                         (4, 'Campaign optimizer'),
                         (5, 'Campaign viewer');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_role_permission` (
               `role_id` int(11) NOT NULL,
@@ -1477,7 +1560,7 @@ class UPGRADE
               CONSTRAINT `202_role_permission_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `202_roles` (`role_id`),
               CONSTRAINT `202_role_permission_ibfk_2` FOREIGN KEY (`permission_id`) REFERENCES `202_permissions` (`permission_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_role_permission` (`role_id`, `permission_id`)
                     VALUES
@@ -1526,7 +1609,7 @@ class UPGRADE
                         (3, 14),
                         (3, 15),
                         (4, 12);";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_user_role` (
               `user_id` mediumint(8) unsigned NOT NULL,
@@ -1536,19 +1619,19 @@ class UPGRADE
               CONSTRAINT `202_user_role_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `202_users` (`user_id`),
               CONSTRAINT `202_user_role_ibfk_2` FOREIGN KEY (`role_id`) REFERENCES `202_roles` (`role_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_user_role` (`user_id`, `role_id`) VALUES (1, 1);";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_rotators MODIFY `auto_monetizer` char(4) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_rotator_rules MODIFY `auto_monetizer` char(4) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_trackers MODIFY `click_cpc` decimal(7,5) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_custom_variables` (
@@ -1559,7 +1642,7 @@ class UPGRADE
               KEY `variable` (`variable`(191)),
               KEY `ppc_variable_id` (`ppc_variable_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_clicks_variable` (
               `click_id` bigint(20) unsigned NOT NULL,
@@ -1567,7 +1650,7 @@ class UPGRADE
               KEY `custom_variable_id` (`variable_set_id`),
               KEY `click_id` (`click_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_ppc_network_variables` (
               `ppc_variable_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1579,7 +1662,7 @@ class UPGRADE
               PRIMARY KEY (`ppc_variable_id`),
               KEY `ppc_network_id` (`ppc_network_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_variable_sets` (
               `variable_set_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -1587,7 +1670,7 @@ class UPGRADE
               KEY `custom_variable_id` (`variables`),
               KEY `click_id` (`variable_set_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_dirty_hours 
                     ADD COLUMN `ppc_network_id` mediumint(8) unsigned DEFAULT '0',
@@ -1617,20 +1700,20 @@ class UPGRADE
                     ADD COLUMN `click_filtered` tinyint(1) NOT NULL DEFAULT '0',
                     ADD COLUMN `click_bot` tinyint(1) NOT NULL DEFAULT '0',
                     ADD COLUMN `click_alp` tinyint(1) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_cronjob_logs` (
                       `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
                       `last_execution_time` int(10) unsigned NOT NULL,
                       PRIMARY KEY (`id`)
                     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // $sql = "ALTER TABLE 202_dataengine ADD COLUMN `variable_set_id` varchar(255) DEFAULT '0'";
-            //$result = _mysqli_query($sql);
+            //$result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.5'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.5';
         }
 
@@ -1643,7 +1726,7 @@ class UPGRADE
                   `rule_redirect_id` bigint(20) unsigned NOT NULL,
                   PRIMARY KEY (`click_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_dataengine_new` (
                 `user_id` mediumint(8) unsigned NOT NULL,
@@ -1692,7 +1775,7 @@ class UPGRADE
                 KEY `user_id` (`user_id`,`click_time`),
                 KEY `dataenginejob` (`click_time`,`ppc_network_id`,`aff_network_id`,`keyword_id`,`click_referer_site_url_id`,`country_id`,`region_id`,`city_id`,`browser_id`,`device_id`,`platform_id`,`ip_id`,`c1_id`,`c2_id`,`c3_id`,`c4_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             if (!$mysql_partitioning_fail) {
                 $partition_time = $partition_start;
@@ -1706,7 +1789,7 @@ class UPGRADE
                 }
                 $p_count += 1;
                 $sql .= "PARTITION p" . $p_count . " VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */;";
-                $result = _mysqli_query($sql);
+                $result = _upgrade_query($sql);
             }
 
             $time_to = time();
@@ -1714,10 +1797,10 @@ class UPGRADE
             $snippet = "AND 2c.user_id = 1";
 
             $sql = "RENAME TABLE 202_dataengine TO 202_dataengine_old";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "RENAME TABLE 202_dataengine_new TO 202_dataengine";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $de = new DataEngine();
             // PHPStan resolves DataEngine to the slim stub (see note above); the full class
@@ -1740,10 +1823,10 @@ class UPGRADE
                   `name` text NOT NULL,
                   PRIMARY KEY (`id`)
                 ) ENGINE=InnoDB";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "SELECT * FROM 202_rotator_rules";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             if ($result->num_rows > 0) {
                 while ($row = $result->fetch_assoc()) {
                     $redirect_name = '';
@@ -1751,12 +1834,12 @@ class UPGRADE
                         $redirect_name = "URL: <a href=" . $row['redirect_url'] . ">link</a>";
                     } else if ($row['redirect_campaign'] != null) {
                         $redirect_type_sql = "SELECT aff_campaign_name FROM 202_aff_campaigns WHERE aff_campaign_id = '" . $row['redirect_campaign'] . "'";
-                        $redirect_type_result = _mysqli_query($redirect_type_sql);
+                        $redirect_type_result = _upgrade_query($redirect_type_sql);
                         $redirect_type_row = $redirect_type_result->fetch_assoc();
                         $redirect_name = "Campaign: " . $redirect_type_row['aff_campaign_name'];
                     } else if ($row['redirect_lp'] != null) {
                         $redirect_type_sql = "SELECT landing_page_nickname FROM 202_landing_pages WHERE landing_page_id = '" . $row['redirect_lp'] . "'";
-                        $redirect_type_result = _mysqli_query($redirect_type_sql);
+                        $redirect_type_result = _upgrade_query($redirect_type_sql);
                         $redirect_type_row = $redirect_type_result->fetch_assoc();
                         $redirect_name = "Landing page: " . $redirect_type_row['landing_page_nickname'];
                     } else if ($row['auto_monetizer'] != null) {
@@ -1785,20 +1868,20 @@ class UPGRADE
 
                     $insert_redirect_sql .= "name = '" . $redirect_name . "'";
 
-                    $insert_redirect_result = _mysqli_query($insert_redirect_sql);
+                    $insert_redirect_result = _upgrade_query($insert_redirect_sql);
                 }
             }
 
             $sql = "ALTER TABLE 202_rotator_rules DROP redirect_url, DROP redirect_campaign, DROP redirect_lp, DROP auto_monetizer, ADD COLUMN `splittest` tinyint(1) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users_pref ADD COLUMN `auto_cron` tinyint(1) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $autocron = false;
 
             $sql = "SELECT * FROM 202_cronjob_logs";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             if ($result->num_rows > 0) {
                 $row = $result->fetch_assoc();
 
@@ -1816,112 +1899,112 @@ class UPGRADE
 
                 if (is_array($cron) && ($cron['status'] ?? null) === 'success') {
                     $sql = "UPDATE 202_users_pref SET auto_cron = '1' WHERE user_id = '1'";
-                    $result = _mysqli_query($sql);
+                    $result = _upgrade_query($sql);
                 }
             }
 
 
             $sql = "UPDATE 202_version SET version='1.9.6'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.6';
         }
 
         if ($prosper202_version == '1.9.6') {
 
             $sql = "ALTER TABLE 202_users_pref ADD COLUMN `user_daily_email` char(2) NOT NULL DEFAULT '07'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "SELECT user_timezone, install_hash, user_daily_email FROM 202_users LEFT JOIN 202_users_pref USING (user_id) WHERE user_id = 1";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $row = $result->fetch_assoc();
 
             registerDailyEmail($row['user_daily_email'], $row['user_timezone'], $row['install_hash']);
 
             $sql = "ALTER TABLE 202_keywords CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.7'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.7';
         }
 
         if ($prosper202_version == '1.9.7') {
 
             $sql = "UPDATE 202_version SET version='1.9.8'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.8';
         }
 
         if ($prosper202_version == '1.9.8') {
 
             $sql = "UPDATE 202_version SET version='1.9.9'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.9';
         }
 
         if ($prosper202_version == '1.9.9') {
 
             $sql = "UPDATE 202_version SET version='1.9.10'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.10';
         }
 
         if ($prosper202_version == '1.9.10') {
 
             $sql = "UPDATE 202_version SET version='1.9.11'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.11';
         }
 
         if ($prosper202_version == '1.9.11') {
             $sql = "ALTER TABLE 202_rotators ADD COLUMN `public_id` int(11) NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "SELECT id FROM 202_rotators";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             if ($result->num_rows > 0) {
                 while ($row = $result->fetch_assoc()) {
-                    _mysqli_query("UPDATE 202_rotators SET public_id = '" . random_int(1, 9) . $row['id'] . random_int(1, 9) . "' WHERE id = '" . $row['id'] . "'");
+                    _upgrade_query("UPDATE 202_rotators SET public_id = '" . random_int(1, 9) . $row['id'] . random_int(1, 9) . "' WHERE id = '" . $row['id'] . "'");
                 }
             }
 
             $sql = "UPDATE 202_version SET version='1.9.12'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.12';
         }
 
         if ($prosper202_version == '1.9.12') {
 
             $sql = "UPDATE 202_version SET version='1.9.13'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.13';
         }
 
         if ($prosper202_version == '1.9.13') {
 
             $sql = "UPDATE 202_version SET version='1.9.14'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.14';
         }
 
         if ($prosper202_version == '1.9.14') {
 
             $sql = "UPDATE 202_version SET version='1.9.15'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.15';
         }
 
         if ($prosper202_version == '1.9.15') {
 
             $sql = "UPDATE 202_version SET version='1.9.16'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.16';
         }
 
         if ($prosper202_version == '1.9.16') {
 
             $sql = "UPDATE 202_version SET version='1.9.17'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.17';
         }
 
@@ -1939,14 +2022,14 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `networkId` (`networkId`(191))
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_aff_networks ADD COLUMN `dni_network_id` mediumint(8) DEFAULT NULL, ADD INDEX `dni_network_id` (`dni_network_id`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
 
             $sql = "UPDATE 202_version SET version='1.9.18'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $prosper202_version = '1.9.18';
         }
 
@@ -1960,13 +2043,13 @@ class UPGRADE
 				  KEY `202_auth_keys_user_id_auth_key` (`user_id`,`auth_key`),
 				  KEY `202_auth_keys_expires` (`expires`)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users` ADD COLUMN `secret_key` CHAR(48) NULL  AFTER `user_deleted`";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.19'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.19';
         }
@@ -1974,10 +2057,10 @@ class UPGRADE
         if ($prosper202_version == '1.9.19') {
 
             $sql = "ALTER TABLE `202_dni_networks` ADD COLUMN `shortDescription` varchar(255) NOT NULL, ADD COLUMN `favIcon` varchar(255) NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.20'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.20';
         }
@@ -1985,7 +2068,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.20') {
 
             $sql = "UPDATE 202_version SET version='1.9.21'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.21';
         }
@@ -1993,20 +2076,20 @@ class UPGRADE
         if ($prosper202_version == '1.9.21') {
 
             $sql = "DROP INDEX ppc_network_id ON 202_ppc_network_variables";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE INDEX ppc_network_id ON 202_ppc_network_variables (ppc_network_id,deleted)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             //make gclid longer for everyone currently on pro
             $sql = "ALTER TABLE 202_google MODIFY gclid VARCHAR(150)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_dynamic_bid` tinyint(1) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.22'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.22';
         }
@@ -2014,7 +2097,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.22') {
 
             $sql = "UPDATE 202_version SET version='1.9.23'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.23';
         }
@@ -2022,7 +2105,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.23') {
 
             $sql = "UPDATE 202_version SET version='1.9.24'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.24';
         }
@@ -2030,7 +2113,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.24') {
 
             $sql = "UPDATE 202_version SET version='1.9.25'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.25';
         }
@@ -2038,7 +2121,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.25') {
 
             $sql = "UPDATE 202_version SET version='1.9.26'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.26';
         }
@@ -2046,7 +2129,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.26') {
 
             $sql = "UPDATE 202_version SET version='1.9.27'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.27';
         }
@@ -2054,16 +2137,16 @@ class UPGRADE
         if ($prosper202_version == '1.9.27') {
 
             $sql = "ALTER TABLE 202_users DROP `leave_behind_page_url`";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users DROP `user_mods`";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users ADD COLUMN  `user_mods_lb` tinyint(1) unsigned NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.28'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.28';
         }
@@ -2071,10 +2154,10 @@ class UPGRADE
         if ($prosper202_version == '1.9.28') {
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_subid` bigint(20) unsigned DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.29'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.29';
         }
@@ -2082,25 +2165,25 @@ class UPGRADE
         if ($prosper202_version == '1.9.29' || $prosper202_version == '1.9.30' || $prosper202_version == '1.9.30a' || $prosper202_version == '1.9.30b') {
 
             $sql = "ALTER TABLE `202_conversion_logs` ADD COLUMN `transaction_id` varchar(255) DEFAULT NULL, ADD COLUMN `click_payout` decimal(11,5) NOT NULL, ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_auto_database_optimization_days` int(11) unsigned DEFAULT '0', ADD COLUMN `zaxaa_api_signature` varchar(250) DEFAULT NULL, ADD COLUMN `jvzoo_ipn_secret_key` varchar(250) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_account_currency` char(3) NOT NULL DEFAULT 'USD'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_variable_sets2` (`variable_set_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`variables` varchar(255) NOT NULL DEFAULT '',PRIMARY KEY (`variable_set_id`,`variables`(191)),KEY `custom_variable_id` (`variables`(191)),KEY `click_id` (`variable_set_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_aff_campaigns` ADD COLUMN `aff_campaign_currency` char(3) NOT NULL DEFAULT 'USD', ADD COLUMN `aff_campaign_foreign_payout` decimal(8,2) NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_users` ADD COLUMN `p202_customer_api_key` char(60) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.30b'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_filters` (
             `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2109,14 +2192,14 @@ class UPGRADE
             `filter_value` decimal(20,5) DEFAULT NULL,
             PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.30b';
 
             //Move data from variable_sets into variable_sets2
             $sql = "SELECT * from 202_variable_sets";
 
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $i = 0;
             $row = '';
@@ -2131,7 +2214,7 @@ class UPGRADE
 
                 if (($i % 600) == 0) {
                     $row = "insert ignore into `202_variable_sets2` (`variable_set_id`, `variables`) values " . rtrim($row, ',') . ";";
-                    _mysqli_query($row);
+                    _upgrade_query($row);
 
                     $i = 0;
                     $row = '';
@@ -2141,14 +2224,14 @@ class UPGRADE
             //add the last bit of data if there's any left
             if ($row) {
                 $row = "insert ignore into `202_variable_sets2` (`variable_set_id`, `variables`) values " . rtrim($row, ',') . ";";
-                _mysqli_query($row);
+                _upgrade_query($row);
             }
         }
 
         if ($prosper202_version == '1.9.30' || $prosper202_version == '1.9.30a' || $prosper202_version == '1.9.30b') {
 
             $sql = "UPDATE 202_version SET version='1.9.31'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.31';
         }
@@ -2163,7 +2246,7 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `user_id` (`user_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_network_ads` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2172,7 +2255,7 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_network_titles` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2181,10 +2264,10 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.32'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.32';
         }
@@ -2192,7 +2275,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.32') {
 
             $sql = "UPDATE 202_version SET version='1.9.33'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.33';
         }
@@ -2208,7 +2291,7 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_feed_outbrain_tokens` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2220,7 +2303,7 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_feed_taboola_tokens` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2232,7 +2315,7 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_feed_custom_tokens` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2243,19 +2326,19 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_ad_feed_contentad_tokens` ADD COLUMN `utm_term` varchar(350) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_ad_feed_taboola_tokens` ADD COLUMN `utm_term` varchar(350) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_ad_feed_outbrain_tokens` ADD COLUMN `utm_term` varchar(350) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.34'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.34';
         }
@@ -2263,7 +2346,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.34') {
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `revcontent_user_id` varchar(250) DEFAULT NULL, ADD COLUMN `revcontent_user_secret` varchar(250) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_feed_revcontent_tokens` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2276,23 +2359,23 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_ad_network_feeds` ADD COLUMN `revcontent_boost_id` text";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.35'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.35';
         }
 
         if ($prosper202_version == '1.9.35') {
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `facebook_ads_linked` int(1) NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_ad_network_feeds` ADD COLUMN `facebook_ad_set_id` int(11) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_feed_facebook_tokens` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2305,7 +2388,7 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ad_network_bodies` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2314,10 +2397,10 @@ class UPGRADE
               PRIMARY KEY (`id`),
               KEY `feed_id` (`feed_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.36'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.36';
         }
@@ -2325,7 +2408,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.36') {
 
             $sql = "UPDATE 202_version SET version='1.9.37'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.37';
         }
@@ -2333,7 +2416,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.37') {
 
             $sql = "UPDATE 202_version SET version='1.9.38'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.38';
         }
@@ -2341,14 +2424,14 @@ class UPGRADE
         if ($prosper202_version == '1.9.38') {
 
             $sql = "ALTER TABLE `202_users_pref` ADD COLUMN `user_pref_ad_settings` varchar(11) NOT NULL DEFAULT 'show_all'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_users_pref SET maxmind_isp='0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
 
             $sql = "UPDATE 202_version SET version='1.9.39'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.39';
         }
@@ -2356,10 +2439,10 @@ class UPGRADE
         if ($prosper202_version == '1.9.39') {
 
             $sql = "ALTER TABLE 202_landing_pages ADD COLUMN leave_behind_page_url varchar(255) NOT NULL DEFAULT ''";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.40'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.40';
         }
@@ -2367,13 +2450,13 @@ class UPGRADE
         if ($prosper202_version == '1.9.40') {
 
             $sql = "ALTER TABLE 202_ppc_accounts ADD COLUMN `ppc_account_default` tinyint(1) unsigned NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_ppc_accounts ADD INDEX (`ppc_account_default`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.41'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.41';
         }
@@ -2381,10 +2464,10 @@ class UPGRADE
         if ($prosper202_version == '1.9.41') {
 
             $sql = "INSERT INTO 202_users_pref(user_id) SELECT user_id from `202_users` where `user_id` not in (select user_id from 202_users_pref)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.42'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.42';
         }
@@ -2393,7 +2476,7 @@ class UPGRADE
 
 
             $sql = "UPDATE 202_version SET version='1.9.43'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.43';
         }
@@ -2402,7 +2485,7 @@ class UPGRADE
 
 
             $sql = "UPDATE 202_version SET version='1.9.44'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.44';
         }
@@ -2411,7 +2494,7 @@ class UPGRADE
 
 
             $sql = "UPDATE 202_version SET version='1.9.45'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.45';
         }
@@ -2420,13 +2503,13 @@ class UPGRADE
 
             //This is a fix for 1.9.44 not setting this up for new installs
             $sql = "ALTER TABLE 202_ppc_accounts ADD COLUMN `ppc_account_default` tinyint(1) unsigned NOT NULL DEFAULT '0'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_ppc_accounts ADD INDEX (`ppc_account_default`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.46'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.46';
         }
@@ -2435,7 +2518,7 @@ class UPGRADE
 
 
             $sql = "UPDATE 202_version SET version='1.9.47'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.47';
         }
@@ -2443,19 +2526,19 @@ class UPGRADE
         if ($prosper202_version == '1.9.47') {
 
             $sql = "ALTER TABLE 202_users ADD COLUMN `user_public_publisher_id` varchar(10) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users ADD INDEX (`user_public_publisher_id`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_roles` (`role_id`, `role_name`) VALUES (6, 'Publisher')";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // Add publisher Ids to all existing users
             createPublisherIds();
 
             $sql = "UPDATE 202_version SET version='1.9.48'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.48';
         }
@@ -2463,7 +2546,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.48') {
 
             $sql = "UPDATE 202_version SET version='1.9.49'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.49';
         }
@@ -2471,10 +2554,10 @@ class UPGRADE
         if ($prosper202_version == '1.9.49') {
 
             $sql = "ALTER TABLE 202_users ADD COLUMN `user_dash_email` varchar(100) NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.50'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.50';
         }
@@ -2482,16 +2565,16 @@ class UPGRADE
         if ($prosper202_version == '1.9.50') {
 
             $sql = "ALTER TABLE 202_cpa_trackers ADD PRIMARY KEY (`click_id`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users_pref ADD COLUMN `user_delete_data_clickid` int(10) unsigned DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE 202_users_pref ADD COLUMN `user_pref_privacy` varchar(100) NOT NULL DEFAULT 'disabled'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_locations_city` ADD INDEX   `city_name` (`city_name`,`main_country_id`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_bing` (
             `click_id` bigint(20) unsigned NOT NULL,
@@ -2504,7 +2587,7 @@ class UPGRADE
             PRIMARY KEY (`click_id`,`msclkid`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE `202_ips_v6` (
             `ip_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -2515,15 +2598,15 @@ class UPGRADE
             KEY `location_id` (`location_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             //set collations and char set
 
             $sql = "ALTER TABLE `202_ips` CHANGE `ip_address` `ip_address` VARCHAR(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.51'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.51';
         }
@@ -2534,16 +2617,16 @@ class UPGRADE
             //set collations and char set
 
             $sql = "ALTER TABLE `202_ips` CHANGE `ip_address` `ip_address` VARCHAR(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // for the varchar(191) fix
             $sql = "CREATE TABLE  IF NOT EXISTS `202_variable_sets2` (`variable_set_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,`variables` varchar(255) NOT NULL DEFAULT '',PRIMARY KEY (`variable_set_id`,`variables`(191)),KEY `custom_variable_id` (`variables`(191)),KEY `click_id` (`variable_set_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             //Move data from variable_sets into variable_sets2
             $sql = "SELECT * from 202_variable_sets";
 
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $i = 0;
             $row = '';
@@ -2558,7 +2641,7 @@ class UPGRADE
 
                 if (($i % 600) == 0) {
                     $row = "insert ignore into `202_variable_sets2` (`variable_set_id`, `variables`) values " . rtrim($row, ',') . ";";
-                    _mysqli_query($row);
+                    _upgrade_query($row);
 
                     $i = 0;
                     $row = '';
@@ -2568,7 +2651,7 @@ class UPGRADE
             //add the last bit of data if there's any left
             if ($row) {
                 $row = "insert ignore into `202_variable_sets2` (`variable_set_id`, `variables`) values " . rtrim($row, ',') . ";";
-                _mysqli_query($row);
+                _upgrade_query($row);
             }
 
             //add fbclid table
@@ -2582,13 +2665,13 @@ class UPGRADE
             `utm_content_id` bigint(20) unsigned NOT NULL,
             PRIMARY KEY (`click_id`,`fbclid`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_ppc_account_pixels` ADD INDEX  `ppc_account_id` (`ppc_account_id`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.52'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.52';
         }
@@ -2597,10 +2680,10 @@ class UPGRADE
         if ($prosper202_version == '1.9.52') {
 
             $sql = "ALTER TABLE 202_users_pref ADD COLUMN `ipqs_api_key` varchar(250) DEFAULT NULL";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.53'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.53';
         }
@@ -2617,7 +2700,7 @@ class UPGRADE
                 PRIMARY KEY (`b202_fbpa_id`),
                 UNIQUE KEY `landing_page_id` (`landing_page_id`)
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_bot202_facebook_pixel_content_type` (
                 `content_type_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2626,7 +2709,7 @@ class UPGRADE
                 PRIMARY KEY (`content_type_id`),
                 KEY `content_type_id` (`content_type_id`,`content_type_description`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_bot202_facebook_pixel_click_events` (
                 `event_type_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2635,15 +2718,15 @@ class UPGRADE
                 PRIMARY KEY (`event_type_id`),
                 KEY `event_type_id` (`event_type_id`,`event_type_description`)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
 
             $sql = "INSERT IGNORE INTO `202_pixel_types` (`pixel_type`) VALUES
 				('Bot202 Facebook Pixel Assistant');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.54'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.54';
         }
@@ -2651,7 +2734,7 @@ class UPGRADE
         if ($prosper202_version == '1.9.54') {
 
             $sql = "DROP TABLE IF EXISTS `202_bot202_facebook_pixel_click_events`";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_bot202_facebook_pixel_click_events` (
                 `event_type_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2660,16 +2743,16 @@ class UPGRADE
                 PRIMARY KEY (`event_type_id`),
                 KEY `event_type_id` (`event_type_id`,`event_type_description`)
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_bot202_facebook_pixel_click_events` (`event_type_id`, `event_type`, `event_type_description`)
                     VALUES
                     (1,X'56696577436F6E74656E74',X'547261636B2041733A205669657720436F6E74656E74'),
                     (2,X'416464546F43617274',X'547261636B2041733A2041646420546F2043617274');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "DROP TABLE IF EXISTS `202_bot202_facebook_pixel_content_type`;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_bot202_facebook_pixel_content_type` (
                 `content_type_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2678,7 +2761,7 @@ class UPGRADE
                 PRIMARY KEY (`content_type_id`),
                 KEY `content_type_id` (`content_type_id`,`content_type_description`)
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT INTO `202_bot202_facebook_pixel_content_type` (`content_type_id`, `content_type`, `content_type_description`)
             VALUES
@@ -2688,20 +2771,20 @@ class UPGRADE
                 (4,X'64657374696E6174696F6E',X'54726176656C2044657374696E6174696F6E'),
                 (5,X'76656869636C65',X'4E6577202620557365642056656869636C6573'),
                 (6,X'686F6D655F6C697374696E67',X'5265616C2045737461746520262052656E74616C2050726F7065727479');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "ALTER TABLE `202_aff_campaigns` ADD INDEX  `aff_campaign_id` (`aff_campaign_id`,`aff_campaign_name`)";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             if ($_POST['lp_ssl'] == 1 || !isset($_POST['lp_ssl'])) {
 
                 //upgrade to ssl if user requests it or if no option is set
                 $sql = "UPDATE 202_landing_pages set landing_page_url = REPLACE(landing_page_url,'http://','https://')";
-                $result = _mysqli_query($sql);
+                $result = _upgrade_query($sql);
             }
 
             $sql = "UPDATE 202_version SET version='1.9.55'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.55';
         }
@@ -2725,7 +2808,7 @@ class UPGRADE
               KEY `content_type_active_published` (`content_type`,`is_active`,`published_at`),
               UNIQUE KEY `unique_content` (`content_type`,`external_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // Create dashboard sync tracking table
             $sql = "CREATE TABLE IF NOT EXISTS `202_dashboard_sync` (
@@ -2736,10 +2819,10 @@ class UPGRADE
               `last_error` text,
               PRIMARY KEY (`content_type`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.56'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.56';
         }
@@ -2761,7 +2844,7 @@ class UPGRADE
               UNIQUE KEY `model_slug_user` (`user_id`,`model_slug`),
               KEY `user_default` (`user_id`,`is_default`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_attribution_snapshots` (
               `snapshot_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -2781,7 +2864,7 @@ class UPGRADE
               KEY `model_hour_scope` (`model_id`,`date_hour`,`scope_type`,`scope_id`),
               KEY `user_hour` (`user_id`,`date_hour`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_attribution_touchpoints` (
               `touchpoint_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -2796,7 +2879,7 @@ class UPGRADE
               KEY `snapshot_conv` (`snapshot_id`,`conv_id`),
               KEY `click_lookup` (`click_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_attribution_settings` (
               `setting_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -2811,7 +2894,7 @@ class UPGRADE
               UNIQUE KEY `user_scope` (`user_id`,`scope_type`,`scope_id`),
               KEY `model_lookup` (`model_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_attribution_audit` (
               `audit_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -2825,7 +2908,7 @@ class UPGRADE
               KEY `model_lookup` (`model_id`),
               KEY `action_lookup` (`action`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_attribution_exports` (
               `export_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -2858,12 +2941,12 @@ class UPGRADE
               KEY `user_status` (`user_id`,`status`),
               KEY `queued_at` (`queued_at`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT IGNORE INTO `202_permissions` (`permission_id`, `permission_description`) VALUES
                     (22, 'view_attribution_reports'),
                     (23, 'manage_attribution_models');";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "INSERT IGNORE INTO `202_role_permission` (`role_id`, `permission_id`) VALUES
                     (1, 22),
@@ -2871,21 +2954,21 @@ class UPGRADE
                     (2, 22),
                     (2, 23),
                     (3, 22);";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             // Add attribution model reference to campaigns table (check if column exists first)
             $sql = "SELECT COUNT(*) as count FROM INFORMATION_SCHEMA.COLUMNS
                     WHERE TABLE_SCHEMA = DATABASE()
                     AND TABLE_NAME = '202_aff_campaigns'
                     AND COLUMN_NAME = 'attribution_model_id'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $row = mysqli_fetch_assoc($result);
 
             if ($row['count'] == 0) {
                 $sql = "ALTER TABLE `202_aff_campaigns`
                         ADD COLUMN `attribution_model_id` int(11) DEFAULT NULL
                         AFTER `aff_campaign_cloaking`";
-                $result = _mysqli_query($sql);
+                $result = _upgrade_query($sql);
             }
 
             // Create index for attribution model lookups (check if index exists first)
@@ -2893,13 +2976,13 @@ class UPGRADE
                     WHERE TABLE_SCHEMA = DATABASE()
                     AND TABLE_NAME = '202_aff_campaigns'
                     AND INDEX_NAME = 'idx_attribution_model'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             $row = mysqli_fetch_assoc($result);
 
             if ($row['count'] == 0) {
                 $sql = "ALTER TABLE `202_aff_campaigns`
                         ADD INDEX `idx_attribution_model` (`attribution_model_id`)";
-                $result = _mysqli_query($sql);
+                $result = _upgrade_query($sql);
             }
 
             // Create default "Last Touch" attribution model for existing users
@@ -2926,10 +3009,10 @@ class UPGRADE
                         UNIX_TIMESTAMP() as updated_at
                     FROM `202_users`
                     WHERE `user_id` > 0";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.56'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.56';
         }
@@ -2947,10 +3030,10 @@ class UPGRADE
               KEY `conv_id` (`conv_id`),
               KEY `click_lookup` (`click_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.57'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.57';
         }
@@ -3030,7 +3113,7 @@ class UPGRADE
             }
 
             $sql = "UPDATE 202_version SET version='1.9.58'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.58';
         }
@@ -3063,10 +3146,10 @@ class UPGRADE
               KEY `user_status` (`user_id`,`status`),
               KEY `model_status` (`model_id`,`status`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "UPDATE 202_version SET version='1.9.59'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.59';
         }
@@ -3101,7 +3184,7 @@ class UPGRADE
               KEY `created_at` (`created_at`),
               KEY `source_target` (`source_label`,`target_label`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sync_job_events` (
               `event_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -3114,7 +3197,7 @@ class UPGRADE
               PRIMARY KEY (`event_id`),
               KEY `job_created` (`sync_job_id`,`created_at`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sync_job_items` (
               `item_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -3133,7 +3216,7 @@ class UPGRADE
               KEY `job_entity_status` (`sync_job_id`,`entity`,`status`),
               KEY `job_action` (`sync_job_id`,`action`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_change_log` (
               `change_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -3148,7 +3231,7 @@ class UPGRADE
               KEY `entity_changed` (`entity`,`changed_at`),
               KEY `digest_lookup` (`natural_key_digest`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_deleted_log` (
               `deleted_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -3162,7 +3245,7 @@ class UPGRADE
               KEY `entity_deleted` (`entity`,`deleted_at`),
               KEY `digest_lookup` (`natural_key_digest`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "CREATE TABLE IF NOT EXISTS `202_sync_audit` (
               `audit_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -3181,17 +3264,17 @@ class UPGRADE
               KEY `actor_created` (`actor_user_id`,`created_at`),
               KEY `source_target_status` (`source_label`,`target_label`,`status`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $sql = "SHOW COLUMNS FROM `202_api_keys` LIKE 'scope'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
             if (!($result && mysqli_num_rows($result) > 0)) {
                 $sql = "ALTER TABLE `202_api_keys` ADD COLUMN `scope` text DEFAULT NULL AFTER `api_key`";
-                $result = _mysqli_query($sql);
+                $result = _upgrade_query($sql);
             }
 
             $sql = "UPDATE 202_version SET version='1.9.60'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
 
             $prosper202_version = '1.9.60';
         }
@@ -3201,7 +3284,7 @@ class UPGRADE
 
             $prosper202_version = '1.9.60';
             $sql = "UPDATE 202_version SET version='" . $prosper202_version . "'";
-            $result = _mysqli_query($sql);
+            $result = _upgrade_query($sql);
         }
 
         return true;

--- a/202-config/functions-upgrade.php
+++ b/202-config/functions-upgrade.php
@@ -7,38 +7,27 @@ if (!class_exists('DataEngine')) {
     include_once(__DIR__ . '/class-dataengine.php');
 }
 
-if (!function_exists('_upgrade_query')) {
+if (!function_exists('_upgrade_query_run')) {
     /**
-     * Resilient query runner for the upgrade path.
+     * Testable core of the upgrade query runner. Kept free of globals, real sleeps
+     * and _die() so the retry/classification logic can be unit-tested: the caller
+     * supplies the connection, the backoff sleeper, and the "give up" handler.
      *
-     * Runs the same global-$db query that _mysqli_query() does, but transparently
-     * retries transient lock-wait (1205) / deadlock (1213) errors — the failures a
-     * live, loaded server produces mid-migration — with exponential backoff. For
-     * those two errors the statement provably did not apply (the lock was never
-     * granted / the work was rolled back), so re-running the identical SQL is safe
-     * even when the statement isn't idempotent.
+     * Retries transient lock-wait (1205) / deadlock (1213) errors — for those the
+     * statement provably did not apply, so re-running the identical SQL is safe even
+     * when it isn't idempotent. Every other outcome preserves _mysqli_query()'s
+     * contract exactly (the mysqli_result, or false). A transient error that never
+     * clears hands off to $onExhausted instead of silently skipping a step.
      *
-     * Every other outcome preserves _mysqli_query()'s contract exactly (the
-     * mysqli_result, or false), so the upgrade's intentional "ignore an
-     * already-applied step" calls keep behaving as before. A transient error that
-     * never clears stops with a clear, resumable message instead of silently
-     * skipping a migration step.
-     *
-     * Only autocommit statements flow through here; the one explicit-transaction
-     * block (the 1.9.57 migration) calls $connection->query() directly, so a
-     * per-statement retry never runs inside an open transaction.
-     *
-     * @param  string|mixed $sql
-     * @return \mysqli_result|bool
+     * @param  object   $conn        anything exposing query(), ->errno and ->error (a mysqli in production)
+     * @param  string   $sql
+     * @param  callable $sleeper     fn(int $seconds): void — invoked with the backoff before each retry
+     * @param  callable $onExhausted fn(int $errno, string $error): mixed — invoked when a transient error never clears
+     * @param  int      $maxAttempts total attempts (1 + retries)
+     * @return \mysqli_result|bool|mixed
      */
-    function _upgrade_query($sql)
+    function _upgrade_query_run($conn, string $sql, callable $sleeper, callable $onExhausted, int $maxAttempts = 4)
     {
-        global $db;
-
-        $conn = ($db instanceof \mysqli) ? $db : $db->getConnection();
-        $sql  = (string) $sql;
-
-        $maxAttempts    = 4;            // 1 attempt + up to 3 retries
         $transientCodes = [1205, 1213]; // lock wait timeout, deadlock
 
         for ($attempt = 1; ; $attempt++) {
@@ -69,23 +58,61 @@ if (!function_exists('_upgrade_query')) {
             if ($isTransient && $attempt < $maxAttempts) {
                 error_log('Prosper202 upgrade: transient DB error ' . $errno . ' (' . $error
                     . '); retry ' . $attempt . ' of ' . ($maxAttempts - 1));
-                sleep(2 ** ($attempt - 1)); // 1s, 2s, 4s
+                $sleeper(2 ** ($attempt - 1)); // 1s, 2s, 4s
                 continue;
             }
 
-            // Transient but exhausted: the server stayed locked. Stop loudly — the
-            // upgrade is built to resume (IF [NOT] EXISTS / existence guards), so a
-            // re-run picks up where this left off.
+            // Transient but exhausted: hand off to the caller to stop loudly.
             if ($isTransient) {
-                error_log('Prosper202 upgrade: persistent transient DB error ' . $errno . ': ' . $error);
-                _die("<h6>Upgrade paused</h6>
-                    <small>The database stayed locked after several retries, which usually means the server is busy right now. Please re-run the upgrade in a few minutes — it resumes where it left off. <a href='" . get_absolute_url() . "202-login.php'>Back to login</a></small>");
+                return $onExhausted($errno, $error);
             }
 
             // Non-transient failure: preserve _mysqli_query()'s legacy contract so the
             // upgrade's "ignore already-applied" steps behave exactly as before.
             return false;
         }
+    }
+}
+
+if (!function_exists('_upgrade_query')) {
+    /**
+     * Resilient query runner for the upgrade path.
+     *
+     * Runs the same global-$db query that _mysqli_query() does, but transparently
+     * retries transient lock-wait (1205) / deadlock (1213) errors — the failures a
+     * live, loaded server produces mid-migration — with exponential backoff. A
+     * transient error that never clears stops with a clear, resumable message
+     * instead of silently skipping a migration step; every other outcome preserves
+     * _mysqli_query()'s contract exactly (the mysqli_result, or false).
+     *
+     * Only autocommit statements flow through here; the one explicit-transaction
+     * block (the 1.9.57 migration) calls $connection->query() directly, so a
+     * per-statement retry never runs inside an open transaction.
+     *
+     * @param  string|mixed $sql
+     * @return \mysqli_result|bool
+     */
+    function _upgrade_query($sql)
+    {
+        global $db;
+
+        $conn = ($db instanceof \mysqli) ? $db : $db->getConnection();
+
+        return _upgrade_query_run(
+            $conn,
+            (string) $sql,
+            static function (int $seconds): void {
+                sleep($seconds);
+            },
+            static function (int $errno, string $error) {
+                // Transient error that never cleared: the server stayed locked. Stop
+                // loudly — the upgrade resumes (IF [NOT] EXISTS / existence guards) on
+                // re-run. The errno/error go only to the log, never to the user.
+                error_log('Prosper202 upgrade: persistent transient DB error ' . $errno . ': ' . $error);
+                _die("<h6>Upgrade paused</h6>
+                    <small>The database stayed locked after several retries, which usually means the server is busy right now. Please re-run the upgrade in a few minutes — it resumes where it left off. <a href='" . get_absolute_url() . "202-login.php'>Back to login</a></small>");
+            }
+        );
     }
 }
 

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 //include mysql settings
 include_once(__DIR__ . '/connect.php');
 include_once(__DIR__ . '/functions-install.php');
+include_once(__DIR__ . '/functions-install-helpers.php');
 if (!isset($db) || !($db instanceof mysqli)) {
 	_die('Database connection unavailable.');
 }
@@ -18,14 +19,9 @@ $install_warnings = [];
 // Whether the last account-creation failure looks transient and worth a retry.
 $retryable = false;
 
-// Single source of truth for the field rules, shared by the server-side checks
-// below and the client-side JS (injected via json_encode) so the two can't drift.
-$rules = [
-	'username_min' => 4,
-	'username_max' => 20,
-	'password_min' => 6,
-	'password_max' => 35,
-];
+// Field rules, shared by the server-side validation and the client-side JS
+// (injected via json_encode) so the two can't drift. See functions-install-helpers.php.
+$rules = install_default_rules();
 
 /**
  * Emit a JSON response for the AJAX install flow and stop. Any buffered output is
@@ -139,7 +135,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	// persisted across AJAX via withWritableSession). Reject any POST whose token
 	// doesn't match the session before doing any work.
 	$expected_token = (string) ($_SESSION['token'] ?? '');
-	$csrf_ok = $expected_token !== '' && hash_equals($expected_token, (string) ($_POST['token'] ?? ''));
+	$csrf_ok = install_csrf_ok($expected_token, (string) ($_POST['token'] ?? ''));
 
 	if (!$csrf_ok) {
 		$error['general'] = '<div class="error">Your session has expired or the security check failed. Please refresh the page and submit again.</div>';
@@ -152,51 +148,13 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		}
 	}
 
-	// Raw POST reads are null-coalesced so a malformed request (missing fields)
-	// produces validation errors, not "undefined array key" warnings.
-	$in_email = (string) ($_POST['user_email'] ?? '');
-	$in_name  = (string) ($_POST['user_name'] ?? '');
-
-	//check email
-	if (check_email_address($in_email) == false) {
-		$error['user_email'] = '<div class="error">Please enter a valid email address</div>';
-	}
-
-	//check username
-	if ($in_name === '') {
-		$error['user_name'] = '<div class="error">You must type in your desired username</div>';
-	}
-	if (!ctype_alnum($in_name)) {
-		$error['user_name'] .= '<div class="error">Your username may only contain alphanumeric characters</div>';
-	}
-	if ((strlen($in_name) < $rules['username_min']) or (strlen($in_name) > $rules['username_max'])) {
-		$error['user_name'] .= '<div class="error">Your username must be between ' . $rules['username_min'] . ' and ' . $rules['username_max'] . ' characters long</div>';
-	}
-
-	// Check if password field is empty
-	if (!isset($_POST['user_pass']) || empty($_POST['user_pass'])) {
-		$error['user_pass'] = '<div class="error">You must type in your desired password</div>';
-	}
-
-		// Check if password verification field is empty
-		if (!isset($_POST['verify_user_pass']) || empty($_POST['verify_user_pass'])) {
-			$error['user_pass'] .= '<div class="error">You must verify your password</div>';
-		}
-
-		// Check password length only if password was provided
-		if (isset($_POST['user_pass']) && !empty($_POST['user_pass'])) {
-			$pass_length = strlen((string) $_POST['user_pass']);
-			if ($pass_length < $rules['password_min']) {
-				$error['user_pass'] .= '<div class="error">Your password must be at least ' . $rules['password_min'] . ' characters long</div>';
-			} elseif ($pass_length > $rules['password_max']) {
-				$error['user_pass'] .= '<div class="error">Your password must be no more than ' . $rules['password_max'] . ' characters long</div>';
-			}
-		}
-
-		// Check if passwords match only if both were provided
-		if (isset($_POST['user_pass']) && isset($_POST['verify_user_pass']) && $_POST['user_pass'] != $_POST['verify_user_pass']) {
-			$error['user_pass'] .= '<div class="error">Your passwords did not match, please try again</div>';
-		}
+	// Validate the account fields. The rule checks live in a pure, unit-tested
+	// helper (functions-install-helpers.php); $error['general'] from the CSRF check
+	// above is preserved.
+	$fieldErrors = install_validate_account($_POST, $rules);
+	$error['user_email'] = $fieldErrors['user_email'];
+	$error['user_name']  = $fieldErrors['user_name'];
+	$error['user_pass']  = $fieldErrors['user_pass'];
 
 	//if the CSRF check passed and no validation error occurred, create the account
 	if ($csrf_ok && empty($error['user_email']) && empty($error['user_name']) && empty($error['user_pass'])) {

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -244,7 +244,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$retryable = false;
 				$error['general'] = '<div class="error">We couldn\'t finish creating your account. You can '
 					. '<a href="' . get_absolute_url() . '202-config/setup-config.php">re-check your database settings</a> '
-					. 'or follow the <a href="http://support.tracking202.com/" target="_blank">manual install guide</a>, then try again.</div>';
+					. 'or follow the <a href="http://support.tracking202.com/" target="_blank" rel="noopener noreferrer">manual install guide</a>, then try again.</div>';
 			}
 		}
 
@@ -383,7 +383,7 @@ if (!$success) {
 		<h6>Welcome</h6>
 		<small>Welcome to the five minute Prosper202 installation process! Just fill in the information below, and you'll be on your way to using the most powerful internet marketing applications in the world.</small>
 		<br><br>
-		<small>Need Extra Help? Check out our <a href="http://support.tracking202.com/" target="_blank">ReadMe documentation</a>.</small>
+		<small>Need Extra Help? Check out our <a href="http://support.tracking202.com/" target="_blank" rel="noopener noreferrer">ReadMe documentation</a>.</small>
 
 		<h6>Create your account</h6>
 		<small>Please provide the following information. Don't worry, you can always change these settings later.</small>
@@ -608,7 +608,7 @@ if (!$success) {
 						setHtml('install-general-error', '<div class="error">We\'re having trouble reaching the server. '
 							+ 'Check your connection and try again. If it keeps happening you can '
 							+ '<a href="' + BASE + '202-config/setup-config.php">re-check your database settings</a> '
-							+ 'or follow the <a href="http://support.tracking202.com/" target="_blank">manual install guide</a>.</div>');
+							+ 'or follow the <a href="http://support.tracking202.com/" target="_blank" rel="noopener noreferrer">manual install guide</a>.</div>');
 					});
 				}
 

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -187,6 +187,12 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				throw new \RuntimeException('Failed to insert user: ' . $stmtError, $errno);
 			}
 			$user_id = (int) $db->insert_id;
+			// Whether THIS request created the user, vs. INSERT IGNORE finding an
+			// existing row in the lookup below. Only a newly-created account gets a
+			// default chart: 202_charts has no unique key, so inserting one for an
+			// already-existing user (e.g. two concurrent same-username installs) would
+			// duplicate it. The pref/role rows are INSERT IGNORE, so they're already safe.
+			$user_created = $user_id > 0;
 			$stmt->close();
 
 			// INSERT IGNORE yields insert_id 0 when the row already exists;
@@ -231,21 +237,23 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			}
 			$stmt->close();
 
-			// Default dashboard chart for the new account, keyed on the committed
-			// $user_id. A rolled-back retry consumes the AUTO_INCREMENT id, so the
-			// account isn't necessarily user 1; account_overview.php joins charts on
-			// the user's own id, so a hard-coded id would leave the account chartless.
-			$chart_data = 'a:3:{i:0;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:6:"clicks";}i:1;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:9:"click_out";}i:2;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:5:"leads";}}';
-			$chart_range = 'days';
-			$stmt = $prepare("INSERT INTO `202_charts` (`user_id`, `data`, `chart_time_range`) VALUES (?, ?, ?)");
-			$stmt->bind_param('iss', $user_id, $chart_data, $chart_range);
-			if (!$stmt->execute()) {
-				$errno = (int) $stmt->errno;
-				$stmtError = $stmt->error;
+			if ($user_created) {
+				// Default dashboard chart for the new account, keyed on the committed
+				// $user_id. A rolled-back retry consumes the AUTO_INCREMENT id, so the
+				// account isn't necessarily user 1; account_overview.php joins charts on
+				// the user's own id, so a hard-coded id would leave the account chartless.
+				$chart_data = 'a:3:{i:0;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:6:"clicks";}i:1;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:9:"click_out";}i:2;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:5:"leads";}}';
+				$chart_range = 'days';
+				$stmt = $prepare("INSERT INTO `202_charts` (`user_id`, `data`, `chart_time_range`) VALUES (?, ?, ?)");
+				$stmt->bind_param('iss', $user_id, $chart_data, $chart_range);
+				if (!$stmt->execute()) {
+					$errno = (int) $stmt->errno;
+					$stmtError = $stmt->error;
+					$stmt->close();
+					throw new \RuntimeException('Failed to insert default chart: ' . $stmtError, $errno);
+				}
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert default chart: ' . $stmtError, $errno);
 			}
-			$stmt->close();
 
 			if (!$db->commit()) {
 				throw new \RuntimeException('Failed to commit transaction: ' . $db->error, (int) $db->errno);
@@ -514,9 +522,9 @@ if (!$success) {
 			<button class="btn btn-lg btn-p202 btn-block" type="submit">Install Prosper202 ClickServer<span class="fui-check-inverted pull-right"></span></button>
 			<script type="text/javascript">
 			(function () {
-				var BASE = <?php echo json_encode(get_absolute_url()); ?>;
+				var BASE = <?php echo json_encode(get_absolute_url()) ?: '""'; ?>;
 				// Field rules come from the server ($rules) so client and server can't drift.
-				var RULES = <?php echo json_encode($rules); ?>;
+				var RULES = <?php echo json_encode($rules) ?: '{}'; ?>;
 				var MAX_ATTEMPTS = 3; // 1 try + 2 auto-retries on transient/network failures
 				var form = document.getElementById('install-prosper202');
 				if (!form) { return; }

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -7,6 +7,82 @@ if (!isset($db) || !($db instanceof mysqli)) {
 	_die('Database connection unavailable.');
 }
 
+// Detect XHR/AJAX submissions so we can answer with JSON instead of a full page.
+$isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH'])
+	&& strtolower((string) $_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+// Non-critical issues collected during install. They're surfaced as a gentle note
+// on the success screen instead of blocking the install — all are safe to fix later.
+$install_warnings = [];
+
+// Whether the last account-creation failure looks transient and worth a retry.
+$retryable = false;
+
+/**
+ * Emit a JSON response for the AJAX install flow and stop. Any buffered output is
+ * discarded first so the body is always valid JSON. A json_encode() failure is
+ * surfaced explicitly rather than sending an empty body (CLAUDE.md #4).
+ *
+ * @param array<string,mixed> $payload
+ */
+function install_json(array $payload): never
+{
+	while (ob_get_level() > 0) {
+		ob_end_clean();
+	}
+	header('Content-Type: application/json; charset=utf-8');
+	$json = json_encode($payload);
+	if ($json === false) {
+		http_response_code(500);
+		echo '{"success":false,"retryable":true,"errors":{"general":"<div class=\"error\">The server hit an unexpected error encoding its response. Please try again.</div>"}}';
+		exit;
+	}
+	echo $json;
+	exit;
+}
+
+/**
+ * Render just the post-install success panel (the .main block), so it can be
+ * swapped into the page over AJAX or printed directly on the no-JS path.
+ * $warnings are developer-authored, safe HTML strings.
+ *
+ * @param array<string,string> $html
+ * @param list<string>         $warnings
+ */
+function render_install_success(array $html, array $warnings): void
+{
+	$base = get_absolute_url();
+	?>
+	<div class="main col-xs-7 install">
+		<center><img src="<?php echo $base; ?>202-img/prosper202.png"></center>
+		<h6>Success!</h6>
+		<small>Prosper202 has been installed. Now you can <a href="<?php echo $base; ?>202-login.php">log in</a>.</small><br></br>
+		<div class="row" style="margin-bottom: 10px;">
+			<div class="col-xs-3"><span class="label label-default">Username:</span></div>
+			<div class="col-xs-9"><span class="label label-primary"><?php echo $html['user_name']; ?></span></div>
+		</div>
+		<div class="row" style="margin-bottom: 10px;">
+			<div class="col-xs-3"><span class="label label-default">Login address:</span></div>
+			<div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', $base, $_SERVER['SERVER_NAME'] . $base); ?></small></div>
+		</div>
+		<?php if ($warnings) { ?>
+			<div style="margin: 12px 0; padding: 8px 12px; border: 1px solid #faebcc; background: #fcf8e3; color: #8a6d3b; border-radius: 4px; font-size: 12px;">
+				<strong>You're all set — a couple of optional steps need a quick follow-up:</strong>
+				<ul style="margin: 6px 0 0 18px;">
+					<?php foreach ($warnings as $w) { echo '<li>' . $w . '</li>'; } ?>
+				</ul>
+			</div>
+		<?php } ?>
+		<p><small>Were you expecting more steps? Sorry thats it!</small></p>
+	</div>
+	<?php
+}
+
+// Buffer everything for AJAX requests so stray output never corrupts the JSON body.
+if ($isAjax) {
+	ob_start();
+}
+
 // Initialize the success variable to false by default
 $success = false;
 
@@ -33,6 +109,16 @@ if (isset($_COOKIE['user_api'])) {
 
 //check to see if this is already installed, if so don't do anything
 if (is_installed() == true) {
+
+	if ($isAjax) {
+		install_json([
+			'success'   => false,
+			'retryable' => false,
+			'errors'    => [
+				'general' => '<div class="error">Prosper202 is already installed. <a href="' . get_absolute_url() . '202-login.php">Log in now</a>.</div>',
+			],
+		]);
+	}
 
 	_die("<h6>Already Installed</h6>
 			  <small>You appear to have already installed Prosper202. To reinstall please clear your old database tables first. <a href='" . get_absolute_url() . "202-login.php'>Login Now</a></small>");
@@ -84,9 +170,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	//if no error occurred, let's create the user account
 	if (empty($error['user_email']) && empty($error['user_name']) && empty($error['user_pass'])) {
 
-		//no error, so now setup all of the mysql database structures
+		//no error, so now set up the mysql database structures and the account
 		$installer = new INSTALL();
-		$installer->install_databases();
 
 		// Raw, unescaped values — these are bound as parameters below, so prepared
 		// statements handle the escaping. No manual real_escape_string() needed.
@@ -112,10 +197,17 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			return $stmt;
 		};
 
-		// Create the user, its preference row, and its role atomically so a
-		// mid-way failure can't leave a half-built account behind.
-		$db->begin_transaction();
+		// Build the schema, then create the user / preference / role rows atomically
+		// so a mid-way failure can't leave a half-built account behind.
+		$inTransaction = false;
 		try {
+			// DDL implicitly commits, so all table creation/seeding must happen
+			// before we open our transaction.
+			$installer->install_databases();
+
+			$db->begin_transaction();
+			$inTransaction = true;
+
 			$stmt = $prepare(
 				"INSERT IGNORE INTO 202_users
 					SET user_email=?, user_name=?, user_pass=?, user_timezone=?,
@@ -176,36 +268,64 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$stmt->close();
 
 			$db->commit();
+			$inTransaction = false;
 		} catch (\Throwable $e) {
-			$db->rollback();
+			if ($inTransaction) {
+				$db->rollback();
+			}
 			$user_id = 0;
-			$error['general'] = '<div class="error">Failed to create user account. Please try again with a different username.</div>';
+			error_log('Prosper202 install: account creation failed: ' . $e->getMessage());
+
+			// Transient DB conditions are worth an automatic retry; anything else
+			// gets an actionable message pointing at the manual fallbacks.
+			$transientCodes = [1205 /* lock wait timeout */, 1213 /* deadlock */, 2006 /* server gone away */, 2013 /* lost connection */];
+			if (in_array((int) $e->getCode(), $transientCodes, true)) {
+				$retryable = true;
+				$error['general'] = '<div class="error">The database was briefly unavailable while creating your account. This is usually temporary — please try again.</div>';
+			} else {
+				$retryable = false;
+				$error['general'] = '<div class="error">We couldn\'t finish creating your account. You can '
+					. '<a href="' . get_absolute_url() . '202-config/setup-config.php">re-check your database settings</a> '
+					. 'or follow the <a href="http://support.tracking202.com/" target="_blank">manual install guide</a>, then try again.</div>';
+			}
 		}
 
-		// Only continue post-setup once the account is committed.
+		// Only continue post-setup once the account is committed. Every step here is
+		// non-critical: the account already works, so failures become a friendly note
+		// (CLAUDE.md-style explicit handling) instead of blocking a successful install.
 		if ($user_id > 0) {
-			$cron = callAutoCron('register');
-
-			if (is_array($cron) && ($cron['status'] ?? null) === 'success') {
-				// auto_cron is a non-critical optimization flag; the account is
-				// already committed, so don't fail the install if this can't be set.
-				try {
+			// auto_cron registration calls an external service; treat any failure as optional.
+			try {
+				$cron = callAutoCron('register');
+				if (is_array($cron) && ($cron['status'] ?? null) === 'success') {
 					$stmt = $prepare("UPDATE 202_users_pref SET auto_cron = '1' WHERE user_id = ?");
 					$stmt->bind_param('i', $user_id);
 					if (!$stmt->execute()) {
 						$stmt->close();
-						throw new \RuntimeException('Failed to enable auto cron: ' . $db->error);
+						throw new \RuntimeException('auto_cron flag update failed: ' . $db->error);
 					}
 					$stmt->close();
-				} catch (\Throwable $e) {
-					error_log('Prosper202 install: ' . $e->getMessage());
 				}
+			} catch (\Throwable $e) {
+				error_log('Prosper202 install: auto cron setup failed: ' . $e->getMessage());
+				$install_warnings[] = 'Automatic cron setup didn\'t complete. Tracking still works — you can enable it later from <strong>Settings &rarr; Cron</strong>.';
 			}
 
-			registerDailyEmail('07', $user_timezone, $hash);
+			// Daily email reports register with an external service; optional.
+			try {
+				registerDailyEmail('07', $user_timezone, $hash);
+			} catch (\Throwable $e) {
+				error_log('Prosper202 install: registerDailyEmail failed: ' . $e->getMessage());
+				$install_warnings[] = 'We couldn\'t register daily email reports just now. This is optional and can be set up later from your dashboard.';
+			}
 
-			// create partitions after everything else is setup
-			$installer->install_database_partitions();
+			// Partitioning depends on MySQL features and is purely a performance step.
+			try {
+				$installer->install_database_partitions();
+			} catch (\Throwable $e) {
+				error_log('Prosper202 install: install_database_partitions failed: ' . $e->getMessage());
+				$install_warnings[] = 'Database partitioning was skipped (your MySQL build may not support it). Tracking works normally; high-volume tuning can be added later.';
+			}
 
 			//if this worked, show them the success screen
 			$success = true;
@@ -221,6 +341,32 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	}
 	$html['user_api'] = htmlentities((string) $_COOKIE['user_api'], ENT_QUOTES, 'UTF-8');
 	// Don't store password in HTML for security reasons
+
+	// AJAX submissions get JSON: either the rendered success panel to swap in, or
+	// the field/general errors plus whether a retry is worth attempting.
+	if ($isAjax) {
+		if ($success) {
+			ob_start();
+			render_install_success($html, $install_warnings);
+			$panel = ob_get_clean();
+			install_json([
+				'success'  => true,
+				'html'     => $panel,
+				'warnings' => $install_warnings,
+			]);
+		}
+
+		install_json([
+			'success'   => false,
+			'retryable' => $retryable,
+			'errors'    => [
+				'user_email' => $error['user_email'] ?? '',
+				'user_name'  => $error['user_name'] ?? '',
+				'user_pass'  => $error['user_pass'] ?? '',
+				'general'    => $error['general'] ?? '',
+			],
+		]);
+	}
 }
 
 
@@ -284,7 +430,7 @@ if (!$success) {
 		<h6>Create your account</h6>
 		<small>Please provide the following information. Don't worry, you can always change these settings later.</small>
 		<br><br>
-		<?php if (isset($error['general'])) echo $error['general']; ?>
+		<div id="install-general-error"><?php echo $error['general'] ?? ''; ?></div>
 		<form method="post" action="" class="form-horizontal" role="form" id="install-prosper202">
 
 			<input type="hidden" class="form-control input-sm" id="user_api" name="user_api" value="<?php echo $html['user_api']; ?>">
@@ -293,7 +439,7 @@ if (!$success) {
 				<label for="user_email" class="col-xs-4 control-label"><strong>Your Email:</strong></label>
 				<div class="col-xs-8">
 					<input type="text" class="form-control input-sm" id="user_email" name="user_email" value="<?php echo $html['user_email']; ?>">
-					<?php if ($error['user_email']) echo $error['user_email']; ?>
+					<div class="js-field-error" id="error-user_email"><?php echo $error['user_email']; ?></div>
 				</div>
 			</div>
 
@@ -325,7 +471,8 @@ if (!$success) {
 						$transition =  $current_tz->getTransitions($dt->getTimestamp(), $dt->getTimestamp());
 						$abbr = $transition[0]['abbr'];
 
-						echo '<option value="' . $tz . '">' . $tz . ' [' . $abbr . ' ' . formatOffset($offset) . ']</option>';
+						$selected = ($tz === $user_timezone) ? ' selected' : '';
+						echo '<option value="' . $tz . '"' . $selected . '>' . $tz . ' [' . $abbr . ' ' . formatOffset($offset) . ']</option>';
 					}
 					echo '</select>';
 					?>
@@ -359,7 +506,7 @@ if (!$success) {
 				<label for="user_name" class="col-xs-4 control-label"><strong>Username:</strong></label>
 				<div class="col-xs-8">
 					<input type="text" class="form-control input-sm" id="user_name" name="user_name" value="<?php echo $html['user_name']; ?>">
-					<?php if ($error['user_name']) echo $error['user_name']; ?>
+					<div class="js-field-error" id="error-user_name"><?php echo $error['user_name']; ?></div>
 				</div>
 			</div>
 
@@ -367,10 +514,8 @@ if (!$success) {
 				<label for="user_pass" class="col-xs-4 control-label"><strong>Password:</strong></label>
 				<div class="col-xs-8">
 					<input type="password" class="form-control input-sm" id="user_pass" name="user_pass">
-					<?php
-					// Only show password errors once, at the top password field
-					if ($error['user_pass']) echo $error['user_pass'];
-					?>
+					<?php // Password errors render once, here at the top password field ?>
+					<div class="js-field-error" id="error-user_pass"><?php echo $error['user_pass']; ?></div>
 				</div>
 			</div>
 
@@ -383,10 +528,128 @@ if (!$success) {
 
 			<button class="btn btn-lg btn-p202 btn-block" type="submit">Install Prosper202 ClickServer<span class="fui-check-inverted pull-right"></span></button>
 			<script type="text/javascript">
-				$('form#install-prosper202').submit(function() {
-					$(this).find(':input[type=submit]').prop('disabled', true);
-					$('body').css('cursor', 'wait');
+			(function () {
+				var BASE = <?php echo json_encode(get_absolute_url()); ?>;
+				var MAX_ATTEMPTS = 3; // 1 try + 2 auto-retries on transient/network failures
+				var form = document.getElementById('install-prosper202');
+				if (!form) { return; }
+				var submitBtn = form.querySelector('button[type=submit]');
+
+				function setHtml(id, html) {
+					var el = document.getElementById(id);
+					if (el) { el.innerHTML = html || ''; }
+				}
+				function markGroup(name, on) {
+					var input = form.querySelector('[name="' + name + '"]');
+					if (!input) { return; }
+					var group = input.closest('.form-group');
+					if (group) { group.classList.toggle('has-error', !!on); }
+				}
+				function clearErrors() {
+					setHtml('install-general-error', '');
+					['user_email', 'user_name', 'user_pass'].forEach(function (f) { setHtml('error-' + f, ''); });
+					['user_email', 'user_name', 'user_pass', 'verify_user_pass'].forEach(function (f) { markGroup(f, false); });
+				}
+				// Server messages already carry <div class="error"> markup; wrap plain client text to match.
+				function wrap(msg) { return msg.indexOf('<div') !== -1 ? msg : '<div class="error">' + msg + '</div>'; }
+
+				function showErrors(errors) {
+					if (errors.general) { setHtml('install-general-error', wrap(errors.general)); }
+					['user_email', 'user_name', 'user_pass'].forEach(function (f) {
+						if (errors[f]) { setHtml('error-' + f, wrap(errors[f])); markGroup(f, true); }
+					});
+				}
+
+				// Mirror the server-side validation so users get instant feedback before any round-trip.
+				function clientValidate() {
+					var errors = {};
+					var email = (form.user_email.value || '').trim();
+					var name = form.user_name.value || '';
+					var pass = form.user_pass.value || '';
+					var verify = form.verify_user_pass.value || '';
+					if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+						errors.user_email = 'Please enter a valid email address';
+					}
+					var nameErr = '';
+					if (name === '') {
+						nameErr += 'You must type in your desired username. ';
+					} else {
+						if (!/^[a-zA-Z0-9]+$/.test(name)) { nameErr += 'Your username may only contain alphanumeric characters. '; }
+						if (name.length < 4 || name.length > 20) { nameErr += 'Your username must be between 4 and 20 characters long. '; }
+					}
+					if (nameErr) { errors.user_name = nameErr.trim(); }
+					var passErr = '';
+					if (!pass) { passErr += 'You must type in your desired password. '; }
+					if (!verify) { passErr += 'You must verify your password. '; }
+					if (pass && pass.length < 6) { passErr += 'Your password must be at least 6 characters long. '; }
+					if (pass && pass.length > 35) { passErr += 'Your password must be no more than 35 characters long. '; }
+					if (pass && verify && pass !== verify) { passErr += 'Your passwords did not match, please try again. '; }
+					if (passErr) { errors.user_pass = passErr.trim(); }
+					return errors;
+				}
+
+				function busy(on) {
+					submitBtn.disabled = on;
+					document.body.style.cursor = on ? 'wait' : '';
+					form.dataset.submitting = on ? '1' : '';
+				}
+
+				function postOnce() {
+					return fetch(form.action || window.location.href, {
+						method: 'POST',
+						headers: { 'X-Requested-With': 'XMLHttpRequest' },
+						body: new FormData(form),
+						credentials: 'same-origin'
+					}).then(function (resp) {
+						var ct = resp.headers.get('content-type') || '';
+						if (ct.indexOf('application/json') === -1) { throw new Error('unexpected-response'); }
+						return resp.json();
+					});
+				}
+
+				function attempt(n) {
+					postOnce().then(function (res) {
+						if (res.success) {
+							var main = document.querySelector('.main.install') || document.querySelector('.main');
+							if (main && res.html) {
+								main.outerHTML = res.html;
+								window.scrollTo(0, 0);
+							} else {
+								window.location.reload();
+							}
+							return;
+						}
+						if (res.retryable && n < MAX_ATTEMPTS) {
+							setTimeout(function () { attempt(n + 1); }, Math.pow(2, n) * 1000);
+							return;
+						}
+						busy(false);
+						clearErrors();
+						showErrors(res.errors || {});
+					}).catch(function () {
+						// Network failure or a non-JSON response (e.g. a server error page).
+						if (n < MAX_ATTEMPTS) {
+							setTimeout(function () { attempt(n + 1); }, Math.pow(2, n) * 1000);
+							return;
+						}
+						busy(false);
+						setHtml('install-general-error', '<div class="error">We\'re having trouble reaching the server. '
+							+ 'Check your connection and try again. If it keeps happening you can '
+							+ '<a href="' + BASE + '202-config/setup-config.php">re-check your database settings</a> '
+							+ 'or follow the <a href="http://support.tracking202.com/" target="_blank">manual install guide</a>.</div>');
+					});
+				}
+
+				form.addEventListener('submit', function (e) {
+					e.preventDefault();
+					if (form.dataset.submitting === '1') { return; }
+					clearErrors();
+					var errors = clientValidate();
+					if (Object.keys(errors).length) { showErrors(errors); return; }
+					busy(true);
+					attempt(1);
 				});
+			})();
 			</script>
 		</form>
 	</div>
@@ -396,22 +659,7 @@ if (!$success) {
 
 //if success is equal to true, and this campaign did complete
 if ($success) {
-
-	info_top(); ?>
-	<div class="main col-xs-7 install">
-		<center><img src="<?php echo get_absolute_url(); ?>202-img/prosper202.png"></center>
-		<h6>Success!</h6>
-		<small>Prosper202 has been installed. Now you can <a href="<?php echo get_absolute_url(); ?>202-login.php">log in</a>.</small><br></br>
-		<div class="row" style="margin-bottom: 10px;">
-			<div class="col-xs-3"><span class="label label-default">Username:</span></div>
-			<div class="col-xs-9"><span class="label label-primary"><?php echo $html['user_name']; ?></span></div>
-		</div>
-		<div class="row" style="margin-bottom: 10px;">
-			<div class="col-xs-3"><span class="label label-default">Login address:</span></div>
-			<div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', get_absolute_url(), $_SERVER['SERVER_NAME'] . get_absolute_url()); ?></small></div>
-		</div>
-
-		<p><small>Were you expecting more steps? Sorry thats it!</small></p>
-	</div>
-<?php info_bottom();
+	info_top();
+	render_install_success($html, $install_warnings);
+	info_bottom();
 }

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -163,13 +163,17 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			}
 			$inTransaction = true;
 
+			// user_dash_email is NOT NULL with no default; set it to the account email
+			// so the INSERT is valid regardless of the session sql_mode (strict mode
+			// would otherwise reject the row, and non-strict would store an empty string).
 			$stmt = $prepare(
 				"INSERT IGNORE INTO 202_users
-					SET user_email=?, user_name=?, user_pass=?, user_timezone=?,
+					SET user_email=?, user_dash_email=?, user_name=?, user_pass=?, user_timezone=?,
 						user_time_register=?, install_hash=?, user_hash=?, p202_customer_api_key=?"
 			);
 			$stmt->bind_param(
-				'ssssisss',
+				'sssssisss',
+				$user_email,
 				$user_email,
 				$user_name,
 				$user_pass,

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -115,13 +115,13 @@ if (is_installed() == true) {
 			'success'   => false,
 			'retryable' => false,
 			'errors'    => [
-				'general' => '<div class="error">Prosper202 is already installed. <a href="' . get_absolute_url() . '202-login.php">Log in now</a>.</div>',
+				'general' => '<div class="error">Prosper202 is already installed — your account is ready. <a href="' . get_absolute_url() . '202-login.php">Log in to continue</a>.</div>',
 			],
 		]);
 	}
 
 	_die("<h6>Already Installed</h6>
-			  <small>You appear to have already installed Prosper202. To reinstall please clear your old database tables first. <a href='" . get_absolute_url() . "202-login.php'>Login Now</a></small>");
+			  <small>Prosper202 is already installed — your account is ready. <a href='" . get_absolute_url() . "202-login.php'>Log in to continue</a>.<br>Reinstalling? Clear your old database tables first.</small>");
 }
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -25,8 +25,9 @@ $rules = install_default_rules();
 
 /**
  * Emit a JSON response for the AJAX install flow and stop. Any buffered output is
- * discarded first so the body is always valid JSON. A json_encode() failure is
- * surfaced explicitly rather than sending an empty body (CLAUDE.md #4).
+ * discarded first so the body is always valid JSON. The payload is encoded via the
+ * unit-tested install_encode_response(), which surfaces a json_encode() failure
+ * explicitly rather than sending an empty body (CLAUDE.md #4).
  *
  * @param array<string,mixed> $payload
  */
@@ -36,51 +37,12 @@ function install_json(array $payload): never
 		ob_end_clean();
 	}
 	header('Content-Type: application/json; charset=utf-8');
-	$json = json_encode($payload);
-	if ($json === false) {
+	$encoded = install_encode_response($payload);
+	if (!$encoded['ok']) {
 		http_response_code(500);
-		echo '{"success":false,"retryable":true,"errors":{"general":"<div class=\"error\">The server hit an unexpected error encoding its response. Please try again.</div>"}}';
-		exit;
 	}
-	echo $json;
+	echo $encoded['body'];
 	exit;
-}
-
-/**
- * Render just the post-install success panel (the .main block), so it can be
- * swapped into the page over AJAX or printed directly on the no-JS path.
- * $warnings are developer-authored, safe HTML strings.
- *
- * @param array<string,string> $html
- * @param list<string>         $warnings
- */
-function render_install_success(array $html, array $warnings): void
-{
-	$base = get_absolute_url();
-	?>
-	<div class="main col-xs-7 install">
-		<center><img src="<?php echo $base; ?>202-img/prosper202.png"></center>
-		<h6>Success!</h6>
-		<small>Prosper202 has been installed. Now you can <a href="<?php echo $base; ?>202-login.php">log in</a>.</small><br></br>
-		<div class="row" style="margin-bottom: 10px;">
-			<div class="col-xs-3"><span class="label label-default">Username:</span></div>
-			<div class="col-xs-9"><span class="label label-primary"><?php echo $html['user_name']; ?></span></div>
-		</div>
-		<div class="row" style="margin-bottom: 10px;">
-			<div class="col-xs-3"><span class="label label-default">Login address:</span></div>
-			<div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', $base, htmlentities((string) ($_SERVER['SERVER_NAME'] ?? ''), ENT_QUOTES, 'UTF-8') . $base); ?></small></div>
-		</div>
-		<?php if ($warnings) { ?>
-			<div style="margin: 12px 0; padding: 8px 12px; border: 1px solid #faebcc; background: #fcf8e3; color: #8a6d3b; border-radius: 4px; font-size: 12px;">
-				<strong>You're all set — a couple of optional steps need a quick follow-up:</strong>
-				<ul style="margin: 6px 0 0 18px;">
-					<?php foreach ($warnings as $w) { echo '<li>' . $w . '</li>'; } ?>
-				</ul>
-			</div>
-		<?php } ?>
-		<p><small>Were you expecting more steps? Sorry thats it!</small></p>
-	</div>
-	<?php
 }
 
 // Buffer everything for AJAX requests so stray output never corrupts the JSON body.
@@ -343,7 +305,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if ($isAjax) {
 		if ($success) {
 			ob_start();
-			render_install_success($html, $install_warnings);
+			render_install_success($html, $install_warnings, get_absolute_url(), (string) ($_SERVER['SERVER_NAME'] ?? ''));
 			$panel = ob_get_clean();
 			install_json([
 				'success'  => true,
@@ -670,6 +632,6 @@ if (!$success) {
 //if success is equal to true, and this campaign did complete
 if ($success) {
 	info_top();
-	render_install_success($html, $install_warnings);
+	render_install_success($html, $install_warnings, get_absolute_url(), (string) ($_SERVER['SERVER_NAME'] ?? ''));
 	info_bottom();
 }

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -88,78 +88,127 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		$installer = new INSTALL();
 		$installer->install_databases();
 
-		$mysql['user_email'] = $db->real_escape_string($_POST['user_email'] ?? '');
-		$mysql['user_name'] = $db->real_escape_string($_POST['user_name'] ?? '');
-		$mysql['user_timezone'] = $db->real_escape_string($_POST['user_timezone'] ?? '');
-		$mysql['p202_customer_api_key'] = $db->real_escape_string($_POST['user_api'] ?? '');
-		$mysql['user_time_register'] = $db->real_escape_string((string) time());
+		// Raw, unescaped values — these are bound as parameters below, so prepared
+		// statements handle the escaping. No manual real_escape_string() needed.
+		$user_email         = (string) ($_POST['user_email'] ?? '');
+		$user_name          = (string) ($_POST['user_name'] ?? '');
+		$user_timezone      = (string) ($_POST['user_timezone'] ?? '');
+		$user_api           = (string) ($_POST['user_api'] ?? '');
+		$user_time_register = time();
 
-		//md5 the user pass with salt
-	 	$hasher = function_exists('hash_user_pass') ? 'hash_user_pass' : 'salt_user_pass';
-	 	$user_pass = $hasher($_POST['user_pass']);
-		$mysql['user_pass'] = $db->real_escape_string($user_pass);      
+		// hash_user_pass() (password_hash/bcrypt) is always available via
+		// functions-auth.php; fresh installs never use the legacy md5 path.
+		$user_pass = hash_user_pass((string) $_POST['user_pass']);
 
- 		$hash = md5(uniqid((string) random_int(0, mt_getrandmax()), TRUE));
-		// $user_hash = intercomHash($hash); // Removed intercomHash call
-		$user_hash = ''; // Default empty value
+		$hash = md5(uniqid((string) random_int(0, mt_getrandmax()), TRUE));
+		$user_hash = ''; // reserved for future use
 
-		//insert this user
-		$user_sql = "INSERT IGNORE INTO 202_users
-					SET	user_email='" . $mysql['user_email'] . "',
-						user_name='" . $mysql['user_name'] . "',
-						user_pass='" . $mysql['user_pass'] . "',
-						user_timezone='" . $mysql['user_timezone'] . "',
-						user_time_register='" . $mysql['user_time_register'] . "',
-						install_hash='" . $hash . "',
-						user_hash='" . $user_hash . "',
-						p202_customer_api_key='" . $mysql['p202_customer_api_key'] . "'";
-		$user_result = _mysqli_query($user_sql);
-
-		// Get the user_id of the newly inserted user or the existing user with the same username
-		$user_id = $db->insert_id;
-
-		// If insert_id is 0 (because the user already existed due to INSERT IGNORE), get the user_id manually
-		if ($user_id == 0) {
-			$check_sql = "SELECT user_id FROM 202_users WHERE user_name='" . $mysql['user_name'] . "'";
-			$check_result = _mysqli_query($check_sql);
-			if ($check_result && $check_result->num_rows > 0) {
-				$check_row = $check_result->fetch_assoc();
-				$user_id = $check_row['user_id'];
+		// prepare-or-throw so every statement's return value is checked (CLAUDE.md #1)
+		$prepare = static function (string $sql) use ($db): \mysqli_stmt {
+			$stmt = $db->prepare($sql);
+			if ($stmt === false) {
+				throw new \RuntimeException('Failed to prepare statement: ' . $db->error);
 			}
+			return $stmt;
+		};
+
+		// Create the user, its preference row, and its role atomically so a
+		// mid-way failure can't leave a half-built account behind.
+		$db->begin_transaction();
+		try {
+			$stmt = $prepare(
+				"INSERT IGNORE INTO 202_users
+					SET user_email=?, user_name=?, user_pass=?, user_timezone=?,
+						user_time_register=?, install_hash=?, user_hash=?, p202_customer_api_key=?"
+			);
+			$stmt->bind_param(
+				'ssssisss',
+				$user_email,
+				$user_name,
+				$user_pass,
+				$user_timezone,
+				$user_time_register,
+				$hash,
+				$user_hash,
+				$user_api
+			);
+			if (!$stmt->execute()) {
+				$stmt->close();
+				throw new \RuntimeException('Failed to insert user: ' . $db->error);
+			}
+			$user_id = (int) $db->insert_id;
+			$stmt->close();
+
+			// INSERT IGNORE yields insert_id 0 when the row already exists;
+			// look up the existing id so the rest of setup can proceed.
+			if ($user_id === 0) {
+				$stmt = $prepare("SELECT user_id FROM 202_users WHERE user_name=? LIMIT 1");
+				$stmt->bind_param('s', $user_name);
+				if (!$stmt->execute()) {
+					$stmt->close();
+					throw new \RuntimeException('Failed to look up user: ' . $db->error);
+				}
+				$lookup = $stmt->get_result();
+				if ($lookup && $row = $lookup->fetch_assoc()) {
+					$user_id = (int) $row['user_id'];
+				}
+				$stmt->close();
+			}
+
+			if ($user_id <= 0) {
+				throw new \RuntimeException('Could not determine a valid user_id');
+			}
+
+			$stmt = $prepare("INSERT IGNORE INTO 202_users_pref SET user_id=?");
+			$stmt->bind_param('i', $user_id);
+			if (!$stmt->execute()) {
+				$stmt->close();
+				throw new \RuntimeException('Failed to insert user preferences: ' . $db->error);
+			}
+			$stmt->close();
+
+			$stmt = $prepare("INSERT IGNORE INTO `202_user_role` (`user_id`, `role_id`) VALUES (?, 1)");
+			$stmt->bind_param('i', $user_id);
+			if (!$stmt->execute()) {
+				$stmt->close();
+				throw new \RuntimeException('Failed to insert user role: ' . $db->error);
+			}
+			$stmt->close();
+
+			$db->commit();
+		} catch (\Throwable $e) {
+			$db->rollback();
+			$user_id = 0;
+			$error['general'] = '<div class="error">Failed to create user account. Please try again with a different username.</div>';
 		}
 
-		// Only proceed if we have a valid user_id
+		// Only continue post-setup once the account is committed.
 		if ($user_id > 0) {
-			$mysql['user_id'] = $db->real_escape_string((string) $user_id);
-
-			// Update user preference table - use INSERT IGNORE to handle duplicates
-			$user_sql = "INSERT IGNORE INTO 202_users_pref SET user_id='" . $mysql['user_id'] . "'";
-			$user_result = _mysqli_query($user_sql);
-
-			// Insert user role - use the actual user_id, not a hardcoded value
-			$role_sql = "INSERT IGNORE INTO `202_user_role` (`user_id`, `role_id`) VALUES ('" . $mysql['user_id'] . "', 1)";
-			$role_result = _mysqli_query($role_sql);
-
 			$cron = callAutoCron('register');
 
 			if (is_array($cron) && ($cron['status'] ?? null) === 'success') {
-				$sql = "UPDATE 202_users_pref SET auto_cron = '1' WHERE user_id = '" . $mysql['user_id'] . "'";
-				$result = _mysqli_query($sql);
+				// auto_cron is a non-critical optimization flag; the account is
+				// already committed, so don't fail the install if this can't be set.
+				try {
+					$stmt = $prepare("UPDATE 202_users_pref SET auto_cron = '1' WHERE user_id = ?");
+					$stmt->bind_param('i', $user_id);
+					if (!$stmt->execute()) {
+						$stmt->close();
+						throw new \RuntimeException('Failed to enable auto cron: ' . $db->error);
+					}
+					$stmt->close();
+				} catch (\Throwable $e) {
+					error_log('Prosper202 install: ' . $e->getMessage());
+				}
 			}
 
-			// Add null check before accessing array offset on line 120
-				if (isset($mysql['user_timezone'])) {
-					registerDailyEmail('07', $mysql['user_timezone'], $hash);
-				}
+			registerDailyEmail('07', $user_timezone, $hash);
 
 			// create partitions after everything else is setup
 			$installer->install_database_partitions();
 
 			//if this worked, show them the success screen
 			$success = true;
-		} else {
-			// If we couldn't get a valid user_id, show an error
-			$error['general'] = '<div class="error">Failed to create user account. Please try again with a different username.</div>';
 		}
 	}
 

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -7,9 +7,9 @@ if (!isset($db) || !($db instanceof mysqli)) {
 	_die('Database connection unavailable.');
 }
 
-// Detect XHR/AJAX submissions so we can answer with JSON instead of a full page.
-$isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH'])
-	&& strtolower((string) $_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+// connect.php already computes this with identical logic; reuse it so AJAX
+// detection stays consistent with the rest of the app. We answer AJAX with JSON.
+$isAjax = $_is_ajax ?? false;
 
 // Non-critical issues collected during install. They're surfaced as a gentle note
 // on the success screen instead of blocking the install — all are safe to fix later.
@@ -63,7 +63,7 @@ function render_install_success(array $html, array $warnings): void
 		</div>
 		<div class="row" style="margin-bottom: 10px;">
 			<div class="col-xs-3"><span class="label label-default">Login address:</span></div>
-			<div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', $base, $_SERVER['SERVER_NAME'] . $base); ?></small></div>
+			<div class="col-xs-9"><small><?php printf('<a href="%s202-login.php">%s202-login.php</a>', $base, htmlentities((string) ($_SERVER['SERVER_NAME'] ?? ''), ENT_QUOTES, 'UTF-8') . $base); ?></small></div>
 		</div>
 		<?php if ($warnings) { ?>
 			<div style="margin: 12px 0; padding: 8px 12px; border: 1px solid #faebcc; background: #fcf8e3; color: #8a6d3b; border-radius: 4px; font-size: 12px;">
@@ -192,7 +192,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		$prepare = static function (string $sql) use ($db): \mysqli_stmt {
 			$stmt = $db->prepare($sql);
 			if ($stmt === false) {
-				throw new \RuntimeException('Failed to prepare statement: ' . $db->error);
+				throw new \RuntimeException('Failed to prepare statement: ' . $db->error, (int) $db->errno);
 			}
 			return $stmt;
 		};
@@ -225,8 +225,12 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$user_api
 			);
 			if (!$stmt->execute()) {
+				// Capture the real driver errno (STRICT-only report mode means
+				// execute() returns false instead of throwing) so the catch below
+				// can tell a transient failure from a permanent one.
+				$errno = (int) $stmt->errno;
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert user: ' . $db->error);
+				throw new \RuntimeException('Failed to insert user: ' . $db->error, $errno);
 			}
 			$user_id = (int) $db->insert_id;
 			$stmt->close();
@@ -237,8 +241,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$stmt = $prepare("SELECT user_id FROM 202_users WHERE user_name=? LIMIT 1");
 				$stmt->bind_param('s', $user_name);
 				if (!$stmt->execute()) {
+					$errno = (int) $stmt->errno;
 					$stmt->close();
-					throw new \RuntimeException('Failed to look up user: ' . $db->error);
+					throw new \RuntimeException('Failed to look up user: ' . $db->error, $errno);
 				}
 				$lookup = $stmt->get_result();
 				if ($lookup && $row = $lookup->fetch_assoc()) {
@@ -254,16 +259,18 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$stmt = $prepare("INSERT IGNORE INTO 202_users_pref SET user_id=?");
 			$stmt->bind_param('i', $user_id);
 			if (!$stmt->execute()) {
+				$errno = (int) $stmt->errno;
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert user preferences: ' . $db->error);
+				throw new \RuntimeException('Failed to insert user preferences: ' . $db->error, $errno);
 			}
 			$stmt->close();
 
 			$stmt = $prepare("INSERT IGNORE INTO `202_user_role` (`user_id`, `role_id`) VALUES (?, 1)");
 			$stmt->bind_param('i', $user_id);
 			if (!$stmt->execute()) {
+				$errno = (int) $stmt->errno;
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert user role: ' . $db->error);
+				throw new \RuntimeException('Failed to insert user role: ' . $db->error, $errno);
 			}
 			$stmt->close();
 

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -156,7 +156,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			// before we open our transaction.
 			$installer->install_databases();
 
-			$db->begin_transaction();
+			if (!$db->begin_transaction()) {
+				throw new \RuntimeException('Failed to start transaction: ' . $db->error, (int) $db->errno);
+			}
 			$inTransaction = true;
 
 			$stmt = $prepare(
@@ -180,8 +182,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				// execute() returns false instead of throwing) so the catch below
 				// can tell a transient failure from a permanent one.
 				$errno = (int) $stmt->errno;
+				$stmtError = $stmt->error;
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert user: ' . $db->error, $errno);
+				throw new \RuntimeException('Failed to insert user: ' . $stmtError, $errno);
 			}
 			$user_id = (int) $db->insert_id;
 			$stmt->close();
@@ -193,8 +196,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$stmt->bind_param('s', $user_name);
 				if (!$stmt->execute()) {
 					$errno = (int) $stmt->errno;
+					$stmtError = $stmt->error;
 					$stmt->close();
-					throw new \RuntimeException('Failed to look up user: ' . $db->error, $errno);
+					throw new \RuntimeException('Failed to look up user: ' . $stmtError, $errno);
 				}
 				$lookup = $stmt->get_result();
 				if ($lookup && $row = $lookup->fetch_assoc()) {
@@ -211,8 +215,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$stmt->bind_param('i', $user_id);
 			if (!$stmt->execute()) {
 				$errno = (int) $stmt->errno;
+				$stmtError = $stmt->error;
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert user preferences: ' . $db->error, $errno);
+				throw new \RuntimeException('Failed to insert user preferences: ' . $stmtError, $errno);
 			}
 			$stmt->close();
 
@@ -220,12 +225,15 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$stmt->bind_param('i', $user_id);
 			if (!$stmt->execute()) {
 				$errno = (int) $stmt->errno;
+				$stmtError = $stmt->error;
 				$stmt->close();
-				throw new \RuntimeException('Failed to insert user role: ' . $db->error, $errno);
+				throw new \RuntimeException('Failed to insert user role: ' . $stmtError, $errno);
 			}
 			$stmt->close();
 
-			$db->commit();
+			if (!$db->commit()) {
+				throw new \RuntimeException('Failed to commit transaction: ' . $db->error, (int) $db->errno);
+			}
 			$inTransaction = false;
 		} catch (\Throwable $e) {
 			if ($inTransaction) {
@@ -259,8 +267,10 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 					$stmt = $prepare("UPDATE 202_users_pref SET auto_cron = '1' WHERE user_id = ?");
 					$stmt->bind_param('i', $user_id);
 					if (!$stmt->execute()) {
+						$errno = (int) $stmt->errno;
+						$stmtError = $stmt->error;
 						$stmt->close();
-						throw new \RuntimeException('auto_cron flag update failed: ' . $db->error);
+						throw new \RuntimeException('auto_cron flag update failed (' . $errno . '): ' . $stmtError);
 					}
 					$stmt->close();
 				}

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -18,6 +18,15 @@ $install_warnings = [];
 // Whether the last account-creation failure looks transient and worth a retry.
 $retryable = false;
 
+// Single source of truth for the field rules, shared by the server-side checks
+// below and the client-side JS (injected via json_encode) so the two can't drift.
+$rules = [
+	'username_min' => 4,
+	'username_max' => 20,
+	'password_min' => 6,
+	'password_max' => 35,
+];
+
 /**
  * Emit a JSON response for the AJAX install flow and stop. Any buffered output is
  * discarded first so the body is always valid JSON. A json_encode() failure is
@@ -126,20 +135,42 @@ if (is_installed() == true) {
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
+	// CSRF: the form embeds the app-wide session token (set in connect.php and
+	// persisted across AJAX via withWritableSession). Reject any POST whose token
+	// doesn't match the session before doing any work.
+	$expected_token = (string) ($_SESSION['token'] ?? '');
+	$csrf_ok = $expected_token !== '' && hash_equals($expected_token, (string) ($_POST['token'] ?? ''));
+
+	if (!$csrf_ok) {
+		$error['general'] = '<div class="error">Your session has expired or the security check failed. Please refresh the page and submit again.</div>';
+		if ($isAjax) {
+			install_json([
+				'success'   => false,
+				'retryable' => false,
+				'errors'    => ['general' => $error['general']],
+			]);
+		}
+	}
+
+	// Raw POST reads are null-coalesced so a malformed request (missing fields)
+	// produces validation errors, not "undefined array key" warnings.
+	$in_email = (string) ($_POST['user_email'] ?? '');
+	$in_name  = (string) ($_POST['user_name'] ?? '');
+
 	//check email
-	if (check_email_address($_POST['user_email']) == false) {
+	if (check_email_address($in_email) == false) {
 		$error['user_email'] = '<div class="error">Please enter a valid email address</div>';
 	}
 
 	//check username
-	if ($_POST['user_name'] == '') {
+	if ($in_name === '') {
 		$error['user_name'] = '<div class="error">You must type in your desired username</div>';
 	}
-	if (!ctype_alnum((string) $_POST['user_name'])) {
+	if (!ctype_alnum($in_name)) {
 		$error['user_name'] .= '<div class="error">Your username may only contain alphanumeric characters</div>';
 	}
-	if ((strlen((string) $_POST['user_name']) < 4) or (strlen((string) $_POST['user_name']) > 20)) {
-		$error['user_name'] .= '<div class="error">Your username must be between 4 and 20 characters long</div>';
+	if ((strlen($in_name) < $rules['username_min']) or (strlen($in_name) > $rules['username_max'])) {
+		$error['user_name'] .= '<div class="error">Your username must be between ' . $rules['username_min'] . ' and ' . $rules['username_max'] . ' characters long</div>';
 	}
 
 	// Check if password field is empty
@@ -155,10 +186,10 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		// Check password length only if password was provided
 		if (isset($_POST['user_pass']) && !empty($_POST['user_pass'])) {
 			$pass_length = strlen((string) $_POST['user_pass']);
-			if ($pass_length < 6) {
-				$error['user_pass'] .= '<div class="error">Your password must be at least 6 characters long</div>';
-			} elseif ($pass_length > 35) {
-				$error['user_pass'] .= '<div class="error">Your password must be no more than 35 characters long</div>';
+			if ($pass_length < $rules['password_min']) {
+				$error['user_pass'] .= '<div class="error">Your password must be at least ' . $rules['password_min'] . ' characters long</div>';
+			} elseif ($pass_length > $rules['password_max']) {
+				$error['user_pass'] .= '<div class="error">Your password must be no more than ' . $rules['password_max'] . ' characters long</div>';
 			}
 		}
 
@@ -167,8 +198,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$error['user_pass'] .= '<div class="error">Your passwords did not match, please try again</div>';
 		}
 
-	//if no error occurred, let's create the user account
-	if (empty($error['user_email']) && empty($error['user_name']) && empty($error['user_pass'])) {
+	//if the CSRF check passed and no validation error occurred, create the account
+	if ($csrf_ok && empty($error['user_email']) && empty($error['user_name']) && empty($error['user_pass'])) {
 
 		//no error, so now set up the mysql database structures and the account
 		$installer = new INSTALL();
@@ -440,6 +471,7 @@ if (!$success) {
 		<div id="install-general-error"><?php echo $error['general'] ?? ''; ?></div>
 		<form method="post" action="" class="form-horizontal" role="form" id="install-prosper202">
 
+			<input type="hidden" name="token" value="<?php echo htmlentities((string) ($_SESSION['token'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
 			<input type="hidden" class="form-control input-sm" id="user_api" name="user_api" value="<?php echo $html['user_api']; ?>">
 
 			<div class="form-group <?php if ($error['user_email']) echo "has-error"; ?>">
@@ -537,6 +569,8 @@ if (!$success) {
 			<script type="text/javascript">
 			(function () {
 				var BASE = <?php echo json_encode(get_absolute_url()); ?>;
+				// Field rules come from the server ($rules) so client and server can't drift.
+				var RULES = <?php echo json_encode($rules); ?>;
 				var MAX_ATTEMPTS = 3; // 1 try + 2 auto-retries on transient/network failures
 				var form = document.getElementById('install-prosper202');
 				if (!form) { return; }
@@ -545,6 +579,12 @@ if (!$success) {
 				function setHtml(id, html) {
 					var el = document.getElementById(id);
 					if (el) { el.innerHTML = html || ''; }
+				}
+				// Neutral (non-error) status shown in the general-error slot while a retry is pending.
+				function showRetrying(nextAttempt) {
+					setHtml('install-general-error', '<div style="margin-top:5px;padding:5px 10px;border-radius:4px;'
+						+ 'font-size:12px;color:#31708f;background-color:#d9edf7;border:1px solid #bce8f1;">'
+						+ 'Connection issue — retrying… (attempt ' + nextAttempt + ' of ' + MAX_ATTEMPTS + ')</div>');
 				}
 				function markGroup(name, on) {
 					var input = form.querySelector('[name="' + name + '"]');
@@ -574,7 +614,10 @@ if (!$success) {
 					var name = form.user_name.value || '';
 					var pass = form.user_pass.value || '';
 					var verify = form.verify_user_pass.value || '';
-					if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+					// Permissive subset of the server's filter_var check: reject only input
+					// that's obviously not an address, so we never block a value the server
+					// would accept. The server stays the authoritative validator.
+					if (!/^[^\s@]+@[^\s@]+$/.test(email)) {
 						errors.user_email = 'Please enter a valid email address';
 					}
 					var nameErr = '';
@@ -582,14 +625,14 @@ if (!$success) {
 						nameErr += 'You must type in your desired username. ';
 					} else {
 						if (!/^[a-zA-Z0-9]+$/.test(name)) { nameErr += 'Your username may only contain alphanumeric characters. '; }
-						if (name.length < 4 || name.length > 20) { nameErr += 'Your username must be between 4 and 20 characters long. '; }
+						if (name.length < RULES.username_min || name.length > RULES.username_max) { nameErr += 'Your username must be between ' + RULES.username_min + ' and ' + RULES.username_max + ' characters long. '; }
 					}
 					if (nameErr) { errors.user_name = nameErr.trim(); }
 					var passErr = '';
 					if (!pass) { passErr += 'You must type in your desired password. '; }
 					if (!verify) { passErr += 'You must verify your password. '; }
-					if (pass && pass.length < 6) { passErr += 'Your password must be at least 6 characters long. '; }
-					if (pass && pass.length > 35) { passErr += 'Your password must be no more than 35 characters long. '; }
+					if (pass && pass.length < RULES.password_min) { passErr += 'Your password must be at least ' + RULES.password_min + ' characters long. '; }
+					if (pass && pass.length > RULES.password_max) { passErr += 'Your password must be no more than ' + RULES.password_max + ' characters long. '; }
 					if (pass && verify && pass !== verify) { passErr += 'Your passwords did not match, please try again. '; }
 					if (passErr) { errors.user_pass = passErr.trim(); }
 					return errors;
@@ -627,6 +670,7 @@ if (!$success) {
 							return;
 						}
 						if (res.retryable && n < MAX_ATTEMPTS) {
+							showRetrying(n + 1);
 							setTimeout(function () { attempt(n + 1); }, Math.pow(2, n) * 1000);
 							return;
 						}
@@ -636,6 +680,7 @@ if (!$success) {
 					}).catch(function () {
 						// Network failure or a non-JSON response (e.g. a server error page).
 						if (n < MAX_ATTEMPTS) {
+							showRetrying(n + 1);
 							setTimeout(function () { attempt(n + 1); }, Math.pow(2, n) * 1000);
 							return;
 						}

--- a/202-config/install.php
+++ b/202-config/install.php
@@ -231,6 +231,22 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			}
 			$stmt->close();
 
+			// Default dashboard chart for the new account, keyed on the committed
+			// $user_id. A rolled-back retry consumes the AUTO_INCREMENT id, so the
+			// account isn't necessarily user 1; account_overview.php joins charts on
+			// the user's own id, so a hard-coded id would leave the account chartless.
+			$chart_data = 'a:3:{i:0;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:6:"clicks";}i:1;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:9:"click_out";}i:2;a:2:{s:11:"campaign_id";s:1:"0";s:10:"value_type";s:5:"leads";}}';
+			$chart_range = 'days';
+			$stmt = $prepare("INSERT INTO `202_charts` (`user_id`, `data`, `chart_time_range`) VALUES (?, ?, ?)");
+			$stmt->bind_param('iss', $user_id, $chart_data, $chart_range);
+			if (!$stmt->execute()) {
+				$errno = (int) $stmt->errno;
+				$stmtError = $stmt->error;
+				$stmt->close();
+				throw new \RuntimeException('Failed to insert default chart: ' . $stmtError, $errno);
+			}
+			$stmt->close();
+
 			if (!$db->commit()) {
 				throw new \RuntimeException('Failed to commit transaction: ' . $db->error, (int) $db->errno);
 			}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,9 @@ When building `bind_param($types, ...)` with many parameters, count types agains
 - Read the file first, then think about what each line does, especially error paths.
 - After writing code, re-read it as a skeptic looking for the failure mode, not as the author expecting it to work.
 - When fixing a pattern (e.g., unchecked execute), grep the entire codebase for every instance — don't fix one and assume the rest are fine.
+
+## Before committing
+- Always perform a full deploy-quality code review of the staged changes before committing. Treat every commit as if it ships to production.
+- Walk each changed file individually (per the Review discipline above), tracing error paths and the failure modes in the "Error patterns to avoid" list.
+- Confirm the code lints/compiles and that any relevant tests pass. If tests or static analysis can't be run in the environment, say so explicitly rather than implying they passed.
+- Only commit once the review is clean; if it surfaces issues, fix them and re-review before committing.

--- a/tests/Install/InstallHelpersTest.php
+++ b/tests/Install/InstallHelpersTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Install;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the installer's pure helpers: field rules, CSRF token check,
+ * and account validation.
+ *
+ * @covers ::install_default_rules
+ * @covers ::install_csrf_ok
+ * @covers ::install_validate_account
+ */
+final class InstallHelpersTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../../202-config/functions-install-helpers.php';
+    }
+
+    /** @return array{username_min:int,username_max:int,password_min:int,password_max:int} */
+    private function rules(): array
+    {
+        return install_default_rules();
+    }
+
+    /** A fully valid submission, overridable per field. */
+    private function validPost(array $overrides = []): array
+    {
+        return array_merge([
+            'user_email'       => 'owner@example.com',
+            'user_name'        => 'admin1',
+            'user_pass'        => 'secret9',
+            'verify_user_pass' => 'secret9',
+        ], $overrides);
+    }
+
+    public function testDefaultRulesAreStable(): void
+    {
+        $this->assertSame(
+            ['username_min' => 4, 'username_max' => 20, 'password_min' => 6, 'password_max' => 35],
+            install_default_rules()
+        );
+    }
+
+    public function testCsrfRejectsEmptyExpectedToken(): void
+    {
+        $this->assertFalse(install_csrf_ok('', ''));
+        $this->assertFalse(install_csrf_ok('', 'anything'));
+    }
+
+    public function testCsrfRejectsMismatchAndEmptySubmission(): void
+    {
+        $this->assertFalse(install_csrf_ok('expected-token', 'wrong-token'));
+        $this->assertFalse(install_csrf_ok('expected-token', ''));
+    }
+
+    public function testCsrfAcceptsExactMatch(): void
+    {
+        $this->assertTrue(install_csrf_ok('a-real-token', 'a-real-token'));
+    }
+
+    public function testValidSubmissionHasNoErrors(): void
+    {
+        $errors = install_validate_account($this->validPost(), $this->rules());
+
+        $this->assertSame(
+            ['user_email' => '', 'user_name' => '', 'user_pass' => ''],
+            $errors
+        );
+    }
+
+    public function testInvalidEmailIsRejected(): void
+    {
+        $errors = install_validate_account($this->validPost(['user_email' => 'not-an-email']), $this->rules());
+
+        $this->assertStringContainsString('valid email address', $errors['user_email']);
+        $this->assertSame('', $errors['user_name']);
+        $this->assertSame('', $errors['user_pass']);
+    }
+
+    public function testMissingEmailKeyIsRejectedWithoutWarning(): void
+    {
+        $post = $this->validPost();
+        unset($post['user_email']);
+
+        $errors = install_validate_account($post, $this->rules());
+
+        $this->assertStringContainsString('valid email address', $errors['user_email']);
+    }
+
+    public function testEmptyUsernameIsRejected(): void
+    {
+        $errors = install_validate_account($this->validPost(['user_name' => '']), $this->rules());
+
+        $this->assertStringContainsString('type in your desired username', $errors['user_name']);
+    }
+
+    public function testNonAlphanumericUsernameIsRejected(): void
+    {
+        $errors = install_validate_account($this->validPost(['user_name' => 'bad name!']), $this->rules());
+
+        $this->assertStringContainsString('alphanumeric', $errors['user_name']);
+    }
+
+    public function testTooShortUsernameIsRejected(): void
+    {
+        $errors = install_validate_account($this->validPost(['user_name' => 'ab']), $this->rules());
+
+        $this->assertStringContainsString('between 4 and 20', $errors['user_name']);
+    }
+
+    public function testTooLongUsernameIsRejected(): void
+    {
+        $errors = install_validate_account($this->validPost(['user_name' => str_repeat('a', 21)]), $this->rules());
+
+        $this->assertStringContainsString('between 4 and 20', $errors['user_name']);
+    }
+
+    public function testMissingPasswordIsRejected(): void
+    {
+        $post = $this->validPost();
+        unset($post['user_pass'], $post['verify_user_pass']);
+
+        $errors = install_validate_account($post, $this->rules());
+
+        $this->assertStringContainsString('type in your desired password', $errors['user_pass']);
+        $this->assertStringContainsString('verify your password', $errors['user_pass']);
+    }
+
+    public function testTooShortPasswordIsRejected(): void
+    {
+        $errors = install_validate_account(
+            $this->validPost(['user_pass' => 'ab1', 'verify_user_pass' => 'ab1']),
+            $this->rules()
+        );
+
+        $this->assertStringContainsString('at least 6 characters', $errors['user_pass']);
+    }
+
+    public function testTooLongPasswordIsRejected(): void
+    {
+        $long = str_repeat('x', 36);
+        $errors = install_validate_account(
+            $this->validPost(['user_pass' => $long, 'verify_user_pass' => $long]),
+            $this->rules()
+        );
+
+        $this->assertStringContainsString('no more than 35 characters', $errors['user_pass']);
+    }
+
+    public function testMismatchedPasswordsAreRejected(): void
+    {
+        $errors = install_validate_account(
+            $this->validPost(['user_pass' => 'secret9', 'verify_user_pass' => 'secret8']),
+            $this->rules()
+        );
+
+        $this->assertStringContainsString('did not match', $errors['user_pass']);
+    }
+
+    public function testRuleBoundsAreHonored(): void
+    {
+        // With a relaxed min, a 2-char username that fails the default passes here.
+        $relaxed = ['username_min' => 2, 'username_max' => 20, 'password_min' => 6, 'password_max' => 35];
+
+        $errors = install_validate_account($this->validPost(['user_name' => 'ab']), $relaxed);
+
+        $this->assertSame('', $errors['user_name']);
+    }
+}

--- a/tests/Install/InstallHelpersTest.php
+++ b/tests/Install/InstallHelpersTest.php
@@ -8,11 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the installer's pure helpers: field rules, CSRF token check,
- * and account validation.
+ * account validation, JSON encoding, base-URL building, and success rendering.
  *
  * @covers ::install_default_rules
  * @covers ::install_csrf_ok
  * @covers ::install_validate_account
+ * @covers ::install_encode_response
+ * @covers ::install_request_base_url
+ * @covers ::render_install_success
  */
 final class InstallHelpersTest extends TestCase
 {

--- a/tests/Install/InstallHelpersTest.php
+++ b/tests/Install/InstallHelpersTest.php
@@ -171,4 +171,73 @@ final class InstallHelpersTest extends TestCase
 
         $this->assertSame('', $errors['user_name']);
     }
+
+    public function testEncodeResponseRoundTripsValidPayload(): void
+    {
+        $payload = ['success' => true, 'warnings' => ['a'], 'errors' => ['general' => '<div>x</div>']];
+
+        $encoded = install_encode_response($payload);
+
+        $this->assertTrue($encoded['ok']);
+        $this->assertSame($payload, json_decode($encoded['body'], true));
+    }
+
+    public function testEncodeResponseFallsBackOnUnencodablePayload(): void
+    {
+        // Malformed UTF-8 makes json_encode() return false.
+        $encoded = install_encode_response(['errors' => ['general' => "\xB1\x31"]]);
+
+        $this->assertFalse($encoded['ok']);
+        $decoded = json_decode($encoded['body'], true);
+        $this->assertIsArray($decoded);
+        $this->assertFalse($decoded['success']);
+        $this->assertTrue($decoded['retryable']);
+        $this->assertStringContainsString('unexpected error', $decoded['errors']['general']);
+    }
+
+    /** Capture the success panel HTML. */
+    private function renderSuccess(array $html, array $warnings, string $base, string $serverName): string
+    {
+        ob_start();
+        render_install_success($html, $warnings, $base, $serverName);
+        return (string) ob_get_clean();
+    }
+
+    public function testSuccessPanelRendersAccountAndLoginLink(): void
+    {
+        $out = $this->renderSuccess(['user_name' => 'admin1'], [], 'https://host.test/', 'host.test');
+
+        $this->assertStringContainsString('Success!', $out);
+        $this->assertStringContainsString('admin1', $out);
+        $this->assertStringContainsString('https://host.test/202-login.php', $out);
+        // No warnings block when there are no warnings.
+        $this->assertStringNotContainsString('need a quick follow-up', $out);
+    }
+
+    public function testSuccessPanelRendersWarnings(): void
+    {
+        $out = $this->renderSuccess(
+            ['user_name' => 'admin1'],
+            ['Cron setup did not complete.'],
+            'https://host.test/',
+            'host.test'
+        );
+
+        $this->assertStringContainsString('need a quick follow-up', $out);
+        $this->assertStringContainsString('Cron setup did not complete.', $out);
+    }
+
+    public function testSuccessPanelEscapesServerName(): void
+    {
+        $out = $this->renderSuccess(
+            ['user_name' => 'admin1'],
+            [],
+            'https://host.test/',
+            '"><img src=x onerror=alert(1)>'
+        );
+
+        // The injected markup must be escaped, never reflected raw.
+        $this->assertStringNotContainsString('<img src=x', $out);
+        $this->assertStringContainsString('&lt;img', $out);
+    }
 }

--- a/tests/Upgrade/UpgradeQueryIntegrationTest.php
+++ b/tests/Upgrade/UpgradeQueryIntegrationTest.php
@@ -62,6 +62,11 @@ final class UpgradeQueryIntegrationTest extends TestCase
         if (self::$lock instanceof \mysqli && !self::$lock->connect_errno) {
             self::$lock->close();
         }
+
+        // Restore the default mysqli reporting we turned off in setUpBeforeClass so
+        // later tests in the same process aren't affected (e.g. mysqli_sql_exception
+        // failures staying hidden).
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
     }
 
     private function noopSleeper(): callable

--- a/tests/Upgrade/UpgradeQueryIntegrationTest.php
+++ b/tests/Upgrade/UpgradeQueryIntegrationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Upgrade;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Integration coverage for the upgrade query runner against a real MySQL: proves
+ * that a genuine lock-wait timeout (errno 1205) is retried and succeeds once the
+ * lock clears, and that real success / permanent-error paths behave as documented.
+ *
+ * Tagged @group integration so it is excluded from the default/CI run
+ * (phpunit.xml excludes that group). It self-skips unless a DB is reachable. Run:
+ *   P202_TEST_DB_NAME=test vendor/bin/phpunit --group integration tests/Upgrade/UpgradeQueryIntegrationTest.php
+ *
+ * @group integration
+ */
+final class UpgradeQueryIntegrationTest extends TestCase
+{
+    private static ?\mysqli $main = null;
+    private static ?\mysqli $lock = null;
+    private static string $table = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../../202-config/functions-upgrade.php';
+
+        $name = getenv('P202_TEST_DB_NAME') ?: '';
+        if ($name === '') {
+            self::markTestSkipped('Set P202_TEST_DB_NAME (and _HOST/_USER/_PASS) to run the upgrade integration test.');
+        }
+
+        $host = getenv('P202_TEST_DB_HOST') ?: '127.0.0.1';
+        $user = getenv('P202_TEST_DB_USER') ?: 'root';
+        $pass = getenv('P202_TEST_DB_PASS') ?: '';
+
+        // Don't let the driver throw on connect; we want a clean skip instead.
+        mysqli_report(MYSQLI_REPORT_OFF);
+
+        self::$main = @new \mysqli($host, $user, $pass, $name);
+        self::$lock = @new \mysqli($host, $user, $pass, $name);
+        if (self::$main->connect_errno || self::$lock->connect_errno) {
+            self::markTestSkipped('Could not connect to the test database.');
+        }
+
+        self::$table = 'p202_upgrade_it_' . substr(md5((string) mt_rand()), 0, 8);
+        self::$main->query(
+            'CREATE TABLE `' . self::$table . '` (id INT PRIMARY KEY, val INT NOT NULL) ENGINE=InnoDB'
+        );
+        self::$main->query('INSERT INTO `' . self::$table . '` (id, val) VALUES (1, 0)');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$main instanceof \mysqli && !self::$main->connect_errno) {
+            self::$main->query('DROP TABLE IF EXISTS `' . self::$table . '`');
+            self::$main->close();
+        }
+        if (self::$lock instanceof \mysqli && !self::$lock->connect_errno) {
+            self::$lock->close();
+        }
+    }
+
+    private function noopSleeper(): callable
+    {
+        return static function (int $seconds): void {
+            // No real backoff sleep in tests.
+        };
+    }
+
+    private function aborter(): callable
+    {
+        return static function (int $errno, string $error): void {
+            throw new RuntimeException('aborted:' . $errno);
+        };
+    }
+
+    public function testRealSuccessReturnsResult(): void
+    {
+        $result = _upgrade_query_run(
+            self::$main,
+            'SELECT val FROM `' . self::$table . '` WHERE id = 1',
+            $this->noopSleeper(),
+            $this->aborter()
+        );
+
+        $this->assertInstanceOf(\mysqli_result::class, $result);
+        $this->assertSame(0, (int) $result->fetch_row()[0]);
+    }
+
+    public function testRealPermanentErrorReturnsFalse(): void
+    {
+        $result = _upgrade_query_run(
+            self::$main,
+            'THIS IS NOT VALID SQL',
+            $this->noopSleeper(),
+            $this->aborter()
+        );
+
+        $this->assertFalse($result);
+    }
+
+    public function testRealLockWaitIsRetriedThenSucceeds(): void
+    {
+        // Hold a row lock on a second connection.
+        self::$lock->begin_transaction();
+        $held = self::$lock->query('SELECT val FROM `' . self::$table . '` WHERE id = 1 FOR UPDATE');
+        $this->assertInstanceOf(\mysqli_result::class, $held);
+
+        // Make the main connection give up waiting for the lock almost immediately,
+        // so the first UPDATE fails with errno 1205.
+        self::$main->query('SET SESSION innodb_lock_wait_timeout = 1');
+
+        // The injected sleeper releases the lock the first time the runner backs off,
+        // so the retried UPDATE succeeds — exercising the real transient-retry path.
+        $released = false;
+        $sleeper = function (int $seconds) use (&$released): void {
+            if (!$released) {
+                self::$lock->commit();
+                $released = true;
+            }
+        };
+
+        $result = _upgrade_query_run(
+            self::$main,
+            'UPDATE `' . self::$table . '` SET val = val + 1 WHERE id = 1',
+            $sleeper,
+            $this->aborter()
+        );
+
+        $this->assertTrue($result, 'the retried UPDATE should succeed once the lock clears');
+        $this->assertTrue($released, 'the runner should have backed off (and released the lock) once');
+
+        $check = self::$main->query('SELECT val FROM `' . self::$table . '` WHERE id = 1');
+        $this->assertSame(1, (int) $check->fetch_row()[0]);
+    }
+}

--- a/tests/Upgrade/UpgradeQueryIntegrationTest.php
+++ b/tests/Upgrade/UpgradeQueryIntegrationTest.php
@@ -37,11 +37,17 @@ final class UpgradeQueryIntegrationTest extends TestCase
         $user = getenv('P202_TEST_DB_USER') ?: 'root';
         $pass = getenv('P202_TEST_DB_PASS') ?: '';
 
-        // Don't let the driver throw on connect; we want a clean skip instead.
+        // Don't let the driver throw on the connection probe; we want a clean skip.
         mysqli_report(MYSQLI_REPORT_OFF);
 
         self::$main = @new \mysqli($host, $user, $pass, $name);
         self::$lock = @new \mysqli($host, $user, $pass, $name);
+
+        // Restore the codebase default (connect.php uses MYSQLI_REPORT_STRICT) right
+        // after the probe so the OFF state can't leak into the rest of the process —
+        // including down the markTestSkipped() path below, which bypasses tearDown.
+        mysqli_report(MYSQLI_REPORT_STRICT);
+
         if (self::$main->connect_errno || self::$lock->connect_errno) {
             self::markTestSkipped('Could not connect to the test database.');
         }
@@ -63,10 +69,10 @@ final class UpgradeQueryIntegrationTest extends TestCase
             self::$lock->close();
         }
 
-        // Restore the default mysqli reporting we turned off in setUpBeforeClass so
-        // later tests in the same process aren't affected (e.g. mysqli_sql_exception
-        // failures staying hidden).
-        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+        // Defensive: also restore the codebase default (MYSQLI_REPORT_STRICT, as
+        // set in connect.php) here. setUpBeforeClass already restores it after the
+        // connection probe, so this only matters if a later change moves that.
+        mysqli_report(MYSQLI_REPORT_STRICT);
     }
 
     private function noopSleeper(): callable

--- a/tests/Upgrade/UpgradeQueryIntegrationTest.php
+++ b/tests/Upgrade/UpgradeQueryIntegrationTest.php
@@ -114,6 +114,16 @@ final class UpgradeQueryIntegrationTest extends TestCase
         // so the first UPDATE fails with errno 1205.
         self::$main->query('SET SESSION innodb_lock_wait_timeout = 1');
 
+        // If the server ignored/clamped that (some managed builds enforce a floor),
+        // the UPDATE below would block for the server default instead of failing
+        // fast — and since the lock is only released inside the sleeper (which runs
+        // only after a 1205), the test would hang. Bail cleanly instead.
+        $timeoutRow = self::$main->query('SELECT @@innodb_lock_wait_timeout AS t')->fetch_assoc();
+        if ((int) $timeoutRow['t'] > 2) {
+            self::$lock->commit(); // release the held lock before skipping
+            $this->markTestSkipped('Server did not honor a low innodb_lock_wait_timeout; skipping to avoid a long block.');
+        }
+
         // The injected sleeper releases the lock the first time the runner backs off,
         // so the retried UPDATE succeeds — exercising the real transient-retry path.
         $released = false;

--- a/tests/Upgrade/UpgradeQueryTest.php
+++ b/tests/Upgrade/UpgradeQueryTest.php
@@ -189,7 +189,7 @@ final class FakeUpgradeConnection
         $outcome = $this->outcomes[$this->queryCount] ?? 0;
         $this->queryCount++;
 
-        if (is_callable($outcome)) {
+        if ($outcome instanceof \Closure) {
             return $outcome();
         }
         if (is_int($outcome)) {

--- a/tests/Upgrade/UpgradeQueryTest.php
+++ b/tests/Upgrade/UpgradeQueryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Upgrade;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Unit tests for _upgrade_query_run() — the resilient query core used by the
+ * live-upgrade path. Exercises the retry/backoff and transient-vs-permanent
+ * classification with a fake connection, no real DB, no real sleeps, and no _die().
+ *
+ * @covers ::_upgrade_query_run
+ */
+final class UpgradeQueryTest extends TestCase
+{
+    /** @var list<int> backoff seconds recorded from the injected sleeper */
+    private array $sleeps = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../../202-config/functions-upgrade.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->sleeps = [];
+    }
+
+    /** Sleeper that records the backoff instead of sleeping. */
+    private function sleeper(): callable
+    {
+        return function (int $seconds): void {
+            $this->sleeps[] = $seconds;
+        };
+    }
+
+    /** onExhausted that throws so the abort is assertable (production _die()s here). */
+    private function aborter(): callable
+    {
+        return function (int $errno, string $error): void {
+            throw new RuntimeException('aborted:' . $errno);
+        };
+    }
+
+    public function testSucceedsOnFirstTryWithoutSleeping(): void
+    {
+        $conn = new FakeUpgradeConnection([true]);
+
+        $result = _upgrade_query_run($conn, 'SELECT 1', $this->sleeper(), $this->aborter());
+
+        $this->assertTrue($result);
+        $this->assertSame(1, $conn->queryCount);
+        $this->assertSame([], $this->sleeps);
+    }
+
+    public function testReturnsTheUnderlyingResultObject(): void
+    {
+        $sentinel = (object) ['rows' => 3];
+        $conn = new FakeUpgradeConnection([$sentinel]);
+
+        $result = _upgrade_query_run($conn, 'SELECT 1', $this->sleeper(), $this->aborter());
+
+        $this->assertSame($sentinel, $result);
+    }
+
+    public function testRetriesLockWaitThenSucceeds(): void
+    {
+        $conn = new FakeUpgradeConnection([1205, true]);
+
+        $result = _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $this->aborter());
+
+        $this->assertTrue($result);
+        $this->assertSame(2, $conn->queryCount);
+        $this->assertSame([1], $this->sleeps);
+    }
+
+    public function testRetriesDeadlockThenSucceeds(): void
+    {
+        $conn = new FakeUpgradeConnection([1213, true]);
+
+        $result = _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $this->aborter());
+
+        $this->assertTrue($result);
+        $this->assertSame(2, $conn->queryCount);
+        $this->assertSame([1], $this->sleeps);
+    }
+
+    public function testPermanentErrorReturnsFalseWithoutRetry(): void
+    {
+        // 1064 = syntax error: never retried, falls through to legacy false contract.
+        $conn = new FakeUpgradeConnection([1064]);
+
+        $result = _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $this->aborter());
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $conn->queryCount);
+        $this->assertSame([], $this->sleeps);
+    }
+
+    public function testExhaustedTransientAbortsAfterExponentialBackoff(): void
+    {
+        $conn = new FakeUpgradeConnection([1205, 1205, 1205, 1205]);
+
+        try {
+            _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $this->aborter());
+            $this->fail('Expected the exhausted-transient path to invoke onExhausted (which throws here).');
+        } catch (RuntimeException $e) {
+            $this->assertSame('aborted:1205', $e->getMessage());
+        }
+
+        // 4 attempts (default), 3 backoffs in the documented 1s/2s/4s sequence.
+        $this->assertSame(4, $conn->queryCount);
+        $this->assertSame([1, 2, 4], $this->sleeps);
+    }
+
+    public function testHonorsCustomMaxAttempts(): void
+    {
+        $conn = new FakeUpgradeConnection([1205, 1205, 1205, 1205]);
+        $exhaustedErrno = null;
+
+        $onExhausted = function (int $errno, string $error) use (&$exhaustedErrno) {
+            $exhaustedErrno = $errno;
+            return false; // mimic a non-throwing handler; core returns this value
+        };
+
+        $result = _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $onExhausted, 2);
+
+        $this->assertFalse($result);
+        $this->assertSame(1205, $exhaustedErrno);
+        $this->assertSame(2, $conn->queryCount); // 1 attempt + 1 retry
+        $this->assertSame([1], $this->sleeps);
+    }
+
+    public function testTransientMysqliExceptionIsRetried(): void
+    {
+        // MYSQLI_REPORT_ERROR environments throw instead of returning false.
+        $conn = new FakeUpgradeConnection([
+            static fn () => throw new \mysqli_sql_exception('lock wait timeout', 1205),
+            true,
+        ]);
+
+        $result = _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $this->aborter());
+
+        $this->assertTrue($result);
+        $this->assertSame(2, $conn->queryCount);
+        $this->assertSame([1], $this->sleeps);
+    }
+
+    public function testPermanentMysqliExceptionReturnsFalse(): void
+    {
+        $conn = new FakeUpgradeConnection([
+            static fn () => throw new \mysqli_sql_exception('syntax error', 1064),
+        ]);
+
+        $result = _upgrade_query_run($conn, 'ALTER TABLE x', $this->sleeper(), $this->aborter());
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $conn->queryCount);
+        $this->assertSame([], $this->sleeps);
+    }
+}
+
+/**
+ * Minimal stand-in for a mysqli connection: returns a queued sequence of outcomes.
+ * Each outcome is one of:
+ *   - true / object : success (returned as-is)
+ *   - int           : failure with that errno (sets ->errno/->error, returns false)
+ *   - callable      : invoked (may throw \mysqli_sql_exception)
+ */
+final class FakeUpgradeConnection
+{
+    public int $errno = 0;
+    public string $error = '';
+    public int $queryCount = 0;
+
+    /** @var list<mixed> */
+    private array $outcomes;
+
+    public function __construct(array $outcomes)
+    {
+        $this->outcomes = $outcomes;
+    }
+
+    public function query(string $sql)
+    {
+        $outcome = $this->outcomes[$this->queryCount] ?? 0;
+        $this->queryCount++;
+
+        if (is_callable($outcome)) {
+            return $outcome();
+        }
+        if (is_int($outcome)) {
+            $this->errno = $outcome;
+            $this->error = 'errno ' . $outcome;
+            return false;
+        }
+
+        $this->errno = 0;
+        $this->error = '';
+        return $outcome;
+    }
+}


### PR DESCRIPTION
The user-creation path in 202-config/install.php predated the codebase's
own conventions (CLAUDE.md). This brings it in line:

- Wrap the user / users_pref / user_role writes in a single
  begin_transaction/commit/rollback so a mid-way failure can't leave a
  half-built account behind.
- Replace string-concatenated SQL (escaped with real_escape_string) with
  prepared statements and bound parameters, mirroring AUTH::LOGIN_SELECT.
- Check every prepare()/execute() return value and throw on failure
  instead of silently discarding it via the @-suppressed _mysqli_query().
- Drop the dead md5 salt_user_pass() fallback and call hash_user_pass()
  (password_hash/bcrypt) directly; the helper is always loaded.

The non-critical auto_cron flag update is kept best-effort (logged, not
fatal) since the account is already committed by that point.