### PR TITLE
Make conversion recording idempotent and atomic across all ingestion paths

### DIFF
--- a/.github/workflows/php-integration.yml
+++ b/.github/workflows/php-integration.yml
@@ -1,0 +1,87 @@
+name: Run Integration Tests
+
+on:
+  push:
+    paths:
+      - '**.php'
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: prosper202
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          # See php-unit.yml for why the procedural `memcache` extension is disabled.
+          extensions: mysqli, pdo, pdo_mysql, memcached, :memcache, mbstring, curl, zip, dom, xml, gd, zlib
+
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            ~/.cache/composer
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Configure Composer authentication
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${GITHUB_TOKEN}" ]; then
+            composer config -g github-oauth.github.com "${GITHUB_TOKEN}"
+          fi
+
+      - name: Install dependencies
+        env:
+          COMPOSER_ALLOW_SUPERUSER: 1
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Wait for MySQL
+        run: |
+          for i in $(seq 1 30); do
+            if mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -proot --silent; then
+              echo "MySQL is up"; exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          exit 1
+
+      # DB-backed integration tests self-install the schema (SchemaInstaller) and
+      # skip cleanly when P202_TEST_DB_HOST is unset, so this job is the only place
+      # they actually exercise a database.
+      - name: Run conversion integrity integration tests
+        env:
+          P202_TEST_DB_HOST: 127.0.0.1
+          P202_TEST_DB_PORT: 3306
+          P202_TEST_DB_USER: root
+          P202_TEST_DB_PASS: root
+          P202_TEST_DB_NAME: prosper202
+        run: |
+          vendor/bin/phpunit --configuration phpunit.ci.xml \
+            --group integration \
+            tests/Conversion/ConversionIdempotencyIntegrationTest.php \
+            --verbose --no-coverage

--- a/202-config/Conversion/ClickNotFoundException.php
+++ b/202-config/Conversion/ClickNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prosper202\Conversion;
+
+use RuntimeException;
+
+/**
+ * Thrown by the conversion repository when the source click does not exist (or is
+ * not owned by the given user). Extends RuntimeException so existing callers that
+ * catch RuntimeException keep working, while newer callers (e.g. the V3 API) can
+ * catch this specific type to map it to a 404 instead of a 500.
+ */
+final class ClickNotFoundException extends RuntimeException
+{
+}

--- a/202-config/Conversion/MysqlConversionRepository.php
+++ b/202-config/Conversion/MysqlConversionRepository.php
@@ -104,7 +104,11 @@ final class MysqlConversionRepository implements ConversionRepositoryInterface
             $stmt = $this->conn->prepareWrite(
                 'INSERT INTO 202_conversion_logs (click_id, transaction_id, campaign_id, click_payout, user_id, click_time, conv_time, deleted) VALUES (?, ?, ?, ?, ?, ?, ?, 0)'
             );
-            $this->conn->bind($stmt, 'isidiii', [$clickId, $transactionId, $campaignId, $payout, $userId, $clickTime, $convTime]);
+            // Store an absent transaction id as NULL (not '') so the UNIQUE key on
+            // (click_id, transaction_id) still allows a click to convert more than
+            // once when no order id is supplied (multiple NULLs do not collide).
+            $transactionIdForInsert = $transactionId !== '' ? $transactionId : null;
+            $this->conn->bind($stmt, 'isidiii', [$clickId, $transactionIdForInsert, $campaignId, $payout, $userId, $clickTime, $convTime]);
             $convId = $this->conn->executeInsert($stmt);
 
             $stmt = $this->conn->prepareWrite(

--- a/202-config/Conversion/MysqlConversionRepository.php
+++ b/202-config/Conversion/MysqlConversionRepository.php
@@ -77,17 +77,49 @@ final class MysqlConversionRepository implements ConversionRepositoryInterface
 
     public function create(int $userId, array $data): int
     {
-        $clickId = (int) $data['click_id'];
+        $result = $this->record($userId, $data, function (int $clickId, float $payout) use ($userId): void {
+            $this->applyStandardClickUpdate($clickId, $payout, $userId);
+        });
+
+        if (!$result['clickFound']) {
+            throw new ClickNotFoundException('Click not found or not owned by user');
+        }
+
+        return $result['convId'];
+    }
+
+    /**
+     * Single owner of the transactional conversion write used by every ingestion
+     * path (V3 API and the legacy static postback/pixel endpoints).
+     *
+     * In one transaction it: locks the source click (SELECT ... FOR UPDATE) so
+     * concurrent/retried postbacks serialise; de-duplicates on transaction_id
+     * (matching the UNIQUE (click_id, transaction_id) key, which ignores
+     * `deleted`); inserts the conversion_logs row; and runs an optional
+     * caller-supplied click-side update inside the same transaction so the click
+     * flag and the audit row commit or roll back together.
+     *
+     * @param array<string, mixed> $data Requires click_id. Optional:
+     *        transaction_id, payout, conv_time, campaign_id, click_time, and the
+     *        legacy columns time_difference, ip, pixel_type, user_agent (only
+     *        written when present, so the V3 insert keeps its historical shape).
+     * @param (callable(int $clickId, float $payout): void)|null $clickSideUpdate
+     * @return array{convId: int, duplicate: bool, clickFound: bool}
+     */
+    public function record(int $userId, array $data, ?callable $clickSideUpdate = null): array
+    {
+        $clickId = (int) ($data['click_id'] ?? 0);
         if ($clickId <= 0) {
             throw new RuntimeException('click_id is required');
         }
 
-        $transactionId = (string) ($data['transaction_id'] ?? '');
+        $rawTransactionId = (string) ($data['transaction_id'] ?? '');
+        $transactionId = $rawTransactionId !== '' ? $rawTransactionId : null;
         $convTime = (int) ($data['conv_time'] ?? time());
         $payoutOverride = isset($data['payout']) ? (float) $data['payout'] : null;
 
-        return $this->conn->transaction(function () use ($clickId, $transactionId, $payoutOverride, $userId, $convTime): int {
-            // Look up source click inside transaction with FOR UPDATE to prevent TOCTOU race
+        return $this->conn->transaction(function () use ($userId, $clickId, $transactionId, $convTime, $payoutOverride, $data, $clickSideUpdate): array {
+            // Lock the source click so concurrent/retried postbacks serialise here.
             $clickStmt = $this->conn->prepareWrite(
                 'SELECT click_id, aff_campaign_id, click_payout, click_time FROM 202_clicks WHERE click_id = ? AND user_id = ? LIMIT 1 FOR UPDATE'
             );
@@ -95,31 +127,64 @@ final class MysqlConversionRepository implements ConversionRepositoryInterface
             $click = $this->conn->fetchOne($clickStmt);
 
             if ($click === null) {
-                throw new RuntimeException('Click not found or not owned by user');
+                return ['convId' => 0, 'duplicate' => false, 'clickFound' => false];
+            }
+
+            // Idempotency: a transaction_id already recorded for this click is a
+            // replay/retry. The lookup ignores `deleted` so it matches the UNIQUE
+            // (click_id, transaction_id) key and never collides on insert.
+            if ($transactionId !== null) {
+                $dupStmt = $this->conn->prepareWrite(
+                    'SELECT conv_id FROM 202_conversion_logs WHERE click_id = ? AND transaction_id = ? LIMIT 1'
+                );
+                $this->conn->bind($dupStmt, 'is', [$clickId, $transactionId]);
+                $dup = $this->conn->fetchOne($dupStmt);
+                if ($dup !== null) {
+                    return ['convId' => (int) $dup['conv_id'], 'duplicate' => true, 'clickFound' => true];
+                }
             }
 
             $payout = $payoutOverride ?? (float) ($click['click_payout'] ?? 0);
-            $campaignId = (int) $click['aff_campaign_id'];
-            $clickTime = (int) ($click['click_time'] ?? 0);
+            $campaignId = isset($data['campaign_id']) ? (int) $data['campaign_id'] : (int) $click['aff_campaign_id'];
+            $clickTime = isset($data['click_time']) ? (int) $data['click_time'] : (int) ($click['click_time'] ?? 0);
+
+            // Base column set is exactly the historical V3 insert; the legacy
+            // columns are appended only when the caller supplies them.
+            $columns = ['click_id', 'transaction_id', 'campaign_id', 'click_payout', 'user_id', 'click_time', 'conv_time'];
+            $types = 'isidiii';
+            $values = [$clickId, $transactionId, $campaignId, $payout, $userId, $clickTime, $convTime];
+
+            foreach (['time_difference' => 's', 'ip' => 's', 'pixel_type' => 'i', 'user_agent' => 's'] as $col => $type) {
+                if (array_key_exists($col, $data)) {
+                    $columns[] = $col;
+                    $types .= $type;
+                    $values[] = $type === 'i' ? (int) $data[$col] : (string) $data[$col];
+                }
+            }
+
+            $placeholders = rtrim(str_repeat('?, ', count($values)), ', ');
             $stmt = $this->conn->prepareWrite(
-                'INSERT INTO 202_conversion_logs (click_id, transaction_id, campaign_id, click_payout, user_id, click_time, conv_time, deleted) VALUES (?, ?, ?, ?, ?, ?, ?, 0)'
+                'INSERT INTO 202_conversion_logs (' . implode(', ', $columns) . ', deleted) VALUES (' . $placeholders . ', 0)'
             );
-            // Store an absent transaction id as NULL (not '') so the UNIQUE key on
-            // (click_id, transaction_id) still allows a click to convert more than
-            // once when no order id is supplied (multiple NULLs do not collide).
-            $transactionIdForInsert = $transactionId !== '' ? $transactionId : null;
-            $this->conn->bind($stmt, 'isidiii', [$clickId, $transactionIdForInsert, $campaignId, $payout, $userId, $clickTime, $convTime]);
+            $this->conn->bind($stmt, $types, $values);
             $convId = $this->conn->executeInsert($stmt);
 
-            $stmt = $this->conn->prepareWrite(
-                'UPDATE 202_clicks SET click_lead = 1, click_payout = ? WHERE click_id = ? AND user_id = ?'
-            );
-            $this->conn->bind($stmt, 'dii', [$payout, $clickId, $userId]);
-            $this->conn->execute($stmt);
-            $stmt->close();
+            if ($clickSideUpdate !== null) {
+                $clickSideUpdate($clickId, $payout);
+            }
 
-            return $convId;
+            return ['convId' => $convId, 'duplicate' => false, 'clickFound' => true];
         });
+    }
+
+    private function applyStandardClickUpdate(int $clickId, float $payout, int $userId): void
+    {
+        $stmt = $this->conn->prepareWrite(
+            'UPDATE 202_clicks SET click_lead = 1, click_payout = ? WHERE click_id = ? AND user_id = ?'
+        );
+        $this->conn->bind($stmt, 'dii', [$payout, $clickId, $userId]);
+        // executeUpdate() runs the checked execute and closes the statement.
+        $this->conn->executeUpdate($stmt);
     }
 
     public function softDelete(int $id, int $userId): void

--- a/202-config/Conversion/MysqlConversionRepository.php
+++ b/202-config/Conversion/MysqlConversionRepository.php
@@ -113,7 +113,9 @@ final class MysqlConversionRepository implements ConversionRepositoryInterface
             throw new RuntimeException('click_id is required');
         }
 
-        $rawTransactionId = (string) ($data['transaction_id'] ?? '');
+        // Trim centrally so a blank/whitespace-only id is treated as absent
+        // (stored NULL, no dedup) across every ingestion path.
+        $rawTransactionId = trim((string) ($data['transaction_id'] ?? ''));
         $transactionId = $rawTransactionId !== '' ? $rawTransactionId : null;
         $convTime = (int) ($data['conv_time'] ?? time());
         $payoutOverride = isset($data['payout']) ? (float) $data['payout'] : null;

--- a/202-config/Database/Tables/AttributionTables.php
+++ b/202-config/Database/Tables/AttributionTables.php
@@ -199,7 +199,7 @@ final class AttributionTables
                 `user_agent` text NOT NULL,
                 `deleted` tinyint(4) NOT NULL DEFAULT '0',
                 PRIMARY KEY (`conv_id`),
-                KEY `click_id` (`click_id`),
+                UNIQUE KEY `uniq_click_transaction` (`click_id`,`transaction_id`),
                 KEY `user_id` (`user_id`),
                 KEY `campaign_id` (`campaign_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"

--- a/202-config/Database/Tables/ClickTables.php
+++ b/202-config/Database/Tables/ClickTables.php
@@ -62,7 +62,8 @@ final class ClickTables
                 KEY `click_alp` (`click_alp`),
                 KEY `landing_page_id` (`landing_page_id`),
                 KEY `overview_index2` (`user_id`,`click_filtered`,`landing_page_id`,`aff_campaign_id`),
-                KEY `rotator_id` (`rotator_id`)
+                KEY `rotator_id` (`rotator_id`),
+                KEY `user_click_time` (`user_id`,`click_time`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
         );
     }

--- a/202-config/functions-upgrade.php
+++ b/202-config/functions-upgrade.php
@@ -3196,10 +3196,62 @@ class UPGRADE
             $prosper202_version = '1.9.60';
         }
 
-        //This will enable p202 to downgrade to this version if installed over a newer version
-        if ($prosper202_version > '1.9.60') {
+        // upgrade from 1.9.60 to 1.9.61 - enforce conversion idempotency at the DB
+        // level so retried/replayed postbacks can never double-count a conversion.
+        if ($prosper202_version == '1.9.60') {
 
-            $prosper202_version = '1.9.60';
+            // Empty transaction ids must be stored as NULL, not '', otherwise the
+            // UNIQUE key below would reject a click legitimately converting more
+            // than once when no network order id is supplied (NULLs do not collide).
+            $sql = "UPDATE 202_conversion_logs SET transaction_id = NULL WHERE transaction_id = ''";
+            $result = _mysqli_query($sql);
+
+            // Defensively neutralise any pre-existing duplicate (click_id, transaction_id)
+            // rows by nulling the transaction id on all but the earliest of each group.
+            // This preserves every conversion row (no data loss) while allowing the
+            // UNIQUE index to be created on installs that already contain duplicates.
+            $sql = "UPDATE 202_conversion_logs AS c
+                    JOIN (
+                        SELECT MIN(conv_id) AS keep_id, click_id, transaction_id
+                        FROM 202_conversion_logs
+                        WHERE transaction_id IS NOT NULL
+                        GROUP BY click_id, transaction_id
+                        HAVING COUNT(*) > 1
+                    ) AS d
+                      ON c.click_id = d.click_id
+                     AND c.transaction_id = d.transaction_id
+                    SET c.transaction_id = NULL
+                    WHERE c.conv_id <> d.keep_id";
+            $result = _mysqli_query($sql);
+
+            // Add the UNIQUE backstop only if it is not already present.
+            $sql = "SHOW INDEX FROM `202_conversion_logs` WHERE Key_name = 'uniq_click_transaction'";
+            $result = _mysqli_query($sql);
+            if (!($result && mysqli_num_rows($result) > 0)) {
+                $sql = "ALTER TABLE `202_conversion_logs`
+                        ADD UNIQUE KEY `uniq_click_transaction` (`click_id`,`transaction_id`)";
+                $result = _mysqli_query($sql);
+
+                // The new composite unique key covers the click_id lookup as a
+                // leftmost prefix, so drop the now-redundant standalone index.
+                $sql = "SHOW INDEX FROM `202_conversion_logs` WHERE Key_name = 'click_id'";
+                $result = _mysqli_query($sql);
+                if ($result && mysqli_num_rows($result) > 0) {
+                    $sql = "ALTER TABLE `202_conversion_logs` DROP INDEX `click_id`";
+                    $result = _mysqli_query($sql);
+                }
+            }
+
+            $sql = "UPDATE 202_version SET version='1.9.61'";
+            $result = _mysqli_query($sql);
+
+            $prosper202_version = '1.9.61';
+        }
+
+        //This will enable p202 to downgrade to this version if installed over a newer version
+        if ($prosper202_version > '1.9.61') {
+
+            $prosper202_version = '1.9.61';
             $sql = "UPDATE 202_version SET version='" . $prosper202_version . "'";
             $result = _mysqli_query($sql);
         }

--- a/202-config/functions-upgrade.php
+++ b/202-config/functions-upgrade.php
@@ -3227,18 +3227,27 @@ class UPGRADE
             // Add the UNIQUE backstop only if it is not already present.
             $sql = "SHOW INDEX FROM `202_conversion_logs` WHERE Key_name = 'uniq_click_transaction'";
             $result = _mysqli_query($sql);
-            if (!($result && mysqli_num_rows($result) > 0)) {
+            $uniqueKeyPresent = ($result && mysqli_num_rows($result) > 0);
+            if (!$uniqueKeyPresent) {
                 $sql = "ALTER TABLE `202_conversion_logs`
                         ADD UNIQUE KEY `uniq_click_transaction` (`click_id`,`transaction_id`)";
-                $result = _mysqli_query($sql);
+                _mysqli_query($sql);
 
-                // The new composite unique key covers the click_id lookup as a
-                // leftmost prefix, so drop the now-redundant standalone index.
-                $sql = "SHOW INDEX FROM `202_conversion_logs` WHERE Key_name = 'click_id'";
+                // Re-check: only treat the key as present if the ALTER actually
+                // succeeded (e.g. it can fail if de-duplication above did not run).
+                $sql = "SHOW INDEX FROM `202_conversion_logs` WHERE Key_name = 'uniq_click_transaction'";
                 $result = _mysqli_query($sql);
-                if ($result && mysqli_num_rows($result) > 0) {
-                    $sql = "ALTER TABLE `202_conversion_logs` DROP INDEX `click_id`";
+                $uniqueKeyPresent = ($result && mysqli_num_rows($result) > 0);
+
+                if ($uniqueKeyPresent) {
+                    // The new composite unique key covers the click_id lookup as a
+                    // leftmost prefix, so drop the now-redundant standalone index.
+                    $sql = "SHOW INDEX FROM `202_conversion_logs` WHERE Key_name = 'click_id'";
                     $result = _mysqli_query($sql);
+                    if ($result && mysqli_num_rows($result) > 0) {
+                        $sql = "ALTER TABLE `202_conversion_logs` DROP INDEX `click_id`";
+                        _mysqli_query($sql);
+                    }
                 }
             }
 
@@ -3250,13 +3259,20 @@ class UPGRADE
             $result = _mysqli_query($sql);
             if (!($result && mysqli_num_rows($result) > 0)) {
                 $sql = "ALTER TABLE `202_clicks` ADD KEY `user_click_time` (`user_id`,`click_time`)";
-                $result = _mysqli_query($sql);
+                _mysqli_query($sql);
             }
 
-            $sql = "UPDATE 202_version SET version='1.9.61'";
-            $result = _mysqli_query($sql);
+            // Only advance the schema version once the UNIQUE integrity backstop is
+            // actually in place. If it could not be created (e.g. a failed
+            // de-duplication left colliding rows), leave the version at 1.9.60 so
+            // this block re-runs next upgrade instead of silently skipping the key.
+            // The UPDATE/ALTER statements above are all idempotent on re-run.
+            if ($uniqueKeyPresent) {
+                $sql = "UPDATE 202_version SET version='1.9.61'";
+                $result = _mysqli_query($sql);
 
-            $prosper202_version = '1.9.61';
+                $prosper202_version = '1.9.61';
+            }
         }
 
         //This will enable p202 to downgrade to this version if installed over a newer version

--- a/202-config/functions-upgrade.php
+++ b/202-config/functions-upgrade.php
@@ -3242,6 +3242,17 @@ class UPGRADE
                 }
             }
 
+            // Add a composite index for the "last click for this ip/user within N
+            // days" lookback the off/postback redirects run on every conversion.
+            // The existing (user_id, click_lead) key can't serve the click_time
+            // range, forcing a scan that adds latency to the hot path.
+            $sql = "SHOW INDEX FROM `202_clicks` WHERE Key_name = 'user_click_time'";
+            $result = _mysqli_query($sql);
+            if (!($result && mysqli_num_rows($result) > 0)) {
+                $sql = "ALTER TABLE `202_clicks` ADD KEY `user_click_time` (`user_id`,`click_time`)";
+                $result = _mysqli_query($sql);
+            }
+
             $sql = "UPDATE 202_version SET version='1.9.61'";
             $result = _mysqli_query($sql);
 

--- a/202-config/static-endpoint-helpers.php
+++ b/202-config/static-endpoint-helpers.php
@@ -142,40 +142,17 @@ if (!function_exists('p202ExtractTransactionId')) {
     }
 }
 
-if (!function_exists('p202SafeDbError')) {
-    /**
-     * Read mysqli::$error without risking a fatal Error. On PHP 8.4 accessing
-     * ->error on a closed/never-opened connection throws "object is already
-     * closed"; we never want diagnostics to crash the caller.
-     */
-    function p202SafeDbError(mysqli $db): string
-    {
-        try {
-            return (string) $db->error;
-        } catch (\Error $e) {
-            return '(error unavailable)';
-        }
-    }
-}
-
 if (!function_exists('p202RecordConversion')) {
     /**
      * Record a conversion atomically and idempotently for the legacy static
      * postback/pixel endpoints (gpx/gpb/upx).
      *
-     * Everything runs in a single transaction:
-     *   1. the source click row is locked with SELECT ... FOR UPDATE so concurrent
-     *      or retried postbacks for the same click serialise here instead of both
-     *      recording a conversion (TOCTOU race / double count);
-     *   2. when $transactionId is a non-empty network order id that was already
-     *      recorded for this click, the existing conv_id is returned and nothing
-     *      is written (idempotent replay);
-     *   3. otherwise the click-side update (lead flag / payout) and the
-     *      202_conversion_logs insert are applied together — if either fails the
-     *      whole thing is rolled back, so a click is never flagged converted
-     *      without an audit row and vice versa.
-     *
-     * Values in $log are raw (unescaped); this function escapes them.
+     * Thin adapter over the canonical writer MysqlConversionRepository::record():
+     * the click is locked (SELECT ... FOR UPDATE), the conversion is de-duplicated
+     * on a non-empty transaction id (idempotent replay), and the conversion_logs
+     * insert plus the legacy click-side update (lead flag / cpa / payout / spy
+     * table) commit or roll back together. The dirty-hour cache write happens
+     * after commit, only for a newly recorded conversion.
      *
      * @param array<string,int|float|string> $log Conversion_logs column values.
      *        Required keys: click_id, campaign_id, user_id, click_time, conv_time,
@@ -196,91 +173,45 @@ if (!function_exists('p202RecordConversion')) {
             throw new \InvalidArgumentException('p202RecordConversion: click_id must be a positive integer');
         }
 
-        $transactionId = trim($transactionId);
+        // Delegate the transactional lock + idempotency + insert to the single
+        // canonical conversion writer (MysqlConversionRepository). The legacy
+        // click-side update (lead flag, cpa, spy table) runs inside that same
+        // transaction via the callback, so the click flag and the audit row commit
+        // or roll back together. Dirty-hour cache invalidation is deferred to after
+        // commit so the click-row lock is not held across memcache I/O.
+        $conn = new \Prosper202\Database\Connection($db);
+        $repo = new \Prosper202\Conversion\MysqlConversionRepository($conn);
 
-        $db->begin_transaction();
-        try {
-            // Lock the source click row so concurrent/retried postbacks for the
-            // same click serialise here instead of both recording a conversion.
-            $lockResult = $db->query('SELECT click_id FROM 202_clicks WHERE click_id = ' . $clickId . ' LIMIT 1 FOR UPDATE');
-            if ($lockResult === false) {
-                throw new \RuntimeException('p202RecordConversion: failed to lock click row: ' . p202SafeDbError($db));
-            }
-            $clickExists = $lockResult->fetch_assoc();
-            $lockResult->free();
-            if (!$clickExists) {
-                // The click is gone; do not insert an orphan conversion.
-                $db->rollback();
-                return ['conv_id' => 0, 'duplicate' => false];
-            }
+        $data = [
+            'click_id'        => $clickId,
+            'transaction_id'  => trim($transactionId),
+            'campaign_id'     => (int) ($log['campaign_id'] ?? 0),
+            'payout'          => (float) ($log['click_payout'] ?? 0),
+            'click_time'      => (int) ($log['click_time'] ?? 0),
+            'conv_time'       => (int) ($log['conv_time'] ?? time()),
+            'time_difference' => (string) ($log['time_difference'] ?? ''),
+            'ip'              => (string) ($log['ip'] ?? ''),
+            'pixel_type'      => (int) ($log['pixel_type'] ?? 0),
+            'user_agent'      => (string) ($log['user_agent'] ?? ''),
+        ];
 
-            // Idempotency: a non-empty network order id already recorded for this
-            // click means this is a replay/retry — return the existing conversion.
-            // The lookup intentionally does NOT filter on `deleted`: it must match
-            // the UNIQUE (click_id, transaction_id) key (which ignores `deleted`),
-            // otherwise a replay of a soft-deleted conversion would miss here and
-            // then hit a duplicate-key error on insert.
-            if ($transactionId !== '') {
-                $txEsc = $db->real_escape_string($transactionId);
-                $dupSql = "SELECT conv_id FROM 202_conversion_logs"
-                    . " WHERE click_id = " . $clickId
-                    . " AND transaction_id = '" . $txEsc . "'"
-                    . " LIMIT 1";
-                $dupResult = $db->query($dupSql);
-                if ($dupResult === false) {
-                    throw new \RuntimeException('p202RecordConversion: idempotency lookup failed: ' . p202SafeDbError($db));
-                }
-                $dupRow = $dupResult->fetch_assoc();
-                $dupResult->free();
-                if ($dupRow) {
-                    $db->commit();
-                    return ['conv_id' => (int) $dupRow['conv_id'], 'duplicate' => true];
+        $result = $repo->record(
+            (int) ($log['user_id'] ?? 0),
+            $data,
+            function (int $lockedClickId, float $payout) use ($db, $clickCpa, $usePixelPayout, $clickPayout): void {
+                if (!p202ApplyConversionUpdate($db, (string) $lockedClickId, $clickCpa, $usePixelPayout, $clickPayout, null, true)) {
+                    throw new \RuntimeException('p202RecordConversion: click update failed for click ' . $lockedClickId);
                 }
             }
+        );
 
-            // Apply the click-side conversion update (lead flag, cpa, payout).
-            // Defer the dirty-hour cache write until after commit (below) so the
-            // click-row lock is not held across memcache I/O.
-            if (!p202ApplyConversionUpdate($db, (string) $clickId, $clickCpa, $usePixelPayout, $clickPayout, null, true)) {
-                throw new \RuntimeException('p202RecordConversion: click update failed for click ' . $clickId);
-            }
-
-            // Empty transaction ids are stored as NULL (not '') so the UNIQUE key on
-            // (click_id, transaction_id) still allows a click to convert more than
-            // once when no network order id is supplied.
-            $transactionSql = $transactionId !== ''
-                ? "'" . $db->real_escape_string($transactionId) . "'"
-                : 'NULL';
-
-            $insertSql = "INSERT INTO 202_conversion_logs SET"
-                . " click_id = " . $clickId . ","
-                . " transaction_id = " . $transactionSql . ","
-                . " campaign_id = '" . $db->real_escape_string((string) ($log['campaign_id'] ?? '0')) . "',"
-                . " click_payout = '" . $db->real_escape_string((string) ($log['click_payout'] ?? '0')) . "',"
-                . " user_id = '" . $db->real_escape_string((string) ($log['user_id'] ?? '0')) . "',"
-                . " click_time = '" . $db->real_escape_string((string) ($log['click_time'] ?? '0')) . "',"
-                . " conv_time = '" . $db->real_escape_string((string) ($log['conv_time'] ?? '0')) . "',"
-                . " time_difference = '" . $db->real_escape_string((string) ($log['time_difference'] ?? '')) . "',"
-                . " ip = '" . $db->real_escape_string((string) ($log['ip'] ?? '')) . "',"
-                . " pixel_type = '" . $db->real_escape_string((string) ($log['pixel_type'] ?? '0')) . "',"
-                . " user_agent = '" . $db->real_escape_string((string) ($log['user_agent'] ?? '')) . "',"
-                . " deleted = 0";
-
-            if (!$db->query($insertSql)) {
-                throw new \RuntimeException('p202RecordConversion: conversion_logs insert failed: ' . p202SafeDbError($db));
-            }
-            $convId = (int) $db->insert_id;
-
-            $db->commit();
-
-            // Cache invalidation runs AFTER commit so the click lock is released first.
+        // Invalidate the hour cache only when a NEW conversion was recorded — not on
+        // an idempotent duplicate, and not when the click was missing.
+        if ($result['clickFound'] && !$result['duplicate']) {
             $de = new DataEngine();
             $de->setDirtyHour((string) $clickId);
-
-            return ['conv_id' => $convId, 'duplicate' => false];
-        } catch (\Throwable $e) {
-            $db->rollback();
-            throw $e;
         }
+
+        return ['conv_id' => $result['convId'], 'duplicate' => $result['duplicate']];
     }
 }

--- a/202-config/static-endpoint-helpers.php
+++ b/202-config/static-endpoint-helpers.php
@@ -60,7 +60,8 @@ if (!function_exists('p202ApplyConversionUpdate')) {
         string $clickCpa,
         bool $usePixelPayout = false,
         string $clickPayout = '',
-        ?string $affCampaignId = null
+        ?string $affCampaignId = null,
+        bool $deferDirtyHour = false
     ): bool {
         $escapedCpa = $db->real_escape_string($clickCpa);
         $sqlSet = $escapedCpa !== ''
@@ -102,8 +103,12 @@ if (!function_exists('p202ApplyConversionUpdate')) {
             }
         }
 
-        $de = new DataEngine();
-        $de->setDirtyHour($clickId);
+        // Cache invalidation (memcache write). Transactional callers defer this
+        // until AFTER commit so the click-row lock is not held across cache I/O.
+        if (!$deferDirtyHour) {
+            $de = new DataEngine();
+            $de->setDirtyHour($clickId);
+        }
 
         // Report whether the primary 202_clicks update succeeded so transactional
         // callers (p202RecordConversion) can roll back instead of committing a
@@ -211,12 +216,16 @@ if (!function_exists('p202RecordConversion')) {
 
             // Idempotency: a non-empty network order id already recorded for this
             // click means this is a replay/retry — return the existing conversion.
+            // The lookup intentionally does NOT filter on `deleted`: it must match
+            // the UNIQUE (click_id, transaction_id) key (which ignores `deleted`),
+            // otherwise a replay of a soft-deleted conversion would miss here and
+            // then hit a duplicate-key error on insert.
             if ($transactionId !== '') {
                 $txEsc = $db->real_escape_string($transactionId);
                 $dupSql = "SELECT conv_id FROM 202_conversion_logs"
                     . " WHERE click_id = " . $clickId
                     . " AND transaction_id = '" . $txEsc . "'"
-                    . " AND deleted = 0 LIMIT 1";
+                    . " LIMIT 1";
                 $dupResult = $db->query($dupSql);
                 if ($dupResult === false) {
                     throw new \RuntimeException('p202RecordConversion: idempotency lookup failed: ' . p202SafeDbError($db));
@@ -230,7 +239,9 @@ if (!function_exists('p202RecordConversion')) {
             }
 
             // Apply the click-side conversion update (lead flag, cpa, payout).
-            if (!p202ApplyConversionUpdate($db, (string) $clickId, $clickCpa, $usePixelPayout, $clickPayout)) {
+            // Defer the dirty-hour cache write until after commit (below) so the
+            // click-row lock is not held across memcache I/O.
+            if (!p202ApplyConversionUpdate($db, (string) $clickId, $clickCpa, $usePixelPayout, $clickPayout, null, true)) {
                 throw new \RuntimeException('p202RecordConversion: click update failed for click ' . $clickId);
             }
 
@@ -261,6 +272,10 @@ if (!function_exists('p202RecordConversion')) {
             $convId = (int) $db->insert_id;
 
             $db->commit();
+
+            // Cache invalidation runs AFTER commit so the click lock is released first.
+            $de = new DataEngine();
+            $de->setDirtyHour((string) $clickId);
 
             return ['conv_id' => $convId, 'duplicate' => false];
         } catch (\Throwable $e) {

--- a/202-config/static-endpoint-helpers.php
+++ b/202-config/static-endpoint-helpers.php
@@ -61,7 +61,7 @@ if (!function_exists('p202ApplyConversionUpdate')) {
         bool $usePixelPayout = false,
         string $clickPayout = '',
         ?string $affCampaignId = null
-    ): void {
+    ): bool {
         $escapedCpa = $db->real_escape_string($clickCpa);
         $sqlSet = $escapedCpa !== ''
             ? "click_cpc='" . $escapedCpa . "', click_lead='1', click_filtered='0'"
@@ -79,7 +79,9 @@ if (!function_exists('p202ApplyConversionUpdate')) {
             $updateClicksSql .= "\n\t\t\t, click_payout='" . $escapedPayout . "'";
         }
         $updateClicksSql .= "\n\t\tWHERE\n\t\t\t" . $where;
+        $clicksUpdateOk = true;
         if (!$db->query($updateClicksSql)) {
+            $clicksUpdateOk = false;
             try {
                 error_log('p202ApplyConversionUpdate: failed to update 202_clicks: ' . $db->error);
             } catch (\Error $e) {
@@ -102,5 +104,168 @@ if (!function_exists('p202ApplyConversionUpdate')) {
 
         $de = new DataEngine();
         $de->setDirtyHour($clickId);
+
+        // Report whether the primary 202_clicks update succeeded so transactional
+        // callers (p202RecordConversion) can roll back instead of committing a
+        // conversion whose click never got flagged. The 202_clicks_spy update is a
+        // denormalised real-time copy: its failure is logged but not fatal.
+        return $clicksUpdateOk;
+    }
+}
+
+if (!function_exists('p202ExtractTransactionId')) {
+    /**
+     * Pull a network-supplied transaction/order id from a request array so a
+     * conversion can be recorded idempotently. Returns '' when none is present,
+     * which means "no idempotency key available" (the conversion is still
+     * recorded, it just cannot be de-duplicated on retry).
+     *
+     * @param array<string,mixed> $source Typically $_GET.
+     */
+    function p202ExtractTransactionId(array $source): string
+    {
+        foreach (['txid', 'transaction_id', 'transactionid', 'order_id', 'orderid', 'oid'] as $key) {
+            if (array_key_exists($key, $source) && is_scalar($source[$key])) {
+                $value = trim((string) $source[$key]);
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('p202SafeDbError')) {
+    /**
+     * Read mysqli::$error without risking a fatal Error. On PHP 8.4 accessing
+     * ->error on a closed/never-opened connection throws "object is already
+     * closed"; we never want diagnostics to crash the caller.
+     */
+    function p202SafeDbError(mysqli $db): string
+    {
+        try {
+            return (string) $db->error;
+        } catch (\Error $e) {
+            return '(error unavailable)';
+        }
+    }
+}
+
+if (!function_exists('p202RecordConversion')) {
+    /**
+     * Record a conversion atomically and idempotently for the legacy static
+     * postback/pixel endpoints (gpx/gpb/upx).
+     *
+     * Everything runs in a single transaction:
+     *   1. the source click row is locked with SELECT ... FOR UPDATE so concurrent
+     *      or retried postbacks for the same click serialise here instead of both
+     *      recording a conversion (TOCTOU race / double count);
+     *   2. when $transactionId is a non-empty network order id that was already
+     *      recorded for this click, the existing conv_id is returned and nothing
+     *      is written (idempotent replay);
+     *   3. otherwise the click-side update (lead flag / payout) and the
+     *      202_conversion_logs insert are applied together — if either fails the
+     *      whole thing is rolled back, so a click is never flagged converted
+     *      without an audit row and vice versa.
+     *
+     * Values in $log are raw (unescaped); this function escapes them.
+     *
+     * @param array<string,int|float|string> $log Conversion_logs column values.
+     *        Required keys: click_id, campaign_id, user_id, click_time, conv_time,
+     *        time_difference, ip, pixel_type, user_agent, click_payout.
+     * @return array{conv_id:int, duplicate:bool} conv_id is 0 only when the source
+     *         click no longer exists (no orphan row is written).
+     */
+    function p202RecordConversion(
+        mysqli $db,
+        array $log,
+        string $clickCpa,
+        bool $usePixelPayout,
+        string $clickPayout,
+        string $transactionId = ''
+    ): array {
+        $clickId = (int) ($log['click_id'] ?? 0);
+        if ($clickId <= 0) {
+            throw new \InvalidArgumentException('p202RecordConversion: click_id must be a positive integer');
+        }
+
+        $transactionId = trim($transactionId);
+
+        $db->begin_transaction();
+        try {
+            // Lock the source click row so concurrent/retried postbacks for the
+            // same click serialise here instead of both recording a conversion.
+            $lockResult = $db->query('SELECT click_id FROM 202_clicks WHERE click_id = ' . $clickId . ' LIMIT 1 FOR UPDATE');
+            if ($lockResult === false) {
+                throw new \RuntimeException('p202RecordConversion: failed to lock click row: ' . p202SafeDbError($db));
+            }
+            $clickExists = $lockResult->fetch_assoc();
+            $lockResult->free();
+            if (!$clickExists) {
+                // The click is gone; do not insert an orphan conversion.
+                $db->rollback();
+                return ['conv_id' => 0, 'duplicate' => false];
+            }
+
+            // Idempotency: a non-empty network order id already recorded for this
+            // click means this is a replay/retry — return the existing conversion.
+            if ($transactionId !== '') {
+                $txEsc = $db->real_escape_string($transactionId);
+                $dupSql = "SELECT conv_id FROM 202_conversion_logs"
+                    . " WHERE click_id = " . $clickId
+                    . " AND transaction_id = '" . $txEsc . "'"
+                    . " AND deleted = 0 LIMIT 1";
+                $dupResult = $db->query($dupSql);
+                if ($dupResult === false) {
+                    throw new \RuntimeException('p202RecordConversion: idempotency lookup failed: ' . p202SafeDbError($db));
+                }
+                $dupRow = $dupResult->fetch_assoc();
+                $dupResult->free();
+                if ($dupRow) {
+                    $db->commit();
+                    return ['conv_id' => (int) $dupRow['conv_id'], 'duplicate' => true];
+                }
+            }
+
+            // Apply the click-side conversion update (lead flag, cpa, payout).
+            if (!p202ApplyConversionUpdate($db, (string) $clickId, $clickCpa, $usePixelPayout, $clickPayout)) {
+                throw new \RuntimeException('p202RecordConversion: click update failed for click ' . $clickId);
+            }
+
+            // Empty transaction ids are stored as NULL (not '') so the UNIQUE key on
+            // (click_id, transaction_id) still allows a click to convert more than
+            // once when no network order id is supplied.
+            $transactionSql = $transactionId !== ''
+                ? "'" . $db->real_escape_string($transactionId) . "'"
+                : 'NULL';
+
+            $insertSql = "INSERT INTO 202_conversion_logs SET"
+                . " click_id = " . $clickId . ","
+                . " transaction_id = " . $transactionSql . ","
+                . " campaign_id = '" . $db->real_escape_string((string) ($log['campaign_id'] ?? '0')) . "',"
+                . " click_payout = '" . $db->real_escape_string((string) ($log['click_payout'] ?? '0')) . "',"
+                . " user_id = '" . $db->real_escape_string((string) ($log['user_id'] ?? '0')) . "',"
+                . " click_time = '" . $db->real_escape_string((string) ($log['click_time'] ?? '0')) . "',"
+                . " conv_time = '" . $db->real_escape_string((string) ($log['conv_time'] ?? '0')) . "',"
+                . " time_difference = '" . $db->real_escape_string((string) ($log['time_difference'] ?? '')) . "',"
+                . " ip = '" . $db->real_escape_string((string) ($log['ip'] ?? '')) . "',"
+                . " pixel_type = '" . $db->real_escape_string((string) ($log['pixel_type'] ?? '0')) . "',"
+                . " user_agent = '" . $db->real_escape_string((string) ($log['user_agent'] ?? '')) . "',"
+                . " deleted = 0";
+
+            if (!$db->query($insertSql)) {
+                throw new \RuntimeException('p202RecordConversion: conversion_logs insert failed: ' . p202SafeDbError($db));
+            }
+            $convId = (int) $db->insert_id;
+
+            $db->commit();
+
+            return ['conv_id' => $convId, 'duplicate' => false];
+        } catch (\Throwable $e) {
+            $db->rollback();
+            throw $e;
+        }
     }
 }

--- a/202-config/version.php
+++ b/202-config/version.php
@@ -6,7 +6,7 @@
 declare(strict_types=1);
 
 // Validate version format before defining
-$version_string = '1.9.59';
+$version_string = '1.9.61';
 if (!preg_match('/^\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?$/', $version_string)) {
     throw new Exception('Invalid version format: ' . $version_string);
 }

--- a/api/V3/Controllers/ConversionsController.php
+++ b/api/V3/Controllers/ConversionsController.php
@@ -106,66 +106,28 @@ class ConversionsController
             throw new ValidationException('click_id is required', ['click_id' => 'Must be a positive integer']);
         }
 
-        $payoutInput = array_key_exists('payout', $payload) ? (float)$payload['payout'] : null;
-        $transactionId = (string)($payload['transaction_id'] ?? '');
-        $convTime = (int)($payload['conv_time'] ?? time());
+        $data = [
+            'click_id' => $clickId,
+            'transaction_id' => (string)($payload['transaction_id'] ?? ''),
+            'conv_time' => (int)($payload['conv_time'] ?? time()),
+        ];
+        if (array_key_exists('payout', $payload)) {
+            $data['payout'] = (float)$payload['payout'];
+        }
 
-        $this->db->begin_transaction();
+        // Delegate to the single canonical conversion writer so the V3 API and the
+        // legacy postback/pixel endpoints share one transactional, idempotent path
+        // (locks the click, de-dupes on transaction_id, inserts + flags the click).
+        $repo = new \Prosper202\Conversion\MysqlConversionRepository(
+            new \Prosper202\Database\Connection($this->db)
+        );
+
         try {
-            // Lock the source click row inside the transaction so two concurrent postbacks
-            // for the same click serialize here instead of both recording a conversion
-            // (TOCTOU race). Mirrors MysqlConversionRepository::create().
-            $stmt = $this->prepare('SELECT click_id, aff_campaign_id, click_payout, click_time FROM 202_clicks WHERE click_id = ? AND user_id = ? LIMIT 1 FOR UPDATE');
-            $this->bind($stmt, 'ii', $clickId, $this->userId);
-            $this->execute($stmt, 'Query failed');
-            $click = $stmt->get_result()->fetch_assoc();
-            $stmt->close();
-
-            if (!$click) {
-                throw new NotFoundException('Click not found or not owned by user');
-            }
-
-            // Idempotency: if this transaction_id was already recorded for this click,
-            // return the existing conversion instead of double-counting on a replay/retry.
-            if ($transactionId !== '') {
-                $dupStmt = $this->prepare('SELECT conv_id FROM 202_conversion_logs WHERE user_id = ? AND click_id = ? AND transaction_id = ? AND deleted = 0 LIMIT 1');
-                $this->bind($dupStmt, 'iis', $this->userId, $clickId, $transactionId);
-                $this->execute($dupStmt, 'Query failed');
-                $dup = $dupStmt->get_result()->fetch_assoc();
-                $dupStmt->close();
-                if ($dup) {
-                    $this->db->commit();
-                    return $this->get((int)$dup['conv_id']);
-                }
-            }
-
-            $payout = (float)($payoutInput ?? $click['click_payout'] ?? 0);
-            $campaignId = (int)$click['aff_campaign_id'];
-            $clickTime = (int)($click['click_time'] ?? 0);
-
-            $sql = "INSERT INTO 202_conversion_logs
-                (click_id, transaction_id, campaign_id, click_payout, user_id, click_time, conv_time, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, 0)";
-            $stmt = $this->prepare($sql);
-            // Store an absent transaction id as NULL (not '') so the UNIQUE key on
-            // (click_id, transaction_id) still allows a click to convert more than
-            // once when no order id is supplied (multiple NULLs do not collide).
-            $transactionIdForInsert = $transactionId !== '' ? $transactionId : null;
-            $this->bind($stmt, 'isidiii', $clickId, $transactionIdForInsert, $campaignId, $payout, $this->userId, $clickTime, $convTime);
-
-            $this->execute($stmt, 'Failed to create conversion');
-            $convId = $stmt->insert_id;
-            $stmt->close();
-
-            $stmt = $this->prepare('UPDATE 202_clicks SET click_lead = 1, click_payout = ? WHERE click_id = ? AND user_id = ?');
-            $this->bind($stmt, 'dii', $payout, $clickId, $this->userId);
-            $this->execute($stmt, 'Failed to update click');
-            $stmt->close();
-
-            $this->db->commit();
+            $convId = $repo->create($this->userId, $data);
+        } catch (\Prosper202\Conversion\ClickNotFoundException $e) {
+            throw new NotFoundException('Click not found or not owned by user');
         } catch (\Throwable $e) {
-            $this->db->rollback();
-            throw $e;
+            throw new DatabaseException('Failed to create conversion');
         }
 
         return $this->get($convId);

--- a/api/V3/Controllers/ConversionsController.php
+++ b/api/V3/Controllers/ConversionsController.php
@@ -127,7 +127,8 @@ class ConversionsController
         } catch (\Prosper202\Conversion\ClickNotFoundException $e) {
             throw new NotFoundException('Click not found or not owned by user');
         } catch (\Throwable $e) {
-            throw new DatabaseException('Failed to create conversion');
+            // Preserve the underlying failure for server-side logs via getPrevious().
+            throw new DatabaseException('Failed to create conversion: ' . $e->getMessage(), $e);
         }
 
         return $this->get($convId);

--- a/api/V3/Controllers/ConversionsController.php
+++ b/api/V3/Controllers/ConversionsController.php
@@ -147,7 +147,11 @@ class ConversionsController
                 (click_id, transaction_id, campaign_id, click_payout, user_id, click_time, conv_time, deleted)
                 VALUES (?, ?, ?, ?, ?, ?, ?, 0)";
             $stmt = $this->prepare($sql);
-            $this->bind($stmt, 'isidiii', $clickId, $transactionId, $campaignId, $payout, $this->userId, $clickTime, $convTime);
+            // Store an absent transaction id as NULL (not '') so the UNIQUE key on
+            // (click_id, transaction_id) still allows a click to convert more than
+            // once when no order id is supplied (multiple NULLs do not collide).
+            $transactionIdForInsert = $transactionId !== '' ? $transactionId : null;
+            $this->bind($stmt, 'isidiii', $clickId, $transactionIdForInsert, $campaignId, $payout, $this->userId, $clickTime, $convTime);
 
             $this->execute($stmt, 'Failed to create conversion');
             $convId = $stmt->insert_id;

--- a/tests/Conversion/ConversionIdempotencyIntegrationTest.php
+++ b/tests/Conversion/ConversionIdempotencyIntegrationTest.php
@@ -46,13 +46,20 @@ final class ConversionIdempotencyIntegrationTest extends TestCase
         mysqli_report(MYSQLI_REPORT_STRICT);
 
         $port = (int) (getenv('P202_TEST_DB_PORT') ?: 3306);
-        $db = @mysqli_connect(
-            $host,
-            (string) (getenv('P202_TEST_DB_USER') ?: 'root'),
-            (string) (getenv('P202_TEST_DB_PASS') ?: ''),
-            (string) (getenv('P202_TEST_DB_NAME') ?: 'prosper202'),
-            $port
-        );
+        // Under MYSQLI_REPORT_STRICT a failed connect throws rather than returning
+        // false, so catch it and leave self::$db null → the tests skip cleanly
+        // (e.g. when the DB is briefly unreachable in CI) instead of erroring.
+        try {
+            $db = @mysqli_connect(
+                $host,
+                (string) (getenv('P202_TEST_DB_USER') ?: 'root'),
+                (string) (getenv('P202_TEST_DB_PASS') ?: ''),
+                (string) (getenv('P202_TEST_DB_NAME') ?: 'prosper202'),
+                $port
+            );
+        } catch (\Throwable $e) {
+            return; // connection failed; tests will skip
+        }
         if (!$db) {
             return; // connection failed; tests will skip
         }

--- a/tests/Conversion/ConversionIdempotencyIntegrationTest.php
+++ b/tests/Conversion/ConversionIdempotencyIntegrationTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Conversion;
+
+use PHPUnit\Framework\TestCase;
+use Prosper202\Database\SchemaInstaller;
+
+/**
+ * End-to-end verification of the conversion-recording guarantees against a REAL
+ * MySQL/MariaDB database (the unit tests use fakes and cannot exercise the
+ * insert_id success path, the UNIQUE (click_id, transaction_id) backstop, or
+ * MySQL's "multiple NULLs do not collide" behaviour).
+ *
+ * Skips automatically unless a test database is configured via env:
+ *   P202_TEST_DB_HOST, P202_TEST_DB_PORT, P202_TEST_DB_USER,
+ *   P202_TEST_DB_PASS, P202_TEST_DB_NAME
+ *
+ * @group integration
+ */
+final class ConversionIdempotencyIntegrationTest extends TestCase
+{
+    private static ?\mysqli $db = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        $host = getenv('P202_TEST_DB_HOST');
+        if ($host === false || $host === '') {
+            return; // no DB configured; individual tests will skip
+        }
+
+        // SchemaInstaller and the static helpers expect a global _mysqli_query()
+        // and a DataEngine class to exist. Provide minimal stand-ins so we can
+        // drive the real production code paths without bootstrapping connect2.php.
+        if (!function_exists('_mysqli_query')) {
+            eval('function _mysqli_query($dbOrSql, $sql = null) { return $sql === null ? null : $dbOrSql->query($sql); }');
+        }
+        if (!class_exists('DataEngine', false)) {
+            eval('class DataEngine { public function setDirtyHour($id) {} public function getSummary($s,$e,$p,$u=1,$up=false,$n=false){ return ""; } }');
+        }
+
+        require_once __DIR__ . '/../../202-config/static-endpoint-helpers.php';
+
+        // Match production error mode (connect2.php) so behaviour is realistic.
+        mysqli_report(MYSQLI_REPORT_STRICT);
+
+        $port = (int) (getenv('P202_TEST_DB_PORT') ?: 3306);
+        $db = @mysqli_connect(
+            $host,
+            (string) (getenv('P202_TEST_DB_USER') ?: 'root'),
+            (string) (getenv('P202_TEST_DB_PASS') ?: ''),
+            (string) (getenv('P202_TEST_DB_NAME') ?: 'prosper202'),
+            $port
+        );
+        if (!$db) {
+            return; // connection failed; tests will skip
+        }
+
+        $db->query("SET SESSION sql_mode=''");
+        (new SchemaInstaller($db))->install();
+        self::$db = $db;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$db) {
+            self::$db->close();
+            self::$db = null;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        if (!self::$db) {
+            self::markTestSkipped('No test database configured (set P202_TEST_DB_HOST).');
+        }
+        // Clean slate for each test.
+        self::$db->query('TRUNCATE TABLE 202_conversion_logs');
+        self::$db->query('TRUNCATE TABLE 202_clicks');
+        self::$db->query('TRUNCATE TABLE 202_clicks_spy');
+    }
+
+    private function insertClick(int $clickId, float $payout = 10.0, int $campaignId = 7): void
+    {
+        $db = self::$db;
+        $db->query("INSERT INTO 202_clicks SET click_id=$clickId, user_id=1, aff_campaign_id=$campaignId, click_payout=$payout, click_cpc=0, click_lead=0, click_time=1700000000");
+        $db->query("INSERT INTO 202_clicks_spy SET click_id=$clickId, user_id=1, aff_campaign_id=$campaignId, click_payout=$payout, click_cpc=0, click_lead=0, click_time=1700000000");
+    }
+
+    private function log(int $clickId, float $payout = 10.0): array
+    {
+        return [
+            'click_id'        => $clickId,
+            'campaign_id'     => '7',
+            'user_id'         => '1',
+            'click_time'      => 1700000000,
+            'conv_time'       => 1700000100,
+            'time_difference' => '0 days, 0 hours, 1 min and 40 sec',
+            'ip'              => '203.0.113.9',
+            'pixel_type'      => 3,
+            'user_agent'      => 'IntegrationTest/1.0',
+            'click_payout'    => (string) $payout,
+        ];
+    }
+
+    private function conversionCount(int $clickId): int
+    {
+        $res = self::$db->query("SELECT COUNT(*) AS c FROM 202_conversion_logs WHERE click_id=$clickId");
+        return (int) $res->fetch_assoc()['c'];
+    }
+
+    public function testSuccessfulConversionReturnsRealConvIdAndFlagsClick(): void
+    {
+        $this->insertClick(1000);
+
+        $result = p202RecordConversion(self::$db, $this->log(1000), '', true, '10.0', 'ORD-1');
+
+        self::assertFalse($result['duplicate']);
+        self::assertGreaterThan(0, $result['conv_id'], 'A real conv_id must be returned from insert_id');
+        self::assertSame(1, $this->conversionCount(1000));
+
+        $click = self::$db->query('SELECT click_lead FROM 202_clicks WHERE click_id=1000')->fetch_assoc();
+        self::assertSame('1', (string) $click['click_lead'], 'The source click must be flagged converted');
+    }
+
+    public function testReplayWithSameTransactionIdDoesNotDoubleCount(): void
+    {
+        $this->insertClick(1000);
+
+        $first = p202RecordConversion(self::$db, $this->log(1000), '', true, '10.0', 'ORD-DUP');
+        $second = p202RecordConversion(self::$db, $this->log(1000), '', true, '10.0', 'ORD-DUP');
+
+        self::assertFalse($first['duplicate']);
+        self::assertTrue($second['duplicate'], 'A retried postback with the same order id is a duplicate');
+        self::assertSame($first['conv_id'], $second['conv_id'], 'The existing conversion is returned, not a new one');
+        self::assertSame(1, $this->conversionCount(1000), 'Only one conversion row may exist for a repeated order id');
+    }
+
+    public function testEmptyTransactionIdAllowsRepeatConversions(): void
+    {
+        $this->insertClick(1001);
+
+        $first = p202RecordConversion(self::$db, $this->log(1001), '', true, '10.0', '');
+        $second = p202RecordConversion(self::$db, $this->log(1001), '', true, '10.0', '');
+
+        self::assertFalse($first['duplicate']);
+        self::assertFalse($second['duplicate']);
+        self::assertNotSame($first['conv_id'], $second['conv_id']);
+        self::assertSame(2, $this->conversionCount(1001), 'No order id means no dedup; both conversions are recorded');
+
+        $res = self::$db->query("SELECT COUNT(*) AS c FROM 202_conversion_logs WHERE click_id=1001 AND transaction_id IS NULL");
+        self::assertSame(2, (int) $res->fetch_assoc()['c'], 'Empty transaction ids must be stored as NULL');
+    }
+
+    public function testUniqueKeyRejectsDuplicateTransactionIdAtDbLevel(): void
+    {
+        $this->insertClick(1002);
+        $db = self::$db;
+
+        $ok = $db->query("INSERT INTO 202_conversion_logs SET click_id=1002, transaction_id='X1', campaign_id=7, click_payout=1, user_id=1, click_time=1, conv_time=1, time_difference='', ip='', pixel_type=1, user_agent='', deleted=0");
+        self::assertTrue($ok);
+
+        // Second insert with the same (click_id, transaction_id) must violate the
+        // UNIQUE backstop even if application-level dedup were bypassed. Depending
+        // on the mysqli_report mode this surfaces either as a false return or a
+        // thrown exception — both must carry ER_DUP_ENTRY (1062).
+        try {
+            $dup = $db->query("INSERT INTO 202_conversion_logs SET click_id=1002, transaction_id='X1', campaign_id=7, click_payout=1, user_id=1, click_time=1, conv_time=1, time_difference='', ip='', pixel_type=1, user_agent='', deleted=0");
+            self::assertFalse($dup, 'The UNIQUE (click_id, transaction_id) key must reject a duplicate');
+            self::assertSame(1062, $db->errno, 'MySQL ER_DUP_ENTRY expected');
+        } catch (\mysqli_sql_exception $e) {
+            self::assertSame(1062, $e->getCode(), 'MySQL ER_DUP_ENTRY expected');
+        }
+    }
+
+    public function testMissingSourceClickWritesNoOrphanConversion(): void
+    {
+        // No click inserted for 999999.
+        $result = p202RecordConversion(self::$db, $this->log(999999), '', true, '10.0', 'ORD-X');
+
+        self::assertSame(0, $result['conv_id']);
+        self::assertFalse($result['duplicate']);
+        self::assertSame(0, $this->conversionCount(999999), 'No conversion may be recorded for a non-existent click');
+    }
+}

--- a/tests/Conversion/ConversionIdempotencyIntegrationTest.php
+++ b/tests/Conversion/ConversionIdempotencyIntegrationTest.php
@@ -190,4 +190,31 @@ final class ConversionIdempotencyIntegrationTest extends TestCase
         self::assertFalse($result['duplicate']);
         self::assertSame(0, $this->conversionCount(999999), 'No conversion may be recorded for a non-existent click');
     }
+
+    // --- V3 API path (now shares the same canonical writer) ---
+
+    public function testV3ControllerCreateIsIdempotentThroughSharedWriter(): void
+    {
+        $this->insertClick(1100);
+        $controller = new \Api\V3\Controllers\ConversionsController(self::$db, 1);
+
+        $first = $controller->create(['click_id' => 1100, 'transaction_id' => 'V3-DUP', 'payout' => 5.0]);
+        $second = $controller->create(['click_id' => 1100, 'transaction_id' => 'V3-DUP', 'payout' => 5.0]);
+
+        $firstId = (int) $first['data']['conv_id'];
+        self::assertGreaterThan(0, $firstId);
+        self::assertSame($firstId, (int) $second['data']['conv_id'], 'V3 create must dedupe on transaction_id');
+        self::assertSame(1, $this->conversionCount(1100), 'A replayed V3 create must not double-count');
+
+        $click = self::$db->query('SELECT click_lead FROM 202_clicks WHERE click_id=1100')->fetch_assoc();
+        self::assertSame('1', (string) $click['click_lead'], 'V3 create must flag the source click');
+    }
+
+    public function testV3ControllerCreateThrowsNotFoundForMissingClick(): void
+    {
+        $controller = new \Api\V3\Controllers\ConversionsController(self::$db, 1);
+
+        $this->expectException(\Api\V3\Exception\NotFoundException::class);
+        $controller->create(['click_id' => 888888, 'transaction_id' => 'V3-X']);
+    }
 }

--- a/tests/Conversion/MysqlConversionRepositoryExpandedTest.php
+++ b/tests/Conversion/MysqlConversionRepositoryExpandedTest.php
@@ -170,6 +170,77 @@ final class MysqlConversionRepositoryExpandedTest extends TestCase
         self::assertNotEmpty($lockStmts, 'Must use FOR UPDATE to prevent race conditions');
     }
 
+    public function testCreateDeduplicatesOnTransactionId(): void
+    {
+        $write = new FakeMysqliConnection();
+        $write->whenQueryContainsReturnRows(
+            'FROM 202_clicks WHERE click_id = ?',
+            [['click_id' => 10, 'aff_campaign_id' => 44, 'click_payout' => 2.75, 'click_time' => 1700000000]]
+        );
+        // A conversion with this (click_id, transaction_id) already exists.
+        $write->whenQueryContainsReturnRows('SELECT conv_id FROM 202_conversion_logs', [['conv_id' => 99]]);
+
+        [$repo] = $this->buildRepo($write);
+        $id = $repo->create(1, ['click_id' => 10, 'transaction_id' => 'DUP']);
+
+        self::assertSame(99, $id, 'A duplicate transaction id must return the existing conversion');
+        self::assertCount(0, $write->statementsContaining('INSERT INTO 202_conversion_logs'), 'No second row may be inserted');
+        self::assertCount(0, $write->statementsContaining('UPDATE 202_clicks SET click_lead = 1'), 'The click must not be re-flagged on a duplicate');
+    }
+
+    // --- record() (shared writer used by the legacy static endpoints) ---
+
+    public function testRecordWritesLegacyColumnsAndRunsClickSideCallbackInTransaction(): void
+    {
+        $write = new InsertReportingFakeMysqliConnection(5);
+        $write->whenQueryContainsReturnRows(
+            'FROM 202_clicks WHERE click_id = ?',
+            [['click_id' => 10, 'aff_campaign_id' => 44, 'click_payout' => 2.75, 'click_time' => 1700000000]]
+        );
+        $repo = new MysqlConversionRepository(new Connection($write, new FakeMysqliConnection()));
+
+        $callbackArgs = null;
+        $result = $repo->record(
+            1,
+            [
+                'click_id' => 10,
+                'transaction_id' => '',
+                'pixel_type' => 3,
+                'ip' => '203.0.113.9',
+                'user_agent' => 'UA/1.0',
+                'time_difference' => '0 days',
+            ],
+            function (int $clickId, float $payout) use (&$callbackArgs): void {
+                $callbackArgs = [$clickId, $payout];
+            }
+        );
+
+        self::assertSame(5, $result['convId']);
+        self::assertFalse($result['duplicate']);
+        self::assertTrue($result['clickFound']);
+        self::assertSame([10, 2.75], $callbackArgs, 'The click-side callback runs with the locked click id and payout');
+
+        $insert = $write->statementsContaining('INSERT INTO 202_conversion_logs');
+        self::assertCount(1, $insert);
+        // Base 7 columns (isidiii) + the 4 legacy columns (time_difference, ip,
+        // pixel_type, user_agent) = 11 bound params.
+        self::assertSame(11, strlen($insert[0]->boundTypes));
+        self::assertStringStartsWith('isidiii', $insert[0]->boundTypes);
+        self::assertStringContainsString('pixel_type', $insert[0]->sql);
+    }
+
+    public function testRecordReturnsClickNotFoundWithoutThrowing(): void
+    {
+        $write = new FakeMysqliConnection(); // no click row registered → lock finds nothing
+
+        [$repo] = $this->buildRepo($write);
+        $result = $repo->record(1, ['click_id' => 999]);
+
+        self::assertSame(0, $result['convId']);
+        self::assertFalse($result['clickFound']);
+        self::assertCount(0, $write->statementsContaining('INSERT INTO 202_conversion_logs'));
+    }
+
     // --- softDelete() ---
 
     public function testSoftDeleteSetsDeletedFlag(): void

--- a/tests/StaticEndpoint/RecordConversionTest.php
+++ b/tests/StaticEndpoint/RecordConversionTest.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Tests\StaticEndpoint;
 
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use InvalidArgumentException;
 
 /**
- * Tests for p202RecordConversion() and p202ExtractTransactionId() in
- * static-endpoint-helpers.php.
+ * Tests for the thin parts of the static conversion helpers.
  *
- * p202RecordConversion is the shared transactional + idempotent conversion writer
- * used by the gpx/gpb/upx postback endpoints. Its job is to guarantee that a
- * retried/replayed postback can never double-count, and that a click is never
- * flagged converted without a matching audit row (no partial commits).
+ * p202RecordConversion is now a thin adapter over the canonical writer
+ * Prosper202\Conversion\MysqlConversionRepository::record(): the transactional
+ * lock + idempotency + insert behaviour is unit-tested in
+ * tests/Conversion/MysqlConversionRepository*Test and exercised end-to-end
+ * against a real database in tests/Conversion/ConversionIdempotencyIntegrationTest.
+ * What remains here is the input guard and the pure transaction-id extraction.
  */
 final class RecordConversionTest extends TestCase
 {
@@ -23,21 +23,9 @@ final class RecordConversionTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists('DB', false)) {
-            eval('class DB {
-                private static $instance;
-                public static function getInstance() {
-                    if (!self::$instance) self::$instance = new self();
-                    return self::$instance;
-                }
-                public function getConnection() { return new \mysqli(); }
-            }');
-        }
-
         if (!class_exists('DataEngine', false)) {
             eval('class DataEngine {
-                public array $dirtyHourCalls = [];
-                public function setDirtyHour($click_id) { $this->dirtyHourCalls[] = $click_id; }
+                public function setDirtyHour($click_id) {}
                 public function getSummary($s,$e,$p,$u=1,$up=false,$n=false) { return ""; }
             }');
         }
@@ -48,165 +36,21 @@ final class RecordConversionTest extends TestCase
         }
     }
 
-    private function log(): array
-    {
-        return [
-            'click_id'        => 100,
-            'campaign_id'     => '7',
-            'user_id'         => '1',
-            'click_time'      => 1700000000,
-            'conv_time'       => 1700000100,
-            'time_difference' => '0 days, 0 hours, 1 min and 40 sec',
-            'ip'              => '203.0.113.9',
-            'pixel_type'      => 3,
-            'user_agent'      => 'UnitTest/1.0',
-        ];
-    }
-
-    // --- Idempotency / double-count protection ---
-
-    public function testDuplicateTransactionReturnsExistingConversionWithoutInserting(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->dupRow = ['conv_id' => '42'];
-
-        $result = p202RecordConversion($db, $this->log(), '', false, '', 'ORDER-123');
-
-        self::assertSame(42, $result['conv_id']);
-        self::assertTrue($result['duplicate']);
-        self::assertTrue($db->committed, 'A dedup hit still commits to release the lock');
-        self::assertFalse($db->rolledBack);
-        self::assertNull(
-            $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs'),
-            'A duplicate postback must NOT insert a second conversion row'
-        );
-    }
-
-    public function testIdempotencyLookupIsSkippedWhenNoTransactionId(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->dupRow = ['conv_id' => '42']; // would match, but must be ignored without a txid
-        $db->insertReturns = false;        // stop before the insert_id read
-
-        try {
-            p202RecordConversion($db, $this->log(), '', false, '', '');
-            self::fail('Expected RuntimeException from failing insert');
-        } catch (RuntimeException $e) {
-            // expected — we drove the insert to fail on purpose
-        }
-
-        self::assertNull(
-            $this->firstQueryContaining($db->queries, 'SELECT conv_id'),
-            'Without a transaction id there is no idempotency key, so no dedup lookup runs'
-        );
-    }
-
-    // --- Atomicity / no partial commits ---
-
-    public function testInsertFailureRollsBackInsteadOfCommitting(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->insertReturns = false;
-
-        $this->expectException(RuntimeException::class);
-        try {
-            p202RecordConversion($db, $this->log(), '', false, '', '');
-        } finally {
-            self::assertTrue($db->rolledBack, 'A failed conversion_logs insert must roll back the click update');
-            self::assertFalse($db->committed, 'Nothing may be committed when the insert fails');
-        }
-    }
-
-    public function testMissingSourceClickWritesNoOrphanConversion(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->clickRow = null; // FOR UPDATE finds nothing
-
-        $result = p202RecordConversion($db, $this->log(), '', false, '', 'ORDER-9');
-
-        self::assertSame(0, $result['conv_id']);
-        self::assertFalse($result['duplicate']);
-        self::assertTrue($db->rolledBack);
-        self::assertNull(
-            $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs'),
-            'No conversion row may be written for a click that no longer exists'
-        );
-    }
-
-    // --- Locking ---
-
-    public function testSourceClickIsLockedForUpdate(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->insertReturns = false;
-
-        try {
-            p202RecordConversion($db, $this->log(), '', false, '', '');
-        } catch (RuntimeException $e) {
-            // ignore — we only care about the lock query below
-        }
-
-        $lock = $this->firstQueryContaining($db->queries, 'FOR UPDATE');
-        self::assertNotNull($lock, 'The source click must be locked with SELECT ... FOR UPDATE');
-        self::assertStringContainsString('202_clicks', $lock);
-        self::assertStringContainsString('click_id = 100', $lock);
-    }
-
-    // --- transaction_id storage (NULL vs quoted) ---
-
-    public function testEmptyTransactionIdIsStoredAsNull(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->insertReturns = false;
-
-        try {
-            p202RecordConversion($db, $this->log(), '', false, '', '');
-        } catch (RuntimeException $e) {
-        }
-
-        $insert = $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs');
-        self::assertNotNull($insert);
-        self::assertStringContainsString('transaction_id = NULL', $insert);
-        self::assertStringNotContainsString("transaction_id = ''", $insert);
-    }
-
-    public function testTransactionIdIsEscapedInBothLookupAndInsert(): void
-    {
-        $db = new FakeRecordMysqli();
-        $db->insertReturns = false;
-
-        try {
-            p202RecordConversion($db, $this->log(), '', false, '', "ord'1");
-        } catch (RuntimeException $e) {
-        }
-
-        $lookup = $this->firstQueryContaining($db->queries, 'SELECT conv_id');
-        self::assertNotNull($lookup);
-        self::assertStringContainsString("transaction_id = 'ord\\'1'", $lookup);
-
-        $insert = $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs');
-        self::assertNotNull($insert);
-        self::assertStringContainsString("transaction_id = 'ord\\'1'", $insert);
-    }
-
-    // --- Input validation ---
+    // --- Input validation (guarded in the helper, before any DB work) ---
 
     public function testNonPositiveClickIdThrowsBeforeAnyDbWork(): void
     {
         $db = new FakeRecordMysqli();
-        $log = $this->log();
-        $log['click_id'] = 0;
 
         try {
-            p202RecordConversion($db, $log, '', false, '', '');
+            p202RecordConversion($db, ['click_id' => 0], '', false, '', '');
             self::fail('Expected InvalidArgumentException');
         } catch (InvalidArgumentException $e) {
-            self::assertSame([], $db->queries, 'No query should run for an invalid click id');
-            self::assertFalse($db->committed);
+            self::assertSame([], $db->queries, 'No query/connection work should happen for an invalid click id');
         }
     }
 
-    // --- p202ExtractTransactionId ---
+    // --- p202ExtractTransactionId (pure) ---
 
     public function testExtractTransactionIdReadsCommonKeys(): void
     {
@@ -236,106 +80,25 @@ final class RecordConversionTest extends TestCase
     {
         self::assertSame('xyz', p202ExtractTransactionId(['txid' => '  xyz  ']));
     }
-
-    // --- helpers ---
-
-    private function firstQueryContaining(array $queries, string $needle): ?string
-    {
-        foreach ($queries as $q) {
-            if (str_contains($q, $needle)) {
-                return $q;
-            }
-        }
-        return null;
-    }
 }
 
 /**
- * Fake mysqli_result returning canned rows; only fetch_assoc()/free() are used.
- */
-class FakeRecordResult extends \mysqli_result
-{
-    /** @var list<array<string,mixed>> */
-    private array $rows;
-
-    public function __construct(array $rows)
-    {
-        $this->rows = $rows;
-    }
-
-    #[\ReturnTypeWillChange]
-    public function fetch_assoc(): array|false|null
-    {
-        return array_shift($this->rows) ?? null;
-    }
-
-    #[\ReturnTypeWillChange]
-    public function free(): void
-    {
-    }
-}
-
-/**
- * Fake mysqli that records queries and serves canned results for the lock and
- * idempotency SELECTs, so p202RecordConversion can be exercised without a DB.
- * The success path (which reads the read-only $db->insert_id) is covered by the
- * integration suite; these unit tests drive the dedup / failure / lock paths.
+ * Minimal mysqli double: records any query() calls so the input-guard test can
+ * assert that an invalid click id short-circuits before any DB interaction.
  */
 class FakeRecordMysqli extends \mysqli
 {
     /** @var list<string> */
     public array $queries = [];
-    public bool $committed = false;
-    public bool $rolledBack = false;
-    public bool $insertReturns = true;
-
-    /** @var array<string,mixed>|null Row returned by the FOR UPDATE lock query. */
-    public ?array $clickRow = ['click_id' => '100'];
-    /** @var array<string,mixed>|null Row returned by the idempotency lookup. */
-    public ?array $dupRow = null;
 
     public function __construct()
     {
         // Skip parent constructor — no real connection.
     }
 
-    public function begin_transaction(int $flags = 0, ?string $name = null): bool
-    {
-        return true;
-    }
-
-    public function commit(int $flags = 0, ?string $name = null): bool
-    {
-        $this->committed = true;
-        return true;
-    }
-
-    public function rollback(int $flags = 0, ?string $name = null): bool
-    {
-        $this->rolledBack = true;
-        return true;
-    }
-
-    public function real_escape_string(string $string): string
-    {
-        return addslashes($string);
-    }
-
     public function query(string $query, int $result_mode = MYSQLI_STORE_RESULT): \mysqli_result|bool
     {
         $this->queries[] = $query;
-
-        if (str_contains($query, 'FOR UPDATE')) {
-            return new FakeRecordResult($this->clickRow !== null ? [$this->clickRow] : []);
-        }
-        if (str_contains($query, 'SELECT conv_id')) {
-            return new FakeRecordResult($this->dupRow !== null ? [$this->dupRow] : []);
-        }
-        if (str_starts_with(ltrim($query), 'INSERT')) {
-            return $this->insertReturns;
-        }
-
-        // UPDATE 202_clicks / 202_clicks_spy from p202ApplyConversionUpdate
         return true;
     }
 

--- a/tests/StaticEndpoint/RecordConversionTest.php
+++ b/tests/StaticEndpoint/RecordConversionTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StaticEndpoint;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use InvalidArgumentException;
+
+/**
+ * Tests for p202RecordConversion() and p202ExtractTransactionId() in
+ * static-endpoint-helpers.php.
+ *
+ * p202RecordConversion is the shared transactional + idempotent conversion writer
+ * used by the gpx/gpb/upx postback endpoints. Its job is to guarantee that a
+ * retried/replayed postback can never double-count, and that a click is never
+ * flagged converted without a matching audit row (no partial commits).
+ */
+final class RecordConversionTest extends TestCase
+{
+    private static bool $loaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists('DB', false)) {
+            eval('class DB {
+                private static $instance;
+                public static function getInstance() {
+                    if (!self::$instance) self::$instance = new self();
+                    return self::$instance;
+                }
+                public function getConnection() { return new \mysqli(); }
+            }');
+        }
+
+        if (!class_exists('DataEngine', false)) {
+            eval('class DataEngine {
+                public array $dirtyHourCalls = [];
+                public function setDirtyHour($click_id) { $this->dirtyHourCalls[] = $click_id; }
+                public function getSummary($s,$e,$p,$u=1,$up=false,$n=false) { return ""; }
+            }');
+        }
+
+        if (!self::$loaded) {
+            require_once __DIR__ . '/../../202-config/static-endpoint-helpers.php';
+            self::$loaded = true;
+        }
+    }
+
+    private function log(): array
+    {
+        return [
+            'click_id'        => 100,
+            'campaign_id'     => '7',
+            'user_id'         => '1',
+            'click_time'      => 1700000000,
+            'conv_time'       => 1700000100,
+            'time_difference' => '0 days, 0 hours, 1 min and 40 sec',
+            'ip'              => '203.0.113.9',
+            'pixel_type'      => 3,
+            'user_agent'      => 'UnitTest/1.0',
+        ];
+    }
+
+    // --- Idempotency / double-count protection ---
+
+    public function testDuplicateTransactionReturnsExistingConversionWithoutInserting(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->dupRow = ['conv_id' => '42'];
+
+        $result = p202RecordConversion($db, $this->log(), '', false, '', 'ORDER-123');
+
+        self::assertSame(42, $result['conv_id']);
+        self::assertTrue($result['duplicate']);
+        self::assertTrue($db->committed, 'A dedup hit still commits to release the lock');
+        self::assertFalse($db->rolledBack);
+        self::assertNull(
+            $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs'),
+            'A duplicate postback must NOT insert a second conversion row'
+        );
+    }
+
+    public function testIdempotencyLookupIsSkippedWhenNoTransactionId(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->dupRow = ['conv_id' => '42']; // would match, but must be ignored without a txid
+        $db->insertReturns = false;        // stop before the insert_id read
+
+        try {
+            p202RecordConversion($db, $this->log(), '', false, '', '');
+            self::fail('Expected RuntimeException from failing insert');
+        } catch (RuntimeException $e) {
+            // expected — we drove the insert to fail on purpose
+        }
+
+        self::assertNull(
+            $this->firstQueryContaining($db->queries, 'SELECT conv_id'),
+            'Without a transaction id there is no idempotency key, so no dedup lookup runs'
+        );
+    }
+
+    // --- Atomicity / no partial commits ---
+
+    public function testInsertFailureRollsBackInsteadOfCommitting(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->insertReturns = false;
+
+        $this->expectException(RuntimeException::class);
+        try {
+            p202RecordConversion($db, $this->log(), '', false, '', '');
+        } finally {
+            self::assertTrue($db->rolledBack, 'A failed conversion_logs insert must roll back the click update');
+            self::assertFalse($db->committed, 'Nothing may be committed when the insert fails');
+        }
+    }
+
+    public function testMissingSourceClickWritesNoOrphanConversion(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->clickRow = null; // FOR UPDATE finds nothing
+
+        $result = p202RecordConversion($db, $this->log(), '', false, '', 'ORDER-9');
+
+        self::assertSame(0, $result['conv_id']);
+        self::assertFalse($result['duplicate']);
+        self::assertTrue($db->rolledBack);
+        self::assertNull(
+            $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs'),
+            'No conversion row may be written for a click that no longer exists'
+        );
+    }
+
+    // --- Locking ---
+
+    public function testSourceClickIsLockedForUpdate(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->insertReturns = false;
+
+        try {
+            p202RecordConversion($db, $this->log(), '', false, '', '');
+        } catch (RuntimeException $e) {
+            // ignore — we only care about the lock query below
+        }
+
+        $lock = $this->firstQueryContaining($db->queries, 'FOR UPDATE');
+        self::assertNotNull($lock, 'The source click must be locked with SELECT ... FOR UPDATE');
+        self::assertStringContainsString('202_clicks', $lock);
+        self::assertStringContainsString('click_id = 100', $lock);
+    }
+
+    // --- transaction_id storage (NULL vs quoted) ---
+
+    public function testEmptyTransactionIdIsStoredAsNull(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->insertReturns = false;
+
+        try {
+            p202RecordConversion($db, $this->log(), '', false, '', '');
+        } catch (RuntimeException $e) {
+        }
+
+        $insert = $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs');
+        self::assertNotNull($insert);
+        self::assertStringContainsString('transaction_id = NULL', $insert);
+        self::assertStringNotContainsString("transaction_id = ''", $insert);
+    }
+
+    public function testTransactionIdIsEscapedInBothLookupAndInsert(): void
+    {
+        $db = new FakeRecordMysqli();
+        $db->insertReturns = false;
+
+        try {
+            p202RecordConversion($db, $this->log(), '', false, '', "ord'1");
+        } catch (RuntimeException $e) {
+        }
+
+        $lookup = $this->firstQueryContaining($db->queries, 'SELECT conv_id');
+        self::assertNotNull($lookup);
+        self::assertStringContainsString("transaction_id = 'ord\\'1'", $lookup);
+
+        $insert = $this->firstQueryContaining($db->queries, 'INSERT INTO 202_conversion_logs');
+        self::assertNotNull($insert);
+        self::assertStringContainsString("transaction_id = 'ord\\'1'", $insert);
+    }
+
+    // --- Input validation ---
+
+    public function testNonPositiveClickIdThrowsBeforeAnyDbWork(): void
+    {
+        $db = new FakeRecordMysqli();
+        $log = $this->log();
+        $log['click_id'] = 0;
+
+        try {
+            p202RecordConversion($db, $log, '', false, '', '');
+            self::fail('Expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            self::assertSame([], $db->queries, 'No query should run for an invalid click id');
+            self::assertFalse($db->committed);
+        }
+    }
+
+    // --- p202ExtractTransactionId ---
+
+    public function testExtractTransactionIdReadsCommonKeys(): void
+    {
+        self::assertSame('abc', p202ExtractTransactionId(['txid' => 'abc']));
+        self::assertSame('def', p202ExtractTransactionId(['transaction_id' => 'def']));
+        self::assertSame('ghi', p202ExtractTransactionId(['orderid' => 'ghi']));
+        self::assertSame('123', p202ExtractTransactionId(['oid' => 123]));
+    }
+
+    public function testExtractTransactionIdPrefersTxidOverOtherKeys(): void
+    {
+        self::assertSame('first', p202ExtractTransactionId([
+            'txid' => 'first',
+            'transaction_id' => 'second',
+            'orderid' => 'third',
+        ]));
+    }
+
+    public function testExtractTransactionIdReturnsEmptyWhenAbsentOrBlank(): void
+    {
+        self::assertSame('', p202ExtractTransactionId([]));
+        self::assertSame('', p202ExtractTransactionId(['txid' => '   ']));
+        self::assertSame('', p202ExtractTransactionId(['unrelated' => 'x']));
+    }
+
+    public function testExtractTransactionIdTrimsWhitespace(): void
+    {
+        self::assertSame('xyz', p202ExtractTransactionId(['txid' => '  xyz  ']));
+    }
+
+    // --- helpers ---
+
+    private function firstQueryContaining(array $queries, string $needle): ?string
+    {
+        foreach ($queries as $q) {
+            if (str_contains($q, $needle)) {
+                return $q;
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * Fake mysqli_result returning canned rows; only fetch_assoc()/free() are used.
+ */
+class FakeRecordResult extends \mysqli_result
+{
+    /** @var list<array<string,mixed>> */
+    private array $rows;
+
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function fetch_assoc(): array|false|null
+    {
+        return array_shift($this->rows) ?? null;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function free(): void
+    {
+    }
+}
+
+/**
+ * Fake mysqli that records queries and serves canned results for the lock and
+ * idempotency SELECTs, so p202RecordConversion can be exercised without a DB.
+ * The success path (which reads the read-only $db->insert_id) is covered by the
+ * integration suite; these unit tests drive the dedup / failure / lock paths.
+ */
+class FakeRecordMysqli extends \mysqli
+{
+    /** @var list<string> */
+    public array $queries = [];
+    public bool $committed = false;
+    public bool $rolledBack = false;
+    public bool $insertReturns = true;
+
+    /** @var array<string,mixed>|null Row returned by the FOR UPDATE lock query. */
+    public ?array $clickRow = ['click_id' => '100'];
+    /** @var array<string,mixed>|null Row returned by the idempotency lookup. */
+    public ?array $dupRow = null;
+
+    public function __construct()
+    {
+        // Skip parent constructor — no real connection.
+    }
+
+    public function begin_transaction(int $flags = 0, ?string $name = null): bool
+    {
+        return true;
+    }
+
+    public function commit(int $flags = 0, ?string $name = null): bool
+    {
+        $this->committed = true;
+        return true;
+    }
+
+    public function rollback(int $flags = 0, ?string $name = null): bool
+    {
+        $this->rolledBack = true;
+        return true;
+    }
+
+    public function real_escape_string(string $string): string
+    {
+        return addslashes($string);
+    }
+
+    public function query(string $query, int $result_mode = MYSQLI_STORE_RESULT): \mysqli_result|bool
+    {
+        $this->queries[] = $query;
+
+        if (str_contains($query, 'FOR UPDATE')) {
+            return new FakeRecordResult($this->clickRow !== null ? [$this->clickRow] : []);
+        }
+        if (str_contains($query, 'SELECT conv_id')) {
+            return new FakeRecordResult($this->dupRow !== null ? [$this->dupRow] : []);
+        }
+        if (str_starts_with(ltrim($query), 'INSERT')) {
+            return $this->insertReturns;
+        }
+
+        // UPDATE 202_clicks / 202_clicks_spy from p202ApplyConversionUpdate
+        return true;
+    }
+
+    public function close(): true
+    {
+        return true;
+    }
+}

--- a/tracking202/redirect/dl.php
+++ b/tracking202/redirect/dl.php
@@ -460,33 +460,8 @@ $mysql['ip_id'] = $db->real_escape_string((string)$ip_id);
 $ip_address = $ip;
 $user_id = $tracker_row['user_id'];
 
-//GEO Lookup
-$GeoData = getGeoData($ip_address);
-$countryName = $GeoData['country'] ?? '';
-$countryCode = $GeoData['country_code'] ?? '';
-$country_id = $locationRepo->findOrCreateCountry($countryName, $countryCode);
-$mysql['country_id'] = $db->real_escape_string((string)$country_id);
-
-$regionName = $GeoData['region'] ?? '';
-$region_id = $locationRepo->findOrCreateRegion($regionName, $country_id);
-$mysql['region_id'] = $db->real_escape_string((string)$region_id);
-
-$cityName = $GeoData['city'] ?? '';
-$city_id = $locationRepo->findOrCreateCity($cityName, $country_id);
-$mysql['city_id'] = $db->real_escape_string((string)$city_id);
-
-
-// Initialize isp_id with default value
-$mysql['isp_id'] = '0';
-if ($tracker_row['maxmind_isp'] == '1') {
-	$IspData = getIspData($ip_address);
-	if (is_string($IspData)) {
-		$IspDataParts = explode(',', $IspData);
-		$IspData = $IspDataParts[0];
-	}
-	$isp_id = $locationRepo->findOrCreateIsp($IspData);
-	$mysql['isp_id'] = $db->real_escape_string((string)$isp_id);
-}
+// GEO/ISP (MaxMind) lookups are deferred into $computeAndRecordClick so the slow
+// database reads stay off the redirect critical path for non-cloaked clicks.
 
 if ($device_id['type'] == '4') {
 	$mysql['click_filtered'] = '1';
@@ -533,7 +508,27 @@ if ($cloaking_on === true) {
 }
 
 // Helper: compute remaining click data and record
-$computeAndRecordClick = function () use (&$mysql, $custom_var_ids, $trackingRepo, $locationRepo, $tracker_row, $referer_query, $redirect_site_url, $click_id, $clickRepo, $cloaking_on, $cloaking_site_url): void {
+$computeAndRecordClick = function () use (&$mysql, $custom_var_ids, $trackingRepo, $locationRepo, $tracker_row, $referer_query, $redirect_site_url, $click_id, $clickRepo, $cloaking_on, $cloaking_site_url, $ip_address): void {
+	// GEO lookup (deferred here so MaxMind reads stay off the redirect hot path)
+	$GeoData = getGeoData($ip_address);
+	$country_id = $locationRepo->findOrCreateCountry($GeoData['country'] ?? '', $GeoData['country_code'] ?? '');
+	$mysql['country_id'] = (string) $country_id;
+	$region_id = $locationRepo->findOrCreateRegion($GeoData['region'] ?? '', $country_id);
+	$mysql['region_id'] = (string) $region_id;
+	$city_id = $locationRepo->findOrCreateCity($GeoData['city'] ?? '', $country_id);
+	$mysql['city_id'] = (string) $city_id;
+
+	// ISP lookup (MaxMind; only when the tracker enables it)
+	$mysql['isp_id'] = '0';
+	if ($tracker_row['maxmind_isp'] == '1') {
+		$IspData = getIspData($ip_address);
+		if (is_string($IspData)) {
+			$IspDataParts = explode(',', $IspData);
+			$IspData = $IspDataParts[0];
+		}
+		$mysql['isp_id'] = (string) $locationRepo->findOrCreateIsp($IspData);
+	}
+
 	// Compute variable_set_id
 	$total_vars = count($custom_var_ids);
 	if ($total_vars > 0) {

--- a/tracking202/redirect/dl.php
+++ b/tracking202/redirect/dl.php
@@ -635,7 +635,11 @@ if ($mysql['click_cpa'] != NULL) {
 	$insert_sql = "INSERT INTO 202_cpa_trackers
                                    SET         click_id='" . $mysql['click_id'] . "',
                                                            tracker_id_public='" . $mysql['tracker_id_public'] . "'";
-	$insert_result = $db->query($insert_sql);
+	// Post-redirect: the visitor is already gone, so log a failure instead of
+	// dying (which would abandon the remaining bookkeeping below).
+	if ($db->query($insert_sql) === false) {
+		error_log('dl.php: failed to insert cpa_tracker for click ' . $mysql['click_id'] . ': ' . $db->error);
+	}
 }
 
 //set dirty hour
@@ -644,5 +648,8 @@ $data = ($de->setDirtyHour($mysql['click_id']));
 
 if (isset($_COOKIE['p202_ipx'])) {
 	$mysql['p202_ipx'] = $db->real_escape_string($_COOKIE['p202_ipx']);
-	$db->query("UPDATE 202_clicks_impressions SET click_id = '" . $mysql['click_id'] . "' WHERE impression_id = '" . $mysql['p202_ipx'] . "'");
+	$impression_sql = "UPDATE 202_clicks_impressions SET click_id = '" . $mysql['click_id'] . "' WHERE impression_id = '" . $mysql['p202_ipx'] . "'";
+	if ($db->query($impression_sql) === false) {
+		error_log('dl.php: failed to link impression ' . $mysql['p202_ipx'] . ' to click ' . $mysql['click_id'] . ': ' . $db->error);
+	}
 }

--- a/tracking202/redirect/lp.php
+++ b/tracking202/redirect/lp.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 $vars=$_GET;
 #only allow numeric t202ids
-$lpip = $_GET['lpip']; 
+$lpip = $_GET['lpip'] ?? '';
 if (!is_numeric($lpip)) die();
 
 # check to see if mysql connection works, if not fail over to cached stored redirect urls
@@ -109,10 +109,18 @@ if ($memcacheWorking) {
 }
 
 //grab the GET variables from the LANDING PAGE
-$landing_page_site_url_address_parsed = parse_url((string) $_SERVER['HTTP_REFERER']);  
-parse_str($landing_page_site_url_address_parsed['query'], $_GET);       
+// Only overwrite $_GET when the referer actually carries a query string —
+// otherwise parse_str('') would wipe every incoming parameter (losing the
+// landing page's tracking data) and warn on the missing 'query' key.
+$landing_page_site_url_address_parsed = parse_url((string) ($_SERVER['HTTP_REFERER'] ?? ''));
+$landing_page_query = is_array($landing_page_site_url_address_parsed)
+	? ($landing_page_site_url_address_parsed['query'] ?? '')
+	: '';
+if ($landing_page_query !== '') {
+	parse_str($landing_page_query, $_GET);
+}
 
-if ($_GET['t202id']) { 
+if (!empty($_GET['t202id'])) {
 	//grab tracker data if avaliable
 	$mysql['tracker_id_public'] = $db->real_escape_string((string)$_GET['t202id']);
 

--- a/tracking202/redirect/off.php
+++ b/tracking202/redirect/off.php
@@ -6,7 +6,7 @@ ob_start();
 // only allow numeric acip's
 
 $urlvarslist = $_GET;
-$acip = $_GET['acip'];
+$acip = $_GET['acip'] ?? '';
 
     
 
@@ -227,12 +227,29 @@ $info_sql = "
 ";
 
 $info_row = memcache_mysql_fetch_assoc($db, $info_sql);
+
+// Guard BEFORE dereferencing: the public click id / campaign combo may not
+// exist (expired, mistyped, or a DB hiccup). Never crash the redirect — fall
+// back to the cached outbound url for this campaign if we have one.
+if (!$info_row || !isset($info_row['click_id'])) {
+    if ($memcacheWorking) {
+        $getUrl = $memcache->get(md5('ac_' . $acip . systemHash()));
+        if ($getUrl) {
+            $urlvars = getPrePopVars($urlvarslist);
+            $new_url = setPrePopVars($urlvars, str_replace('[[subid]]', 'p202', $getUrl), false);
+            header('location: ' . $new_url);
+            die();
+        }
+    }
+    die();
+}
+
 // cache the url for later use if db is down
 if ($memcacheWorking) {
-    
-    $url = $tracker_row['aff_campaign_url'] . "&subid=p202";
+
+    $url = $info_row['aff_campaign_url'] . "&subid=p202";
     $tid = $acip;
-    
+
     $getKey = $memcache->get(md5('ac_' . $tid . systemHash()));
     if ($getKey === false) {
         $setUrl = setCache(md5('ac_' . $tid . systemHash()), $url, 0);

--- a/tracking202/redirect/pci.php
+++ b/tracking202/redirect/pci.php
@@ -3,7 +3,11 @@ declare(strict_types=1);
 include_once(substr(__DIR__, 0,-21) . '/202-config/connect2.php');
 include_once(substr(__DIR__, 0,-21) . '/202-config/class-dataengine-slim.php');
 
-$mysql['click_id_public'] = $db->real_escape_string((string)$_GET['pci']);
+$pci = $_GET['pci'] ?? '';
+if (!is_numeric($pci)) {
+	die();
+}
+$mysql['click_id_public'] = $db->real_escape_string((string)$pci);
 
 $click_sql = "
 	SELECT
@@ -21,6 +25,11 @@ $click_sql = "
 ";
 $click_row = memcache_mysql_fetch_assoc($db, $click_sql);
 
+// Guard BEFORE dereferencing: an unknown/expired public click id must not crash
+// the cloaked confirmation redirect.
+if (!$click_row || !isset($click_row['click_id'])) {
+	die();
+}
 
 $click_id = $click_row['click_id'];
 $aff_campaign_id = $click_row['aff_campaign_id'];
@@ -40,13 +49,13 @@ if ($click_row['click_cloaking'] == 1) {
 	$mysql['site_url_id'] = $db->real_escape_string((string) $click_row['click_cloaking_site_url_id']);
 	$site_url_sql = "SELECT site_url_address FROM 202_site_urls WHERE site_url_id='".$mysql['site_url_id']."' limit 1";
 	$site_url_row = memcache_mysql_fetch_assoc($db, $site_url_sql);
-	$cloaking_site_url = $site_url_row['site_url_address'];
+	$cloaking_site_url = $site_url_row['site_url_address'] ?? '';
 } else {
 	$cloaking_on = false;
 	$mysql['site_url_id'] = $db->real_escape_string((string) $click_row['click_redirect_site_url_id']);
 	$site_url_sql = "SELECT site_url_address FROM 202_site_urls WHERE site_url_id='".$mysql['site_url_id']."' limit 1";
 	$site_url_row = memcache_mysql_fetch_assoc($db, $site_url_sql);
-	$redirect_site_url = $site_url_row['site_url_address'];  	
+	$redirect_site_url = $site_url_row['site_url_address'] ?? '';
 }
 
 
@@ -58,9 +67,9 @@ $de = new DataEngine();
 $data=($de->setDirtyHour($mysql['click_id']));
 	
 //now we've updated, lets redirect
-if ($cloaking_on == true) {
-	//if cloaked, redirect them to the cloaked site. 
-	header ('location: '.$cloaking_site_url);    
-} else {
-	header ('location: '.$redirect_site_url);        
+$target = ($cloaking_on == true) ? ($cloaking_site_url ?? '') : ($redirect_site_url ?? '');
+if ($target === '') {
+	// No destination url on file for this click; don't emit a broken redirect.
+	die();
 }
+header('location: ' . $target);

--- a/tracking202/redirect/rtr.php
+++ b/tracking202/redirect/rtr.php
@@ -61,6 +61,21 @@ $rotator_sql = "SELECT  tr.user_id,
 				LEFT JOIN 202_users_pref AS up ON up.user_id = tr.user_id
 				WHERE   tracker_id_public='".$mysql['tracker_id_public']."'"; 
 $rotator_row = memcache_mysql_fetch_assoc($db, $rotator_sql);
+
+// Guard BEFORE dereferencing: a missing row (unknown tracker, DB hiccup, or
+// stale cache) must never crash the redirect. Fall back to the cached default
+// url so the visitor still lands somewhere instead of losing the click.
+if (!$rotator_row) {
+	if ($memcacheWorking) {
+		$getUrl = $memcache->get(md5("default_url" . $tracker_id . systemHash()));
+		if ($getUrl) {
+			header('location: ' . $getUrl);
+			die();
+		}
+	}
+	die();
+}
+
 $user_id = $db->real_escape_string((string)$rotator_row['user_id']);
 $user_keyword_searched_or_bidded = $db->real_escape_string($rotator_row['user_keyword_searched_or_bidded']);
 
@@ -68,9 +83,8 @@ $user_keyword_searched_or_bidded = $db->real_escape_string($rotator_row['user_ke
 $mysql['rotator_id'] = $db->real_escape_string((string)$rotator_row['rotator_id']);
 $rule_sql = "SELECT ru.id as rule_id
 			 FROM 202_rotator_rules AS ru
-			 WHERE rotator_id='".$mysql['rotator_id']."' AND status='1'"; 
+			 WHERE rotator_id='".$mysql['rotator_id']."' AND status='1'";
 $rule_row = foreach_memcache_mysql_fetch_assoc($db, $rule_sql);
-if (!$rotator_row) die();
 
 AUTH::set_timezone($rotator_row['user_timezone']);
 

--- a/tracking202/static/cb202.php
+++ b/tracking202/static/cb202.php
@@ -75,13 +75,15 @@ if (function_exists('openssl_decrypt')) {
 
         $mysql['click_cpa'] = $db->real_escape_string((string) ($cpa_row['click_cpa'] ?? ''));
 
-        p202ApplyConversionUpdate(
+        if (!p202ApplyConversionUpdate(
             $db,
             (string) $mysql['click_id'],
             (string) $mysql['click_cpa'],
             true,
             (string) $mysql['click_payout']
-        );
+        )) {
+            error_log('cb202: failed to apply conversion update for click ' . $mysql['click_id']);
+        }
     }
 
 } else {

--- a/tracking202/static/cb202.php
+++ b/tracking202/static/cb202.php
@@ -9,46 +9,72 @@ $mysql['user_id'] = 1;
 $slack = false;
 $user_sql = "SELECT 2u.user_name as username, 2up.user_slack_incoming_webhook as url, 2up.cb_key AS cb_key FROM 202_users AS 2u INNER JOIN 202_users_pref AS 2up ON (2up.user_id = 1) WHERE 2u.user_id = '".$mysql['user_id']."'";
 $user_results = $db->query($user_sql);
+if ($user_results === false) {
+    p202RespondJsonError(500, 'User lookup failed');
+}
 $user_row = $user_results->fetch_assoc();
+if (!$user_row) {
+    p202RespondJsonError(404, 'User not found');
+}
 
-if (!empty($user_row['url'])) 
+if (!empty($user_row['url']))
     $slack = new Slack($user_row['url']);
 
 if (function_exists('openssl_decrypt')) {
-    $message = json_decode(file_get_contents('php://input'));
+    // Reject malformed input loudly instead of fataling on a null/!object payload.
+    $rawInput = file_get_contents('php://input');
+    if ($rawInput === false || $rawInput === '') {
+        p202RespondJsonError(400, 'Empty request body');
+    }
+    $message = json_decode($rawInput);
+    if (!is_object($message) || !isset($message->notification, $message->iv)) {
+        p202RespondJsonError(400, 'Malformed notification payload');
+    }
     $encrypted = $message->{'notification'};
     $iv = $message->{'iv'};
-    $decrypted = trim(
-        openssl_decrypt(
-            base64_decode((string) $encrypted),
-            'AES-128-CBC',
-            substr(sha1((string) $user_row['cb_key']), 0, 32),
-            OPENSSL_RAW_DATA,
-            base64_decode((string) $iv)
-        ),
-        "\0..\32"
+    $decrypted = openssl_decrypt(
+        base64_decode((string) $encrypted),
+        'AES-128-CBC',
+        substr(sha1((string) $user_row['cb_key']), 0, 32),
+        OPENSSL_RAW_DATA,
+        base64_decode((string) $iv)
     );
+    if ($decrypted === false) {
+        p202RespondJsonError(400, 'Unable to decrypt notification');
+    }
+    $decrypted = trim($decrypted, "\0..\32");
     $order = json_decode($decrypted, true);
+    if (!is_array($order) || !isset($order['transactionType'])) {
+        p202RespondJsonError(400, 'Malformed order payload');
+    }
 
     if ($order['transactionType'] == 'TEST') {
         $user_sql = "UPDATE 202_users_pref
                      SET cb_verified=1
                      WHERE user_id='".$mysql['user_id']."'";
-        $user_results = $db->query($user_sql);
+        if (!$db->query($user_sql)) {
+            p202RespondJsonError(500, 'Failed to record verification');
+        }
 
-        if ($slack) 
+        if ($slack)
             $slack->push('cb_key_verified', []);
 
     } else if($order['transactionType'] == 'SALE') {
+        if (!isset($order['trackingCodes'][0]) || !is_numeric($order['trackingCodes'][0])) {
+            p202RespondJsonError(400, 'Missing tracking code');
+        }
         $mysql['click_id'] = $db->real_escape_string((string) $order['trackingCodes'][0]);
-        $mysql['click_payout'] = $db->real_escape_string((string) $order['totalAccountAmount']);
+        $mysql['click_payout'] = $db->real_escape_string((string) ($order['totalAccountAmount'] ?? '0'));
 
         $cpa_sql = "SELECT 202_cpa_trackers.tracker_id_public, 202_trackers.click_cpa FROM 202_cpa_trackers LEFT JOIN 202_trackers USING (tracker_id_public) WHERE click_id = '".$mysql['click_id']."'";
         $cpa_result = $db->query($cpa_sql);
+        if ($cpa_result === false) {
+            p202RespondJsonError(500, 'CPA lookup failed');
+        }
         $cpa_row = $cpa_result->fetch_assoc();
 
         $mysql['click_cpa'] = $db->real_escape_string((string) ($cpa_row['click_cpa'] ?? ''));
-                
+
         p202ApplyConversionUpdate(
             $db,
             (string) $mysql['click_id'],

--- a/tracking202/static/gpb.php
+++ b/tracking202/static/gpb.php
@@ -109,7 +109,13 @@ LIMIT 1";
 
 
 $cvar_sql_result = $db->query($cvar_sql);
+if ($cvar_sql_result === false) {
+	p202RespondJsonError(500, 'Click lookup failed');
+}
 $cvar_sql_row = $cvar_sql_result->fetch_assoc();
+if (!$cvar_sql_row) {
+	p202RespondJsonError(404, 'Click data not found');
+}
 $mysql['t202kw'] = $db->real_escape_string($cvar_sql_row['keyword']);
 $mysql['c1'] = $db->real_escape_string($cvar_sql_row['c1']);
 $mysql['c2'] = $db->real_escape_string($cvar_sql_row['c2']);
@@ -236,39 +242,45 @@ if($mysql['ppc_account_id']){
 if (is_numeric($mysql['click_id'])) {
 
 	$conv_time = time();
-	$click_time_to_date = new DateTime(date('Y-m-d H:i:s', $mysql['click_time']));
+	$click_time_raw = (int) ($cvar_sql_row['click_time'] ?? 0);
+	$click_time_to_date = new DateTime(date('Y-m-d H:i:s', $click_time_raw));
 	$conv_time_to_date = new DateTime(date('Y-m-d H:i:s', $conv_time));
 	$diff = $click_time_to_date->diff($conv_time_to_date);
-	$mysql['time_difference'] =  $db->real_escape_string($diff->d.' days, '.$diff->h.' hours, '.$diff->i.' min and '.$diff->s.' sec');
-	$mysql['conv_time'] = $db->real_escape_string($conv_time);
-	$mysql['ip'] = $db->real_escape_string($_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '');
-	$mysql['user_agent'] = $db->real_escape_string($_SERVER['HTTP_USER_AGENT'] ?? '');
+	$time_difference = $diff->d.' days, '.$diff->h.' hours, '.$diff->i.' min and '.$diff->s.' sec';
+	$mysql['conv_time'] = $conv_time;
 
 			if (array_key_exists('amount', $_GET) && is_numeric($_GET['amount'])) {
 				$mysql['use_pixel_payout'] = 1;
 				$mysql['click_payout'] = $db->real_escape_string((string)$_GET['amount']);
 			}
-		p202ApplyConversionUpdate(
+
+		// payout to record: pixel amount override if present, otherwise the click's own payout
+		$click_payout_for_log = ($mysql['use_pixel_payout'] == 1)
+			? (string) ($_GET['amount'] ?? '0')
+			: (string) ($cvar_sql_row['click_payout'] ?? '0');
+
+		// Atomic + idempotent: locks the click, dedupes on transaction id, and
+		// applies the click update and conversion_logs insert in one transaction.
+		$conversionResult = p202RecordConversion(
 			$db,
-			(string) $mysql['click_id'],
-			(string) $mysql['click_cpa'],
+			[
+				'click_id'        => (int) $mysql['click_id'],
+				'campaign_id'     => (string) ($cvar_sql_row['aff_campaign_id'] ?? '0'),
+				'user_id'         => (string) ($cvar_sql_row['user_id'] ?? '0'),
+				'click_time'      => $click_time_raw,
+				'conv_time'       => $conv_time,
+				'time_difference' => $time_difference,
+				'ip'              => $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '',
+				'pixel_type'      => 2,
+				'user_agent'      => $_SERVER['HTTP_USER_AGENT'] ?? '',
+				'click_payout'    => $click_payout_for_log,
+			],
+			(string) ($cvar_sql_row['click_cpa'] ?? ''),
 			$mysql['use_pixel_payout'] == 1,
-			(string) ($mysql['click_payout'] ?? '')
+			($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '') : '',
+			p202ExtractTransactionId($_GET)
 		);
-		
-		$log_sql = "INSERT INTO 202_conversion_logs
-				SET conv_id = DEFAULT,
-					click_id = '".$mysql['click_id']."',
-					campaign_id = '".$mysql['campaign_id']."',
-					user_id = '".$mysql['click_user_id']."',
-					click_time = '".$mysql['click_time']."',
-					conv_time = '".$mysql['conv_time']."',
-					time_difference = '".$mysql['time_difference']."',
-					ip = '".$mysql['ip']."',
-					pixel_type = '2',
-					user_agent = '".$mysql['user_agent']."'";
-        $db->query($log_sql);
-        $conversionId = (int) $db->insert_id;
+		$conversionId = $conversionResult['conv_id'];
 	        $advertiserId = p202ResolveAdvertiserId($db, (int) $mysql['campaign_id']);
 
         if ($conversionId > 0) {

--- a/tracking202/static/gpb.php
+++ b/tracking202/static/gpb.php
@@ -261,6 +261,8 @@ if (is_numeric($mysql['click_id'])) {
 
 		// Atomic + idempotent: locks the click, dedupes on transaction id, and
 		// applies the click update and conversion_logs insert in one transaction.
+		$conversionResult = ['conv_id' => 0, 'duplicate' => false];
+		try {
 		$conversionResult = p202RecordConversion(
 			$db,
 			[
@@ -280,10 +282,13 @@ if (is_numeric($mysql['click_id'])) {
 			($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '') : '',
 			p202ExtractTransactionId($_GET)
 		);
+		} catch (\Throwable $conversionError) {
+			error_log('gpb: conversion recording failed for click ' . $mysql['click_id'] . ': ' . $conversionError->getMessage());
+		}
 		$conversionId = $conversionResult['conv_id'];
 	        $advertiserId = p202ResolveAdvertiserId($db, (int) $mysql['campaign_id']);
 
-        if ($conversionId > 0) {
+        if ($conversionId > 0 && !$conversionResult['duplicate']) {
                 $scope = [
                         'user_id' => (int) $mysql['click_user_id'],
                         'campaign_id' => (int) $mysql['campaign_id'],

--- a/tracking202/static/gpx.php
+++ b/tracking202/static/gpx.php
@@ -76,7 +76,15 @@ if (is_numeric($mysql['click_id'])) {
 				LEFT JOIN 202_trackers USING (tracker_id_public)  
 				WHERE click_id = '".$mysql['click_id']."'";
 	$cpa_result = $db->query($cpa_sql);
+	if ($cpa_result === false) {
+		error_log('gpx: cpa lookup failed: ' . $db->error);
+		return;
+	}
 	$cpa_row = $cpa_result->fetch_assoc();
+	if (!$cpa_row) {
+		// Unknown click id; nothing to convert.
+		return;
+	}
 
         if (!$cpa_row['click_lead']) {
 
@@ -86,52 +94,52 @@ if (is_numeric($mysql['click_id'])) {
                 $mysql['click_time'] = $db->real_escape_string((string) ($cpa_row['click_time'] ?? '0'));
 
 		$conv_time = time();
-		$click_time_to_date = new DateTime(date('Y-m-d H:i:s', (int) $mysql['click_time']));
+		$click_time_raw = (int) ($cpa_row['click_time'] ?? 0);
+		$click_time_to_date = new DateTime(date('Y-m-d H:i:s', $click_time_raw));
 		$conv_time_to_date = new DateTime(date('Y-m-d H:i:s', (int) $conv_time));
 		$diff = $click_time_to_date->diff($conv_time_to_date);
-		$mysql['time_difference'] =  $db->real_escape_string($diff->d.' days, '.$diff->h.' hours, '.$diff->i.' min and '.$diff->s.' sec');
-		$mysql['conv_time'] = $db->real_escape_string((string) $conv_time);
-		$mysql['ip'] = $db->real_escape_string($_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '');
-		$mysql['user_agent'] = $db->real_escape_string($_SERVER['HTTP_USER_AGENT'] ?? '');
-		
+		$time_difference = $diff->d.' days, '.$diff->h.' hours, '.$diff->i.' min and '.$diff->s.' sec';
+		$mysql['conv_time'] = $conv_time;
+
 		$mysql['click_cpa'] = $db->real_escape_string((string) ($cpa_row['click_cpa'] ?? ''));
-	
+
 			if (array_key_exists('amount', $_GET) && is_numeric($_GET['amount'])) {
 				$mysql['use_pixel_payout'] = 1;
 				$mysql['click_payout'] = $db->real_escape_string((string)$_GET['amount']);
 			}
-			p202ApplyConversionUpdate(
-				$db,
-				(string) $mysql['click_id'],
-				(string) $mysql['click_cpa'],
-				$mysql['use_pixel_payout'] == 1,
-				(string) ($mysql['click_payout'] ?? '')
-			);
 
-		// Get click_payout for conversion log
-		$click_payout_for_log = $mysql['click_payout'] ?? '0';
-		if (!$mysql['use_pixel_payout']) {
-			$payout_sql = "SELECT click_payout FROM 202_clicks WHERE click_id = '".$mysql['click_id']."'";
+		// payout to record: pixel amount override if present, otherwise the click's own payout
+		$click_payout_for_log = ($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '0') : '0';
+		if ($mysql['use_pixel_payout'] != 1) {
+			$payout_sql = "SELECT click_payout FROM 202_clicks WHERE click_id = " . (int) $mysql['click_id'];
 			$payout_result = $db->query($payout_sql);
 			if ($payout_result && $payout_row = $payout_result->fetch_assoc()) {
-				$click_payout_for_log = $db->real_escape_string($payout_row['click_payout']);
+				$click_payout_for_log = (string) $payout_row['click_payout'];
 			}
 		}
 
-		$log_sql = "INSERT INTO 202_conversion_logs
-				SET conv_id = DEFAULT,
-					click_id = '".$mysql['click_id']."',
-					campaign_id = '".$mysql['campaign_id']."',
-					click_payout = '".$click_payout_for_log."',
-					user_id = '".$mysql['click_user_id']."',
-					click_time = '".$mysql['click_time']."',
-					conv_time = '".$mysql['conv_time']."',
-					time_difference = '".$mysql['time_difference']."',
-					ip = '".$mysql['ip']."',
-					pixel_type = '1',
-					user_agent = '".$mysql['user_agent']."'";
-                $db->query($log_sql);
-                $conversionId = (int) $db->insert_id;
+		// Atomic + idempotent: locks the click, dedupes on transaction id, and
+		// applies the click update and conversion_logs insert in one transaction.
+		$conversionResult = p202RecordConversion(
+			$db,
+			[
+				'click_id'        => (int) $mysql['click_id'],
+				'campaign_id'     => (string) ($cpa_row['aff_campaign_id'] ?? '0'),
+				'user_id'         => (string) ($cpa_row['user_id'] ?? '0'),
+				'click_time'      => $click_time_raw,
+				'conv_time'       => $conv_time,
+				'time_difference' => $time_difference,
+				'ip'              => $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '',
+				'pixel_type'      => 1,
+				'user_agent'      => $_SERVER['HTTP_USER_AGENT'] ?? '',
+				'click_payout'    => $click_payout_for_log,
+			],
+			(string) ($cpa_row['click_cpa'] ?? ''),
+			$mysql['use_pixel_payout'] == 1,
+			($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '') : '',
+			p202ExtractTransactionId($_GET)
+		);
+		$conversionId = $conversionResult['conv_id'];
 
                 if ($conversionId > 0) {
                         $scope = [

--- a/tracking202/static/gpx.php
+++ b/tracking202/static/gpx.php
@@ -120,6 +120,8 @@ if (is_numeric($mysql['click_id'])) {
 
 		// Atomic + idempotent: locks the click, dedupes on transaction id, and
 		// applies the click update and conversion_logs insert in one transaction.
+		$conversionResult = ['conv_id' => 0, 'duplicate' => false];
+		try {
 		$conversionResult = p202RecordConversion(
 			$db,
 			[
@@ -139,9 +141,12 @@ if (is_numeric($mysql['click_id'])) {
 			($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '') : '',
 			p202ExtractTransactionId($_GET)
 		);
+		} catch (\Throwable $conversionError) {
+			error_log('gpx: conversion recording failed for click ' . $mysql['click_id'] . ': ' . $conversionError->getMessage());
+		}
 		$conversionId = $conversionResult['conv_id'];
 
-                if ($conversionId > 0) {
+                if ($conversionId > 0 && !$conversionResult['duplicate']) {
                         $scope = [
                                 'user_id' => (int) $mysql['click_user_id'],
                                 'campaign_id' => (int) $mysql['campaign_id'],

--- a/tracking202/static/pb.php
+++ b/tracking202/static/pb.php
@@ -23,11 +23,13 @@ $cpa_row = ($cpa_result !== false) ? $cpa_result->fetch_assoc() : null;
 
 $mysql['click_cpa'] = $db->real_escape_string($cpa_row['click_cpa'] ?? '');
 	
-p202ApplyConversionUpdate(
+if (!p202ApplyConversionUpdate(
 	$db,
 	(string) $mysql['click_id'],
 	(string) $mysql['click_cpa'],
 	false,
 	'',
 	(string) $mysql['aff_campaign_id']
-);
+)) {
+	error_log('pb: failed to apply conversion update for click ' . $mysql['click_id']);
+}

--- a/tracking202/static/px.php
+++ b/tracking202/static/px.php
@@ -50,9 +50,11 @@ if ($mysql['click_id']) {
 
 	$mysql['click_cpa'] = $db->real_escape_string($cpa_row['click_cpa'] ?? '');
 	
-		p202ApplyConversionUpdate(
+		if (!p202ApplyConversionUpdate(
 			$db,
 			(string) $mysql['click_id'],
 			(string) $mysql['click_cpa']
-		);
+		)) {
+			error_log('px: failed to apply conversion update for click ' . $mysql['click_id']);
+		}
 	}

--- a/tracking202/static/upx.php
+++ b/tracking202/static/upx.php
@@ -260,6 +260,8 @@ if (is_numeric($mysql['click_id'])) {
 
 	// Atomic + idempotent: locks the click, dedupes on transaction id, and
 	// applies the click update and conversion_logs insert in one transaction.
+	$conversionResult = ['conv_id' => 0, 'duplicate' => false];
+	try {
 	$conversionResult = p202RecordConversion(
 		$db,
 		[
@@ -279,9 +281,12 @@ if (is_numeric($mysql['click_id'])) {
 		($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '') : '',
 		p202ExtractTransactionId($_GET)
 	);
+	} catch (\Throwable $conversionError) {
+		error_log('upx: conversion recording failed for click ' . $mysql['click_id'] . ': ' . $conversionError->getMessage());
+	}
 	$conversionId = $conversionResult['conv_id'];
 
-        if ($conversionId > 0) {
+        if ($conversionId > 0 && !$conversionResult['duplicate']) {
                 $scope = [
                         'user_id' => (int) $mysql['click_user_id'],
                         'campaign_id' => (int) $mysql['campaign_id'],

--- a/tracking202/static/upx.php
+++ b/tracking202/static/upx.php
@@ -241,46 +241,45 @@ if($mysql['ppc_account_id']){
 if (is_numeric($mysql['click_id'])) {
 
 	$conv_time = time();
-	$click_time_to_date = new DateTime(date('Y-m-d H:i:s', (int) $mysql['click_time']));
+	$click_time_raw = (int) ($cvar_sql_row['click_time'] ?? 0);
+	$click_time_to_date = new DateTime(date('Y-m-d H:i:s', $click_time_raw));
 	$conv_time_to_date = new DateTime(date('Y-m-d H:i:s', (int) $conv_time));
 	$diff = $click_time_to_date->diff($conv_time_to_date);
-	$mysql['time_difference'] =  $db->real_escape_string($diff->d.' days, '.$diff->h.' hours, '.$diff->i.' min and '.$diff->s.' sec');
-	$mysql['conv_time'] = $db->real_escape_string((string) $conv_time);
-	$mysql['ip'] = $db->real_escape_string($_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '');
-	$mysql['user_agent'] = $db->real_escape_string($_SERVER['HTTP_USER_AGENT'] ?? '');
-	
+	$time_difference = $diff->d.' days, '.$diff->h.' hours, '.$diff->i.' min and '.$diff->s.' sec';
+	$mysql['conv_time'] = $conv_time;
+
 		if (array_key_exists('amount', $_GET) && is_numeric($_GET['amount'])) {
 			$mysql['use_pixel_payout'] = 1;
 			$mysql['click_payout'] = $db->real_escape_string((string)$_GET['amount']);
 		}
-		p202ApplyConversionUpdate(
-			$db,
-			(string) $mysql['click_id'],
-			(string) $mysql['click_cpa'],
-			$mysql['use_pixel_payout'] == 1,
-			(string) ($mysql['click_payout'] ?? '')
-		);
 
-	// Get click_payout for conversion log
-	$click_payout_for_log = $mysql['click_payout'] ?? $mysql['payout'] ?? '0';
+	// payout to record: pixel amount override if present, otherwise the click's own payout
+	$click_payout_for_log = ($mysql['use_pixel_payout'] == 1)
+		? (string) ($_GET['amount'] ?? '0')
+		: (string) ($cvar_sql_row['click_payout'] ?? '0');
 
-	$log_sql = "INSERT INTO 202_conversion_logs
-				SET conv_id = DEFAULT,
-					click_id = '".$mysql['click_id']."',
-					campaign_id = '".$mysql['campaign_id']."',
-					click_payout = '".$click_payout_for_log."',
-					user_id = '".$mysql['click_user_id']."',
-					click_time = '".$mysql['click_time']."',
-					conv_time = '".$mysql['conv_time']."',
-					time_difference = '".$mysql['time_difference']."',
-					ip = '".$mysql['ip']."',
-					pixel_type = '3',
-					user_agent = '".$mysql['user_agent']."'";
-        $logResult = $db->query($log_sql);
-        if (!$logResult) {
-            error_log('Failed to insert conversion log: ' . $db->error);
-        }
-        $conversionId = $logResult ? (int) $db->insert_id : 0;
+	// Atomic + idempotent: locks the click, dedupes on transaction id, and
+	// applies the click update and conversion_logs insert in one transaction.
+	$conversionResult = p202RecordConversion(
+		$db,
+		[
+			'click_id'        => $clickId,
+			'campaign_id'     => (string) ($cvar_sql_row['aff_campaign_id'] ?? '0'),
+			'user_id'         => (string) ($cvar_sql_row['user_id'] ?? '0'),
+			'click_time'      => $click_time_raw,
+			'conv_time'       => $conv_time,
+			'time_difference' => $time_difference,
+			'ip'              => $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '',
+			'pixel_type'      => 3,
+			'user_agent'      => $_SERVER['HTTP_USER_AGENT'] ?? '',
+			'click_payout'    => $click_payout_for_log,
+		],
+		(string) ($cvar_sql_row['click_cpa'] ?? ''),
+		$mysql['use_pixel_payout'] == 1,
+		($mysql['use_pixel_payout'] == 1) ? (string) ($_GET['amount'] ?? '') : '',
+		p202ExtractTransactionId($_GET)
+	);
+	$conversionId = $conversionResult['conv_id'];
 
         if ($conversionId > 0) {
                 $scope = [

--- a/tracking202/update/subids.php
+++ b/tracking202/update/subids.php
@@ -5,6 +5,8 @@ include_once(substr(__DIR__, 0, -19) . '/202-config/connect.php');
 include_once(substr(__DIR__, 0, -19) . '/202-config/class-dataengine-slim.php');
 
 use Prosper202\Attribution\AttributionServiceFactory;
+use Prosper202\Conversion\MysqlConversionRepository;
+use Prosper202\Database\Connection;
 AUTH::require_user();
 
 if (!$userObj->hasPermission("access_to_update_section")) {
@@ -25,6 +27,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	$subids = trim((string) $subids);
 	$subids = explode("\r", $subids);
 	$subids = str_replace("\n", '', $subids);
+
+	// Conversion rows go through the single canonical writer.
+	$conversionRepo = new MysqlConversionRepository(new Connection($db));
 
 	foreach ($subids as $click_id) {
 		$mysql['click_id'] = $db->real_escape_string($click_id);
@@ -78,32 +83,32 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 			";
 			$update_result = $db->query($update_sql) or die($db->error);
 
-			// Insert into conversion_logs for attribution tracking (skip if already logged)
+			// Insert into conversion_logs for attribution tracking. Subid uploads
+			// carry no transaction id, so dedup is click-level: skip if this click
+			// already has a (non-deleted) conversion. The insert itself goes through
+			// the shared writer (prepared statements, full column set).
 			$check_sql = "SELECT conv_id FROM 202_conversion_logs WHERE click_id = '" . $mysql['click_id'] . "' AND user_id = '" . $mysql['user_id'] . "' AND deleted = 0 LIMIT 1";
 			$check_result = $db->query($check_sql);
 			if ($check_result && $check_result->num_rows === 0) {
 				$conv_time = time();
 				$click_time = (int) $click_row['click_time'];
-				$click_time_to_date = new DateTime(date('Y-m-d H:i:s', $click_time));
-				$conv_time_to_date = new DateTime(date('Y-m-d H:i:s', $conv_time));
-				$diff = $click_time_to_date->diff($conv_time_to_date);
-				$time_difference = $db->real_escape_string($diff->d . ' days, ' . $diff->h . ' hours, ' . $diff->i . ' min and ' . $diff->s . ' sec');
-				$campaign_id = $db->real_escape_string((string) $click_row['aff_campaign_id']);
-				$click_payout = $db->real_escape_string((string) $click_row['click_payout']);
+				$diff = (new DateTime(date('Y-m-d H:i:s', $click_time)))->diff(new DateTime(date('Y-m-d H:i:s', $conv_time)));
 
-				$log_sql = "INSERT INTO 202_conversion_logs
-					SET conv_id = DEFAULT,
-						click_id = '" . $mysql['click_id'] . "',
-						campaign_id = '" . $campaign_id . "',
-						click_payout = '" . $click_payout . "',
-						user_id = '" . $mysql['user_id'] . "',
-						click_time = '" . $click_time . "',
-						conv_time = '" . $conv_time . "',
-						time_difference = '" . $time_difference . "',
-						ip = '',
-						pixel_type = '0',
-						user_agent = 'subid-upload'";
-				$db->query($log_sql);
+				$conversionRepo->record(
+					(int) $mysql['user_id'],
+					[
+						'click_id'        => (int) $mysql['click_id'],
+						'transaction_id'  => '',
+						'campaign_id'     => (int) $click_row['aff_campaign_id'],
+						'payout'          => (float) $click_row['click_payout'],
+						'click_time'      => $click_time,
+						'conv_time'       => $conv_time,
+						'time_difference' => $diff->d . ' days, ' . $diff->h . ' hours, ' . $diff->i . ' min and ' . $diff->s . ' sec',
+						'ip'              => '',
+						'pixel_type'      => 0,
+						'user_agent'      => 'subid-upload',
+					]
+				);
 			}
 
 			$de = new DataEngine();

--- a/tracking202/update/subids.php
+++ b/tracking202/update/subids.php
@@ -54,50 +54,37 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		}
 
 		if (is_numeric($mysql['click_id'])) {
-			$update_sql = "
-				UPDATE
-					202_clicks
-				SET
-					click_lead='1',
-					`click_filtered`='0'
-				WHERE
-					click_id='" . $mysql['click_id'] . "'
-					AND user_id='" . $mysql['user_id'] . "'
-			";
-			try {
-				$update_result = $db->query($update_sql);
-			} catch (Exception $e) {
-				error_log("Database query failed: " . $e->getMessage());
-				throw new RuntimeException("An error occurred while updating the database.");
-			}
+			$clickId = (int) $mysql['click_id'];
+			$userId = (int) $mysql['user_id'];
 
-			$update_sql = "
-				UPDATE
-					202_clicks_spy
-				SET
-					click_lead='1',
-					`click_filtered`='0'
-				WHERE
-					click_id='" . $mysql['click_id'] . "'
-					AND user_id='" . $mysql['user_id'] . "'
-			";
-			$update_result = $db->query($update_sql) or die($db->error);
+			// Flag the click as a lead and clear any filtering, on both the clicks
+			// and spy tables. When a conversion row is recorded this runs inside the
+			// repository transaction (below) so the flag and the audit row commit or
+			// roll back together.
+			$applyClickUpdate = function () use ($db, $clickId, $userId): void {
+				foreach (['202_clicks', '202_clicks_spy'] as $table) {
+					$update_sql = "UPDATE " . $table . " SET click_lead='1', `click_filtered`='0'"
+						. " WHERE click_id='" . $clickId . "' AND user_id='" . $userId . "'";
+					if (!$db->query($update_sql)) {
+						throw new RuntimeException('subids: failed to update ' . $table . ' for click ' . $clickId);
+					}
+				}
+			};
 
-			// Insert into conversion_logs for attribution tracking. Subid uploads
-			// carry no transaction id, so dedup is click-level: skip if this click
-			// already has a (non-deleted) conversion. The insert itself goes through
-			// the shared writer (prepared statements, full column set).
-			$check_sql = "SELECT conv_id FROM 202_conversion_logs WHERE click_id = '" . $mysql['click_id'] . "' AND user_id = '" . $mysql['user_id'] . "' AND deleted = 0 LIMIT 1";
+			// Click-level dedup (subid uploads carry no transaction id): only record
+			// a conversion when this click has no non-deleted conversion yet.
+			$check_sql = "SELECT conv_id FROM 202_conversion_logs WHERE click_id = '" . $clickId . "' AND user_id = '" . $userId . "' AND deleted = 0 LIMIT 1";
 			$check_result = $db->query($check_sql);
+
 			if ($check_result && $check_result->num_rows === 0) {
 				$conv_time = time();
 				$click_time = (int) $click_row['click_time'];
 				$diff = (new DateTime(date('Y-m-d H:i:s', $click_time)))->diff(new DateTime(date('Y-m-d H:i:s', $conv_time)));
 
 				$conversionRepo->record(
-					(int) $mysql['user_id'],
+					$userId,
 					[
-						'click_id'        => (int) $mysql['click_id'],
+						'click_id'        => $clickId,
 						'transaction_id'  => '',
 						'campaign_id'     => (int) $click_row['aff_campaign_id'],
 						'payout'          => (float) $click_row['click_payout'],
@@ -107,12 +94,18 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 						'ip'              => '',
 						'pixel_type'      => 0,
 						'user_agent'      => 'subid-upload',
-					]
+					],
+					function (int $lockedClickId, float $payout) use ($applyClickUpdate): void {
+						$applyClickUpdate();
+					}
 				);
+			} else {
+				// Already has a conversion logged; just (re)apply the click flag.
+				$applyClickUpdate();
 			}
 
 			$de = new DataEngine();
-			$de->setDirtyHour($mysql['click_id']);
+			$de->setDirtyHour((string) $clickId);
 		}
 	}
 


### PR DESCRIPTION
Conversions could be double-counted or partially committed. The legacy
postback/pixel endpoints (gpx/gpb/upx) inserted a conversion on every fire
with no idempotency key, no transaction wrapping the click update + log
insert, and unchecked INSERTs that trusted insert_id even on failure. Only
the V3 API deduped, and it stored an empty transaction_id as '' which would
collide under a uniqueness constraint.

- Add p202RecordConversion(): a shared transactional, idempotent writer that
  locks the source click (SELECT ... FOR UPDATE), dedupes on a non-empty
  transaction id, and applies the click update and conversion_logs insert in
  one transaction with every query checked (rolls back on any failure, so a
  click is never flagged converted without an audit row and vice versa).
- Add p202ExtractTransactionId() and wire gpx/gpb/upx through the new helper.
- p202ApplyConversionUpdate() now reports whether the primary click update
  succeeded so transactional callers can roll back.
- Store an absent transaction_id as NULL (not '') in the V3 controller and
  conversion repository so multiple no-txid conversions on one click are
  still allowed.
- Schema: add UNIQUE KEY (click_id, transaction_id) on 202_conversion_logs
  for fresh installs, plus a guarded upgrade (1.9.60 -> 1.9.61) that nulls
  empty/duplicate transaction ids before adding the backstop.
- Harden the unchecked click lookups feeding gpb/gpx, and fix cb202 crashes
  on malformed JSON, undecryptable payloads, and unchecked query results.
- Add unit tests for the idempotency, rollback, locking, NULL-vs-quoted
  transaction id, and input-validation behavior.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jbjm67FCufKVouqsX9vnBa