### PR TITLE
Fix V3 API tracking link: direct_url should use dl.php, not go.php

### DIFF
--- a/api/v3/Controllers/TrackersController.php
+++ b/api/v3/Controllers/TrackersController.php
@@ -51,7 +51,7 @@ class TrackersController extends Controller
             'data' => [
                 'tracker_id'        => $id,
                 'tracker_id_public' => $publicId,
-                'direct_url'        => $baseUrl . '/tracking202/redirect/go.php?t202id=' . $publicId,
+                'direct_url'        => $baseUrl . '/tracking202/redirect/dl.php?t202id=' . $publicId,
                 'tracking_params'   => '?t202id=' . $publicId . '&t202kw={keyword}&c1={c1}&c2={c2}&c3={c3}&c4={c4}',
             ],
         ];

--- a/go-cli/cmd/cmd_test.go
+++ b/go-cli/cmd/cmd_test.go
@@ -2293,7 +2293,7 @@ func TestTrackerGetURL(t *testing.T) {
 		gotPath = r.URL.Path
 		gotMethod = r.Method
 		w.WriteHeader(200)
-		w.Write([]byte(`{"data":{"tracker_id":56,"direct_url":"https://trk.example.com/tracking202/redirect/go.php?t202id=123"}}`))
+		w.Write([]byte(`{"data":{"tracker_id":56,"direct_url":"https://trk.example.com/tracking202/redirect/dl.php?t202id=123"}}`))
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Problem

`GET /api/v3/trackers/{id}/url` (and therefore the Go CLI `tracker get-url` and the onboarding flow) returned a `direct_url` like:

```
http://<domain>/tracking202/redirect/go.php?t202id=793102405
```

But `go.php` is the **second hop** of a tracked visit — it only handles `lpip`/`acip`/`rpi`/`202v` coming from a landing page, and has **no `t202id` branch**. Hitting that URL always falls through to:

```
Missing LPIP, ACIP or RPI variable!
```

So every API/CLI/onboarding-generated direct link was non-functional.

## Root cause

`api/v3/Controllers/TrackersController.php:54` built `direct_url` from `redirect/go.php?t202id=`. The canonical direct-link click endpoint is **`dl.php`** — confirmed by `tracking202/ajax/generate_tracking_link.php:410` (the `directlink` case) and by `dl.php` itself, which looks up the tracker by `t202id`, records the click, and redirects to the offer.

## Fix

- `direct_url` now points to `tracking202/redirect/dl.php?t202id=...`.
- The Go CLI surfaces the API's `direct_url` verbatim, so its onboarding output is fixed by the same change. Updated the CLI test's mock fixture (`go-cli/cmd/cmd_test.go`) to the corrected endpoint.

## Verification
- `php -l` clean on the controller.
- `go build ./...` + `go test ./cmd/ -run TestTracker...` pass.
- No other production reference builds `go.php?t202id` (grep across `*.php`/`*.go`/`*.js`/`*.sh`).

## Related
Independent of #122 (which fixes a fatal in `go.php` itself for the landing-page hop). Both surfaced from the same onboarding report; this PR is what makes the generated link actually track.