### PR TITLE
Fix V3 API 500s on ppc-network/ppc-account/tracker create under strict mode

### DIFF
--- a/api/v3/Controllers/PpcAccountsController.php
+++ b/api/v3/Controllers/PpcAccountsController.php
@@ -20,4 +20,12 @@ class PpcAccountsController extends Controller
             'ppc_account_default' => ['type' => 'i'],
         ];
     }
+
+    #[\Override]
+    protected function beforeCreate(array $payload): array
+    {
+        return [
+            'ppc_account_time' => ['type' => 'i', 'value' => time()],
+        ];
+    }
 }

--- a/api/v3/Controllers/PpcNetworksController.php
+++ b/api/v3/Controllers/PpcNetworksController.php
@@ -18,4 +18,12 @@ class PpcNetworksController extends Controller
             'ppc_network_name' => ['type' => 's', 'required' => true, 'max_length' => 255],
         ];
     }
+
+    #[\Override]
+    protected function beforeCreate(array $payload): array
+    {
+        return [
+            'ppc_network_time' => ['type' => 'i', 'value' => time()],
+        ];
+    }
 }

--- a/api/v3/Controllers/TrackersController.php
+++ b/api/v3/Controllers/TrackersController.php
@@ -16,13 +16,13 @@ class TrackersController extends Controller
     {
         return [
             'aff_campaign_id'   => ['type' => 'i', 'required' => true],
-            'ppc_account_id'    => ['type' => 'i'],
-            'text_ad_id'        => ['type' => 'i'],
-            'landing_page_id'   => ['type' => 'i'],
-            'rotator_id'        => ['type' => 'i'],
+            'ppc_account_id'    => ['type' => 'i', 'default' => 0],
+            'text_ad_id'        => ['type' => 'i', 'default' => 0],
+            'landing_page_id'   => ['type' => 'i', 'default' => 0],
+            'rotator_id'        => ['type' => 'i', 'default' => 0],
             'click_cpc'         => ['type' => 'd'],
             'click_cpa'         => ['type' => 'd'],
-            'click_cloaking'    => ['type' => 'i'],
+            'click_cloaking'    => ['type' => 'i', 'default' => 0],
             'tracker_id_public' => ['type' => 'i'],
         ];
     }


### PR DESCRIPTION
## Problem
The V3 REST API runs its MySQL connection in **strict mode** (the `connect.php` UI path disables it). Under strict mode, an `INSERT` that omits a `NOT NULL` column lacking a DB-level default **fails with a 500** instead of coercing the value. Three create endpoints did exactly that, so basic onboarding via the Go CLI / REST API returned `500 Internal server error`:

- **`POST /api/v3/ppc-networks`** — never supplied `ppc_network_time` (`NOT NULL`, no default)
- **`POST /api/v3/ppc-accounts`** — never supplied `ppc_account_time` (`NOT NULL`, no default)
- **`POST /api/v3/trackers`** — treated `ppc_account_id`, `text_ad_id`, `landing_page_id`, `rotator_id`, `click_cloaking` as optional with no default, so creating a tracker without a text ad or landing page 500'd

## Fix
- `PpcNetworksController` / `PpcAccountsController`: add a `beforeCreate()` hook supplying the `*_time` column, mirroring the existing pattern in `AffNetworksController` / `CampaignsController`.
- `TrackersController`: give the optional `NOT NULL`-without-default columns an explicit `'default' => 0` so omitting them still satisfies strict mode (0 = no text ad / direct-link / cloaking off — matches legacy semantics).

## Audit
Audited **every** other create endpoint for the same pattern — base-CRUD controllers (Campaigns, LandingPages, TextAds, ForecastEvents, AffNetworks) and the custom `INSERT`s in Users/Rotators/Attribution. No remaining gaps: each already supplies every `NOT NULL`-without-default column via `required`, an explicit `default`, or `beforeCreate`.

## Verification
- `php -l` clean on all three files.
- Reproduced the original 500s and confirmed each endpoint now succeeds end-to-end via the Go CLI (`p202 ppc-network/ppc-account/tracker create`), building a working tracking link.