### PR TITLE
Fix V3 create 500 for ppc-networks & ppc-accounts (strict-mode NOT-NULL time column)

### DIFF
--- a/api/v3/Controllers/PpcAccountsController.php
+++ b/api/v3/Controllers/PpcAccountsController.php
@@ -20,4 +20,14 @@ class PpcAccountsController extends Controller
             'ppc_account_default' => ['type' => 'i'],
         ];
     }
+
+    #[\Override]
+    protected function beforeCreate(array $payload): array
+    {
+        // ppc_account_time is NOT NULL with no default; supply it so the INSERT
+        // succeeds under STRICT_TRANS_TABLES (mirrors AffNetworksController).
+        return [
+            'ppc_account_time' => ['type' => 'i', 'value' => time()],
+        ];
+    }
 }

--- a/api/v3/Controllers/PpcNetworksController.php
+++ b/api/v3/Controllers/PpcNetworksController.php
@@ -18,4 +18,14 @@ class PpcNetworksController extends Controller
             'ppc_network_name' => ['type' => 's', 'required' => true, 'max_length' => 255],
         ];
     }
+
+    #[\Override]
+    protected function beforeCreate(array $payload): array
+    {
+        // ppc_network_time is NOT NULL with no default; supply it so the INSERT
+        // succeeds under STRICT_TRANS_TABLES (mirrors AffNetworksController).
+        return [
+            'ppc_network_time' => ['type' => 'i', 'value' => time()],
+        ];
+    }
 }


### PR DESCRIPTION
## Problem

`POST /api/v3/ppc-networks` and `POST /api/v3/ppc-accounts` return **500** on a live install:

```
{"error":true,"message":"Internal server error","status":500}
```

## Root cause

The running DB uses `STRICT_TRANS_TABLES`. `202_ppc_networks.ppc_network_time` and `202_ppc_accounts.ppc_account_time` are **NOT NULL with no default**, but `PpcNetworksController` and `PpcAccountsController` had **no `beforeCreate()`** to populate them — so the INSERT fails strict-mode validation.

`AffNetworksController` already sets `aff_network_time` via `beforeCreate()` (which is why aff-networks create works); the ppc controllers were missing the analogous hook. Textbook CLAUDE.md error pattern #5 (inconsistent pattern across analogous controllers) and the documented V3 strict-mode INSERT pitfall.

## Fix

Add `beforeCreate()` to both controllers to set the `*_time` column, mirroring `AffNetworksController`.

## Verification

`php -l` clean. Verified end-to-end against a live install (`STRICT_TRANS_TABLES`, bind-mounted code):

| entity | create | update | delete | gone |
|---|---|---|---|---|
| ppc-networks | 201 ✅ | 200 ✅ | 204 ✅ | 404 ✅ |
| ppc-accounts | 201 ✅ | 200 ✅ | 204 ✅ | 404 ✅ |

Found while smoke-testing the full V3 CRUD surface. A separate PR handles the other issue found (forecast-events 500 — missing table on upgraded installs).