### PR TITLE
Align report breakdown and rotator rule-update flags with siblings

### DIFF
--- a/go-cli/cmd/consistency_test.go
+++ b/go-cli/cmd/consistency_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// report breakdown should accept the same friendly flags as the analytics
+// shorthand: --group-by (alias of --breakdown), --sort-dir (alias of --sort_dir),
+// and dimension aliases such as lp -> landing_page.
+
+func TestReportBreakdownAcceptsGroupByAlias(t *testing.T) {
+	var gotParams url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParams = r.URL.Query()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("report", "breakdown", "--group-by", "ppc_account"); err != nil {
+		t.Fatalf("report breakdown --group-by error: %v", err)
+	}
+	if got := gotParams.Get("breakdown"); got != "ppc_account" {
+		t.Errorf("breakdown = %q, want %q", got, "ppc_account")
+	}
+}
+
+func TestReportBreakdownDimensionAliasLp(t *testing.T) {
+	var gotParams url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParams = r.URL.Query()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("report", "breakdown", "-b", "lp"); err != nil {
+		t.Fatalf("report breakdown -b lp error: %v", err)
+	}
+	if got := gotParams.Get("breakdown"); got != "landing_page" {
+		t.Errorf("breakdown = %q, want %q (lp alias)", got, "landing_page")
+	}
+}
+
+func TestReportBreakdownAcceptsSortDirAlias(t *testing.T) {
+	var gotParams url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParams = r.URL.Query()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("report", "breakdown", "-b", "country", "--sort", "roi", "--sort-dir", "DESC"); err != nil {
+		t.Fatalf("report breakdown --sort-dir error: %v", err)
+	}
+	if got := gotParams.Get("sort_dir"); got != "DESC" {
+		t.Errorf("sort_dir = %q, want %q", got, "DESC")
+	}
+}
+
+func TestReportBreakdownCanonicalFlagsStillWork(t *testing.T) {
+	var gotParams url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParams = r.URL.Query()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("report", "breakdown", "--breakdown", "device", "--sort_dir", "ASC"); err != nil {
+		t.Fatalf("report breakdown canonical flags error: %v", err)
+	}
+	if got := gotParams.Get("breakdown"); got != "device" {
+		t.Errorf("breakdown = %q, want %q", got, "device")
+	}
+	if got := gotParams.Get("sort_dir"); got != "ASC" {
+		t.Errorf("sort_dir = %q, want %q", got, "ASC")
+	}
+}
+
+// rotator rule-update should accept the rule id via --rule_id as an alternative
+// to the second positional arg, matching the flag-flexible style of rule-delete.
+
+func TestRotatorRuleUpdateAcceptsRuleIdFlag(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("rotator", "rule-update", "4", "--rule_id", "15", "--status", "0"); err != nil {
+		t.Fatalf("rule-update --rule_id error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/rotators/4/rules/15") {
+		t.Errorf("path = %q, want suffix %q", gotPath, "/rotators/4/rules/15")
+	}
+}
+
+func TestRotatorRuleUpdatePositionalStillWorks(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("rotator", "rule-update", "4", "15", "--status", "1"); err != nil {
+		t.Fatalf("rule-update positional error: %v", err)
+	}
+	if !strings.HasSuffix(gotPath, "/rotators/4/rules/15") {
+		t.Errorf("path = %q, want suffix %q", gotPath, "/rotators/4/rules/15")
+	}
+}

--- a/go-cli/cmd/consistency_test.go
+++ b/go-cli/cmd/consistency_test.go
@@ -99,6 +99,59 @@ func TestReportBreakdownCanonicalFlagsStillWork(t *testing.T) {
 	}
 }
 
+// An explicitly passed alias flag must override a configured default for the
+// canonical flag (regression test for the alias-vs-default precedence bug).
+
+func TestReportBreakdownGroupByOverridesConfigDefault(t *testing.T) {
+	var gotParams url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParams = r.URL.Query()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfigWithDefaults(t, tmp, srv.URL, "test-key", map[string]string{
+		"report.breakdown": "campaign",
+		"report.sort_dir":  "ASC",
+	})
+
+	if _, _, err := executeCommand("report", "breakdown", "--group-by", "country", "--sort", "roi", "--sort-dir", "DESC"); err != nil {
+		t.Fatalf("report breakdown --group-by over default error: %v", err)
+	}
+	if got := gotParams.Get("breakdown"); got != "country" {
+		t.Errorf("breakdown = %q, want %q (explicit --group-by must beat config default)", got, "country")
+	}
+	if got := gotParams.Get("sort_dir"); got != "DESC" {
+		t.Errorf("sort_dir = %q, want %q (explicit --sort-dir must beat config default)", got, "DESC")
+	}
+}
+
+func TestReportBreakdownConfigDefaultUsedWhenNoFlag(t *testing.T) {
+	var gotParams url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParams = r.URL.Query()
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfigWithDefaults(t, tmp, srv.URL, "test-key", map[string]string{
+		"report.breakdown": "campaign",
+	})
+
+	if _, _, err := executeCommand("report", "breakdown"); err != nil {
+		t.Fatalf("report breakdown with default error: %v", err)
+	}
+	if got := gotParams.Get("breakdown"); got != "campaign" {
+		t.Errorf("breakdown = %q, want %q (config default applies when no flag)", got, "campaign")
+	}
+}
+
 // rotator rule-update should accept the rule id via --rule_id as an alternative
 // to the second positional arg, matching the flag-flexible style of rule-delete.
 
@@ -121,6 +174,28 @@ func TestRotatorRuleUpdateAcceptsRuleIdFlag(t *testing.T) {
 	}
 	if gotMethod != http.MethodPut {
 		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/rotators/4/rules/15") {
+		t.Errorf("path = %q, want suffix %q", gotPath, "/rotators/4/rules/15")
+	}
+}
+
+func TestRotatorRuleUpdateAcceptsBothPositionalAndFlag(t *testing.T) {
+	// Passing both forms must not be rejected; the positional wins.
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	if _, _, err := executeCommand("rotator", "rule-update", "4", "15", "--rule_id", "15", "--status", "0"); err != nil {
+		t.Fatalf("rule-update with both positional and --rule_id error: %v", err)
 	}
 	if !strings.HasSuffix(gotPath, "/rotators/4/rules/15") {
 		t.Errorf("path = %q, want suffix %q", gotPath, "/rotators/4/rules/15")

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -83,10 +83,15 @@ var reportBreakdownCmd = &cobra.Command{
 
 		// Accept the analytics shorthand's friendly flags for consistency:
 		// --group-by aliases --breakdown, --sort-dir aliases --sort_dir, and
-		// dimension aliases (e.g. lp -> landing_page) are honored.
-		breakdown := getStringFlagOrDefault(cmd, "report", "breakdown")
+		// dimension aliases (e.g. lp -> landing_page) are honored. An explicitly
+		// passed flag (canonical or alias) must win over a configured default,
+		// so the aliases are read before falling back to getConfigDefault.
+		breakdown, _ := cmd.Flags().GetString("breakdown")
 		if breakdown == "" {
 			breakdown, _ = cmd.Flags().GetString("group-by")
+		}
+		if breakdown == "" {
+			breakdown = getConfigDefault("report", "breakdown")
 		}
 		breakdown = strings.ToLower(strings.TrimSpace(breakdown))
 		if mapped, ok := analyticsGroupByAliases[breakdown]; ok {
@@ -96,9 +101,12 @@ var reportBreakdownCmd = &cobra.Command{
 			params["breakdown"] = breakdown
 		}
 
-		sortDir := getStringFlagOrDefault(cmd, "report", "sort_dir")
+		sortDir, _ := cmd.Flags().GetString("sort_dir")
 		if sortDir == "" {
 			sortDir, _ = cmd.Flags().GetString("sort-dir")
+		}
+		if sortDir == "" {
+			sortDir = getConfigDefault("report", "sort_dir")
 		}
 		if sortDir != "" {
 			params["sort_dir"] = sortDir

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"p202/internal/api"
 
 	"github.com/spf13/cobra"
@@ -78,7 +80,31 @@ var reportBreakdownCmd = &cobra.Command{
 			return err
 		}
 		params := collectReportParams(cmd)
-		for _, f := range []string{"breakdown", "sort", "sort_dir", "limit", "offset"} {
+
+		// Accept the analytics shorthand's friendly flags for consistency:
+		// --group-by aliases --breakdown, --sort-dir aliases --sort_dir, and
+		// dimension aliases (e.g. lp -> landing_page) are honored.
+		breakdown := getStringFlagOrDefault(cmd, "report", "breakdown")
+		if breakdown == "" {
+			breakdown, _ = cmd.Flags().GetString("group-by")
+		}
+		breakdown = strings.ToLower(strings.TrimSpace(breakdown))
+		if mapped, ok := analyticsGroupByAliases[breakdown]; ok {
+			breakdown = mapped
+		}
+		if breakdown != "" {
+			params["breakdown"] = breakdown
+		}
+
+		sortDir := getStringFlagOrDefault(cmd, "report", "sort_dir")
+		if sortDir == "" {
+			sortDir, _ = cmd.Flags().GetString("sort-dir")
+		}
+		if sortDir != "" {
+			params["sort_dir"] = sortDir
+		}
+
+		for _, f := range []string{"sort", "limit", "offset"} {
 			if v := getStringFlagOrDefault(cmd, "report", f); v != "" {
 				params[f] = v
 			}
@@ -164,9 +190,11 @@ func init() {
 	addMultiProfileFlags(reportSummaryCmd)
 
 	addReportFilters(reportBreakdownCmd)
-	reportBreakdownCmd.Flags().StringP("breakdown", "b", "", "Dimension: campaign, aff_network, ppc_account, ppc_network, landing_page, keyword, country, city, browser, platform, device, isp, text_ad")
+	reportBreakdownCmd.Flags().StringP("breakdown", "b", "", "Dimension: campaign, aff_network, ppc_account, ppc_network, landing_page (alias: lp), keyword, country, city, browser, platform, device, isp, text_ad")
+	reportBreakdownCmd.Flags().String("group-by", "", "Alias for --breakdown (matches `analytics --group-by`)")
 	reportBreakdownCmd.Flags().StringP("sort", "s", "", "Sort by: total_clicks, total_leads, total_income, total_cost, total_net, roi, epc, conv_rate")
 	reportBreakdownCmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC")
+	reportBreakdownCmd.Flags().String("sort-dir", "", "Alias for --sort_dir (matches `analytics --sort-dir`)")
 	reportBreakdownCmd.Flags().StringP("limit", "l", "", "Max results")
 	reportBreakdownCmd.Flags().StringP("offset", "o", "", "Pagination offset")
 

--- a/go-cli/cmd/rotator.go
+++ b/go-cli/cmd/rotator.go
@@ -309,11 +309,29 @@ var rotatorRuleDeleteCmd = &cobra.Command{
 var rotatorRuleUpdateCmd = &cobra.Command{
 	Use:   "rule-update <rotator_id> <rule_id>",
 	Short: "Update a routing rule on a redirector/rotator",
-	Args:  cobra.ExactArgs(2),
+	Args: func(cmd *cobra.Command, args []string) error {
+		// Accept the rule id as a second positional OR via --rule_id, matching
+		// the flag-flexible style of rule-delete (--ids).
+		if ruleID, _ := cmd.Flags().GetString("rule_id"); strings.TrimSpace(ruleID) != "" {
+			return cobra.ExactArgs(1)(cmd, args)
+		}
+		return cobra.ExactArgs(2)(cmd, args)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := api.NewFromConfig()
 		if err != nil {
 			return err
+		}
+
+		ruleID := ""
+		if len(args) >= 2 {
+			ruleID = args[1]
+		} else {
+			ruleID, _ = cmd.Flags().GetString("rule_id")
+		}
+		ruleID = strings.TrimSpace(ruleID)
+		if ruleID == "" {
+			return fmt.Errorf("rule id is required (pass it as the second argument or via --rule_id)")
 		}
 
 		body := map[string]interface{}{}
@@ -344,7 +362,7 @@ var rotatorRuleUpdateCmd = &cobra.Command{
 			return fmt.Errorf("no fields specified; pass at least one flag to update")
 		}
 
-		data, err := c.Put("rotators/"+args[0]+"/rules/"+args[1], body)
+		data, err := c.Put("rotators/"+args[0]+"/rules/"+ruleID, body)
 		if err != nil {
 			return err
 		}
@@ -379,6 +397,7 @@ func init() {
 	rotatorRuleDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	rotatorRuleDeleteCmd.Flags().String("ids", "", "Comma-separated rule IDs to delete in bulk")
 
+	rotatorRuleUpdateCmd.Flags().String("rule_id", "", "Rule ID (alternative to the second positional arg)")
 	rotatorRuleUpdateCmd.Flags().String("rule_name", "", "Rule name")
 	rotatorRuleUpdateCmd.Flags().String("splittest", "", "Enable split test (0|1)")
 	rotatorRuleUpdateCmd.Flags().String("status", "", "Rule status (0|1)")

--- a/go-cli/cmd/rotator.go
+++ b/go-cli/cmd/rotator.go
@@ -309,14 +309,10 @@ var rotatorRuleDeleteCmd = &cobra.Command{
 var rotatorRuleUpdateCmd = &cobra.Command{
 	Use:   "rule-update <rotator_id> <rule_id>",
 	Short: "Update a routing rule on a redirector/rotator",
-	Args: func(cmd *cobra.Command, args []string) error {
-		// Accept the rule id as a second positional OR via --rule_id, matching
-		// the flag-flexible style of rule-delete (--ids).
-		if ruleID, _ := cmd.Flags().GetString("rule_id"); strings.TrimSpace(ruleID) != "" {
-			return cobra.ExactArgs(1)(cmd, args)
-		}
-		return cobra.ExactArgs(2)(cmd, args)
-	},
+	// Accept the rule id as a second positional OR via --rule_id, matching the
+	// flag-flexible style of rule-delete. RangeArgs(1,2) allows either form
+	// (and both together); the positional wins and is resolved in RunE.
+	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := api.NewFromConfig()
 		if err != nil {


### PR DESCRIPTION
## Three CLI consistency rough edges
Surfaced while driving campaign-optimization workflows:

1. **`report breakdown`** only accepted `--breakdown` / `--sort_dir`, while the `analytics` shorthand uses `--group-by` / `--sort-dir`. Added the friendly names as aliases and honor dimension aliases (`lp` → `landing_page`), so the two commands take the same flags.
2. **`rotator rule-update`** required the rule id as a strict second positional, unlike `rule-delete` which also accepts a flag form. Added `--rule_id` as an alternative to the positional arg.

## Backward compatible
All existing flags/positional forms still work — covered by `TestReportBreakdownCanonicalFlagsStillWork` and `TestRotatorRuleUpdatePositionalStillWorks`.

## Tests
New `go-cli/cmd/consistency_test.go` (6 cases, TDD). Full `go test ./...` green. Verified live against the running tracker.

https://claude.ai/code/session_015vuv7cgTTHcRKnHKURdwVZ