### PR TITLE
Fix check-code-patterns Stop hook aborting under set -e

### DIFF
--- a/scripts/check-code-patterns.sh
+++ b/scripts/check-code-patterns.sh
@@ -18,7 +18,7 @@ add_violation() {
     local pattern="$2"
     local fix="$3"
     violations+="  - ${file}: ${pattern} -> ${fix}"$'\n'
-    ((violation_count++))
+    violation_count=$((violation_count + 1))
 }
 
 # Check if there are modified PHP files
@@ -159,7 +159,7 @@ if [ -x "$phpstan_bin" ] || [ -f "$phpstan_bin" ]; then
                 while IFS= read -r line; do
                     [ -n "$line" ] && violations+="    $line"$'\n'
                 done <<< "$error_lines"
-                ((violation_count++))
+                violation_count=$((violation_count + 1))
             fi
         fi
     fi


### PR DESCRIPTION
## Problem
`scripts/check-code-patterns.sh` runs under `set -euo pipefail` and counted violations with `((violation_count++))`. Bash post-increment evaluates to the *old* value, so the first increment (0 → 1) makes the arithmetic command return exit status **1**, which `set -e` treats as fatal — aborting before the report and `exit 2`. Claude Code saw the non-2 exit as a **Stop hook failure**. On a clean tree it exited 0, so it only broke once there were flagged PHP changes.

## Fix
Replace both `((violation_count++))` with `violation_count=$((violation_count + 1))`, which always returns 0.

## Verification
- Clean tree → exit 0 (unchanged).
- Flagged file → exit 2 with the full violations report (intended behavior), instead of dying at exit 1.
- `bash -n` passes.

https://claude.ai/code/session_015vuv7cgTTHcRKnHKURdwVZ