### PR TITLE
CLI friction & missing-capability improvements (from audit)

### DIFF
--- a/go-cli/cmd/aliases.go
+++ b/go-cli/cmd/aliases.go
@@ -1,10 +1,86 @@
 package cmd
 
 import (
+	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+// applyBreakdownFilters post-filters breakdown rows client-side by --min-clicks,
+// --min-cost, --zero-leads, and --having (FIELD OP VALUE). Returns the original
+// bytes unchanged when no filter is set or the payload can't be parsed.
+func applyBreakdownFilters(cmd *cobra.Command, data []byte) []byte {
+	minClicks, _ := cmd.Flags().GetFloat64("min-clicks")
+	minCost, _ := cmd.Flags().GetFloat64("min-cost")
+	zeroLeads, _ := cmd.Flags().GetBool("zero-leads")
+	having, _ := cmd.Flags().GetString("having")
+	if minClicks == 0 && minCost == 0 && !zeroLeads && strings.TrimSpace(having) == "" {
+		return data
+	}
+	var resp struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if json.Unmarshal(data, &resp) != nil {
+		return data
+	}
+	field, op, want, hasHaving := parseHaving(having)
+
+	out := make([]map[string]interface{}, 0, len(resp.Data))
+	for _, r := range resp.Data {
+		if minClicks > 0 && toFloat(r["total_clicks"]) < minClicks {
+			continue
+		}
+		if minCost > 0 && toFloat(r["total_cost"]) < minCost {
+			continue
+		}
+		if zeroLeads && !(toFloat(r["total_cost"]) > 0 && toFloat(r["total_leads"]) == 0) {
+			continue
+		}
+		if hasHaving && !compareNum(toFloat(r[field]), op, want) {
+			continue
+		}
+		out = append(out, r)
+	}
+	b, _ := json.Marshal(map[string]interface{}{"data": out})
+	return b
+}
+
+func parseHaving(s string) (field, op string, value float64, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", "", 0, false
+	}
+	for _, o := range []string{">=", "<=", "!=", "=", ">", "<"} {
+		if i := strings.Index(s, o); i > 0 {
+			field = strings.TrimSpace(s[:i])
+			v, err := strconv.ParseFloat(strings.TrimSpace(s[i+len(o):]), 64)
+			if err != nil {
+				return "", "", 0, false
+			}
+			return resolveMetric(field), o, v, true
+		}
+	}
+	return "", "", 0, false
+}
+
+func compareNum(a float64, op string, b float64) bool {
+	switch op {
+	case ">":
+		return a > b
+	case "<":
+		return a < b
+	case ">=":
+		return a >= b
+	case "<=":
+		return a <= b
+	case "!=":
+		return a != b
+	default: // "="
+		return a == b
+	}
+}
 
 // dimensionAliases maps short/friendly breakdown dimension names to the API
 // field the backend expects. Identity entries are accepted as-is.

--- a/go-cli/cmd/aliases.go
+++ b/go-cli/cmd/aliases.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 // dimensionAliases maps short/friendly breakdown dimension names to the API
 // field the backend expects. Identity entries are accepted as-is.
@@ -47,4 +51,29 @@ func resolveMetric(m string) string {
 		return mapped
 	}
 	return m
+}
+
+// applyReportSort reads --sort (honoring metric aliases) and the sort direction
+// (--sort_dir or its --sort-dir alias) into params, so every report subcommand
+// accepts the same friendly names regardless of casing.
+func applyReportSort(cmd *cobra.Command, params map[string]string) {
+	sort := getStringFlagOrDefault(cmd, "report", "sort")
+	if sort != "" {
+		params["sort"] = resolveMetric(sort)
+	}
+	dir := getStringFlagOrDefault(cmd, "report", "sort_dir")
+	if dir == "" {
+		dir, _ = cmd.Flags().GetString("sort-dir")
+	}
+	if dir != "" {
+		params["sort_dir"] = dir
+	}
+}
+
+// addSortFlags registers --sort / --sort_dir and the --sort-dir alias on a
+// report subcommand so the sort vocabulary is identical everywhere.
+func addSortFlags(cmd *cobra.Command, sortHelp string) {
+	cmd.Flags().StringP("sort", "s", "", sortHelp)
+	cmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC")
+	cmd.Flags().String("sort-dir", "", "Alias for --sort_dir")
 }

--- a/go-cli/cmd/aliases.go
+++ b/go-cli/cmd/aliases.go
@@ -1,0 +1,50 @@
+package cmd
+
+import "strings"
+
+// dimensionAliases maps short/friendly breakdown dimension names to the API
+// field the backend expects. Identity entries are accepted as-is.
+var dimensionAliases = map[string]string{
+	"lp":      "landing_page",
+	"source":  "ppc_account",
+	"network": "aff_network",
+	"offer":   "campaign",
+	"geo":     "country",
+}
+
+// resolveDimension normalizes a user-supplied breakdown dimension.
+func resolveDimension(d string) string {
+	d = strings.ToLower(strings.TrimSpace(d))
+	if mapped, ok := dimensionAliases[d]; ok {
+		return mapped
+	}
+	return d
+}
+
+// metricAliases maps friendly sort/metric names to the raw API column names,
+// shared by analytics and every report subcommand so `--sort clicks` works
+// everywhere, not just in analytics.
+var metricAliases = map[string]string{
+	"clicks":      "total_clicks",
+	"conversions": "total_leads",
+	"leads":       "total_leads",
+	"revenue":     "total_income",
+	"income":      "total_income",
+	"profit":      "total_net",
+	"net":         "total_net",
+	"cost":        "total_cost",
+	"roi":         "roi",
+	"epc":         "epc",
+	"conv_rate":   "conv_rate",
+	"cpa":         "cpa",
+	"avg_cpc":     "avg_cpc",
+}
+
+// resolveMetric normalizes a user-supplied sort/metric name to the API column.
+func resolveMetric(m string) string {
+	m = strings.ToLower(strings.TrimSpace(m))
+	if mapped, ok := metricAliases[m]; ok {
+		return mapped
+	}
+	return m
+}

--- a/go-cli/cmd/aliases.go
+++ b/go-cli/cmd/aliases.go
@@ -8,6 +8,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// rejectMultiProfile errors when --group/--profiles is set on a command that
+// does not fan out across profiles, instead of silently returning one profile's
+// data (which would be wrong numbers in a multi-profile/client report).
+func rejectMultiProfile(cmd *cobra.Command) error {
+	if groupName != "" {
+		return validationError("--group is not supported here (only `report summary` aggregates across profiles); run per-profile with --profile, or use `exec`")
+	}
+	if cmd.Flags().Lookup("profiles") != nil {
+		if v, _ := cmd.Flags().GetString("profiles"); v != "" {
+			return validationError("--profiles is not supported by this command; use `report summary` or `exec`")
+		}
+	}
+	return nil
+}
+
 // applyBreakdownFilters post-filters breakdown rows client-side by --min-clicks,
 // --min-cost, --zero-leads, and --having (FIELD OP VALUE). Returns the original
 // bytes unchanged when no filter is set or the payload can't be parsed.

--- a/go-cli/cmd/aliases.go
+++ b/go-cli/cmd/aliases.go
@@ -152,19 +152,17 @@ func applyReportSort(cmd *cobra.Command, params map[string]string) {
 	if sort != "" {
 		params["sort"] = resolveMetric(sort)
 	}
+	// --sort_dir and --sort-dir resolve to the same flag via the global name
+	// normalizer (- and _ are interchangeable everywhere).
 	dir := getStringFlagOrDefault(cmd, "report", "sort_dir")
-	if dir == "" {
-		dir, _ = cmd.Flags().GetString("sort-dir")
-	}
 	if dir != "" {
 		params["sort_dir"] = dir
 	}
 }
 
-// addSortFlags registers --sort / --sort_dir and the --sort-dir alias on a
-// report subcommand so the sort vocabulary is identical everywhere.
+// addSortFlags registers --sort and --sort_dir on a report subcommand. The
+// global flag normalizer makes --sort-dir an accepted spelling automatically.
 func addSortFlags(cmd *cobra.Command, sortHelp string) {
 	cmd.Flags().StringP("sort", "s", "", sortHelp)
-	cmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC")
-	cmd.Flags().String("sort-dir", "", "Alias for --sort_dir")
+	cmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC (also --sort-dir)")
 }

--- a/go-cli/cmd/analytics.go
+++ b/go-cli/cmd/analytics.go
@@ -161,7 +161,7 @@ func init() {
 	analyticsCmd.Flags().String("sort-dir", "", "Sort direction: ASC or DESC")
 	analyticsCmd.Flags().StringP("limit", "l", "", "Max results")
 	analyticsCmd.Flags().StringP("offset", "o", "", "Pagination offset")
-	analyticsCmd.Flags().String("aff_campaign_id", "", "Filter by campaign ID")
+	analyticsCmd.Flags().String("aff_campaign_id", "", "Filter by INTERNAL campaign id (from `campaign list`), not the public id in tracking URLs")
 	analyticsCmd.Flags().String("ppc_account_id", "", "Filter by PPC account ID")
 	analyticsCmd.Flags().String("aff_network_id", "", "Filter by affiliate network ID")
 	analyticsCmd.Flags().String("ppc_network_id", "", "Filter by PPC network ID")

--- a/go-cli/cmd/attribution.go
+++ b/go-cli/cmd/attribution.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"p202/internal/api"
-	"p202/internal/output"
 
 	"github.com/spf13/cobra"
 )
@@ -139,23 +138,10 @@ var attrModelUpdateCmd = &cobra.Command{
 
 var attrModelDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
-	Short: "Delete an attribution model and all related data",
-	Args:  cobra.ExactArgs(1),
+	Short: "Delete an attribution model; supports --ids for bulk",
+	Args:  deleteArgsValidator,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := api.NewFromConfig()
-		if err != nil {
-			return err
-		}
-		force, _ := cmd.Flags().GetBool("force")
-		if !force && !confirmPrompt("Delete attribution model %s and all related data?", args[0]) {
-			fmt.Println("Cancelled.")
-			return nil
-		}
-		if err := c.Delete("attribution/models/" + args[0]); err != nil {
-			return err
-		}
-		output.Success("Attribution model %s deleted.", args[0])
-		return nil
+		return bulkOrSingleDelete(cmd, "attribution/models", "attribution model")
 	},
 }
 
@@ -256,6 +242,7 @@ func init() {
 	attrModelUpdateCmd.Flags().String("is_default", "", "1=default, 0=not")
 
 	attrModelDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+	attrModelDeleteCmd.Flags().String("ids", "", "Comma-separated model IDs to delete in bulk")
 
 	attrModelCmd.AddCommand(attrModelListCmd, attrModelGetCmd, attrModelCreateCmd, attrModelUpdateCmd, attrModelDeleteCmd)
 

--- a/go-cli/cmd/cmd_test.go
+++ b/go-cli/cmd/cmd_test.go
@@ -4107,12 +4107,12 @@ func TestConversionDeleteBulkIdsReturnsErrorOnPartialFailure(t *testing.T) {
 	setTestHome(t, tmp)
 	writeTestConfig(t, tmp, srv.URL, "test-key")
 
-	stdout, _, err := executeCommand("conversion", "delete", "--ids=1,2", "--force")
+	_, stderr, err := executeCommand("conversion", "delete", "--ids=1,2", "--force")
 	if err == nil {
 		t.Fatal("expected partial failure error for bulk delete")
 	}
-	if !strings.Contains(stdout, "Deleted 1 of 2 conversions.") {
-		t.Fatalf("unexpected summary output:\n%s", stdout)
+	if !strings.Contains(stderr, "Deleted 1 of 2 conversions.") {
+		t.Fatalf("unexpected summary output:\n%s", stderr)
 	}
 	if len(deletePaths) != 2 {
 		t.Fatalf("expected 2 delete calls, got %d", len(deletePaths))

--- a/go-cli/cmd/consistency_test.go
+++ b/go-cli/cmd/consistency_test.go
@@ -4,8 +4,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // report breakdown should accept the same friendly flags as the analytics
@@ -220,5 +224,37 @@ func TestRotatorRuleUpdatePositionalStillWorks(t *testing.T) {
 	}
 	if !strings.HasSuffix(gotPath, "/rotators/4/rules/15") {
 		t.Errorf("path = %q, want suffix %q", gotPath, "/rotators/4/rules/15")
+	}
+}
+
+// TestVisibleFlagsAreKebabCase walks the whole command tree and asserts every
+// visible flag name is kebab-case. The global normalizer canonicalizes names
+// to kebab and keeps the snake_case spelling working, so this stays true as new
+// commands are added.
+func TestVisibleFlagsAreKebabCase(t *testing.T) {
+	kebab := regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			if f.Hidden {
+				return
+			}
+			if !kebab.MatchString(f.Name) {
+				t.Errorf("%s: flag --%s is not kebab-case", c.CommandPath(), f.Name)
+			}
+		})
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(rootCmd)
+}
+
+func TestFlagNameNormalizerInterchangesDashAndUnderscore(t *testing.T) {
+	if got := string(normalizeFlagName(nil, "aff_campaign_id")); got != "aff-campaign-id" {
+		t.Errorf("normalize(aff_campaign_id) = %q, want aff-campaign-id", got)
+	}
+	if got := string(normalizeFlagName(nil, "sort-dir")); got != "sort-dir" {
+		t.Errorf("normalize(sort-dir) = %q, want sort-dir", got)
 	}
 }

--- a/go-cli/cmd/conversion.go
+++ b/go-cli/cmd/conversion.go
@@ -27,8 +27,14 @@ var conversionListCmd = &cobra.Command{
 			return err
 		}
 		params := map[string]string{}
-		flags := []string{"campaign_id", "time_from", "time_to"}
-		for _, f := range flags {
+		// Accept --aff_campaign_id (the name every other command uses); fall back
+		// to the legacy --campaign_id spelling.
+		if v, _ := cmd.Flags().GetString("aff_campaign_id"); v != "" {
+			params["campaign_id"] = v
+		} else if v, _ := cmd.Flags().GetString("campaign_id"); v != "" {
+			params["campaign_id"] = v
+		}
+		for _, f := range []string{"time_from", "time_to"} {
 			if v, _ := cmd.Flags().GetString(f); v != "" {
 				params[f] = v
 			}
@@ -187,7 +193,9 @@ func init() {
 	conversionListCmd.Flags().StringP("limit", "l", "", "Max results")
 	conversionListCmd.Flags().StringP("offset", "o", "", "Pagination offset")
 	conversionListCmd.Flags().Bool("all", false, "Fetch all rows across pages")
-	conversionListCmd.Flags().String("campaign_id", "", "Filter by campaign ID")
+	conversionListCmd.Flags().String("aff_campaign_id", "", "Filter by campaign ID")
+	conversionListCmd.Flags().String("campaign_id", "", "Legacy alias for --aff_campaign_id")
+	_ = conversionListCmd.Flags().MarkHidden("campaign_id")
 	conversionListCmd.Flags().String("time_from", "", "Start timestamp (unix)")
 	conversionListCmd.Flags().String("time_to", "", "End timestamp (unix)")
 

--- a/go-cli/cmd/conversion_verify.go
+++ b/go-cli/cmd/conversion_verify.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"p202/internal/api"
+	"p202/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+var subidRe = regexp.MustCompile(`[?&](?:s|subid|sid)=([0-9]+)`)
+
+// trackingBaseURL returns the scheme://host of the active profile for hitting
+// the (non-API) redirect and postback endpoints.
+func trackingBaseURL() (string, error) {
+	prof, _, err := config.LoadProfileWithName(profileName)
+	if err != nil {
+		return "", err
+	}
+	if prof.URL == "" {
+		return "", validationError("no URL configured. Run: p202 config set-url <url>")
+	}
+	return strings.TrimRight(prof.URL, "/"), nil
+}
+
+var conversionPostbackURLCmd = &cobra.Command{
+	Use:   "postback-url",
+	Short: "Print the server-to-server postback URL to give your affiliate network",
+	Long:  "Outputs the gpb.php postback template. The network calls it with the conversion payout and the click subid.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		base, err := trackingBaseURL()
+		if err != nil {
+			return err
+		}
+		url := base + "/tracking202/static/gpb.php?amount={payout}&subid={subid}"
+		fmt.Fprintln(os.Stderr, "Server-to-server postback URL (give this to your network):")
+		fmt.Fprintln(os.Stderr, "  Replace {payout} with the conversion amount macro and {subid} with the network's subid macro")
+		fmt.Fprintln(os.Stderr, "  (use ?sid= instead of ?subid= if the network only supports sid).")
+		fmt.Println(url)
+		return nil
+	},
+}
+
+var conversionSimulateCmd = &cobra.Command{
+	Use:   "simulate",
+	Short: "Prove the click -> subid -> postback -> conversion loop works for a tracker",
+	Long: "Fires a synthetic click through the tracker, reads back the subid, fires the\n" +
+		"real S2S postback (gpb.php), and reports whether it was accepted — so you can\n" +
+		"validate the loop before pointing a network's postback at this instance.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		trackerID, _ := cmd.Flags().GetString("tracker")
+		if trackerID == "" {
+			return validationError("--tracker is required (the internal tracker_id from `tracker list`)")
+		}
+		payout, _ := cmd.Flags().GetString("payout")
+		if payout == "" {
+			payout = "1.00"
+		}
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		base, err := trackingBaseURL()
+		if err != nil {
+			return err
+		}
+
+		// 1. Resolve the tracker link.
+		urlData, err := c.Get("trackers/"+trackerID+"/url", nil)
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			Data struct {
+				DirectURL string `json:"direct_url"`
+			} `json:"data"`
+		}
+		if json.Unmarshal(urlData, &resp) != nil || resp.Data.DirectURL == "" {
+			return validationError("tracker has no resolvable link")
+		}
+		link := resp.Data.DirectURL
+		if !strings.HasPrefix(link, "http") {
+			link = scheme(base) + "://" + link
+		}
+
+		// 2. Fire a click and capture the subid from the redirect.
+		noRedir := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+		clickRes, err := noRedir.Get(link + "&t202kw=simulate")
+		if err != nil {
+			return fmt.Errorf("click request failed: %w", err)
+		}
+		loc := clickRes.Header.Get("Location")
+		clickRes.Body.Close()
+		m := subidRe.FindStringSubmatch(loc)
+		if m == nil {
+			return fmt.Errorf("could not parse a subid from the redirect (%q) — the link may be misconfigured", loc)
+		}
+		subid := m[1]
+
+		// 3. Fire the real S2S postback (gpb.php).
+		pbURL := fmt.Sprintf("%s/tracking202/static/gpb.php?amount=%s&subid=%s", base, payout, subid)
+		pbRes, err := http.Get(pbURL)
+		if err != nil {
+			return fmt.Errorf("postback request failed: %w", err)
+		}
+		body, _ := io.ReadAll(pbRes.Body)
+		pbRes.Body.Close()
+
+		pass := pbRes.StatusCode >= 200 && pbRes.StatusCode < 300
+		rows := []map[string]interface{}{{
+			"tracker_id":      trackerID,
+			"subid":           subid,
+			"postback_status": fmt.Sprintf("%d", pbRes.StatusCode),
+			"result":          map[bool]string{true: "PASS", false: "FAIL"}[pass],
+			"detail":          strings.TrimSpace(string(body)),
+		}}
+		render(rowsToJSON(rows))
+		if !pass {
+			return partialFailureError("postback returned HTTP %d — conversions from this network would not record", pbRes.StatusCode)
+		}
+		return nil
+	},
+}
+
+func scheme(base string) string {
+	if strings.HasPrefix(base, "https") {
+		return "https"
+	}
+	return "http"
+}
+
+func init() {
+	conversionSimulateCmd.Flags().String("tracker", "", "Internal tracker_id to simulate a conversion through")
+	conversionSimulateCmd.Flags().String("payout", "1.00", "Conversion payout amount to post")
+	conversionCmd.AddCommand(conversionSimulateCmd, conversionPostbackURLCmd)
+}

--- a/go-cli/cmd/conversion_verify.go
+++ b/go-cli/cmd/conversion_verify.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"p202/internal/api"
 	"p202/internal/config"
@@ -91,8 +92,11 @@ var conversionSimulateCmd = &cobra.Command{
 		}
 
 		// 2. Fire a click and capture the subid from the redirect.
-		noRedir := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
-		clickRes, err := noRedir.Get(link + "&t202kw=simulate")
+		sep := "?"
+		if strings.Contains(link, "?") {
+			sep = "&"
+		}
+		clickRes, err := probeClient().Get(link + sep + "t202kw=simulate")
 		if err != nil {
 			return fmt.Errorf("click request failed: %w", err)
 		}
@@ -106,7 +110,7 @@ var conversionSimulateCmd = &cobra.Command{
 
 		// 3. Fire the real S2S postback (gpb.php).
 		pbURL := fmt.Sprintf("%s/tracking202/static/gpb.php?amount=%s&subid=%s", base, payout, subid)
-		pbRes, err := http.Get(pbURL)
+		pbRes, err := (&http.Client{Timeout: 15 * time.Second}).Get(pbURL)
 		if err != nil {
 			return fmt.Errorf("postback request failed: %w", err)
 		}

--- a/go-cli/cmd/countries.go
+++ b/go-cli/cmd/countries.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// countryNames maps ISO 3166-1 alpha-2 codes to the country name. The rotator
+// criteria value format is "Name(CC)", so --country US builds "United States(US)".
+// Covers the common affiliate geos; use raw --criteria_json for anything absent.
+var countryNames = map[string]string{
+	"US": "United States", "CA": "Canada", "GB": "United Kingdom", "AU": "Australia",
+	"NZ": "New Zealand", "IE": "Ireland", "NL": "Netherlands", "DE": "Germany",
+	"FR": "France", "ES": "Spain", "IT": "Italy", "PT": "Portugal", "BE": "Belgium",
+	"CH": "Switzerland", "AT": "Austria", "SE": "Sweden", "NO": "Norway",
+	"DK": "Denmark", "FI": "Finland", "PL": "Poland", "CZ": "Czechia",
+	"RO": "Romania", "GR": "Greece", "HU": "Hungary", "RU": "Russia",
+	"UA": "Ukraine", "TR": "Turkey", "BR": "Brazil", "MX": "Mexico",
+	"AR": "Argentina", "CL": "Chile", "CO": "Colombia", "PE": "Peru",
+	"IN": "India", "PK": "Pakistan", "BD": "Bangladesh", "ID": "Indonesia",
+	"PH": "Philippines", "VN": "Vietnam", "TH": "Thailand", "MY": "Malaysia",
+	"SG": "Singapore", "JP": "Japan", "KR": "South Korea", "CN": "China",
+	"HK": "Hong Kong", "TW": "Taiwan", "ZA": "South Africa", "NG": "Nigeria",
+	"EG": "Egypt", "KE": "Kenya", "SA": "Saudi Arabia", "AE": "United Arab Emirates",
+	"IL": "Israel", "GB-UK": "United Kingdom",
+}
+
+// countryCriteriaValue returns the "Name(CC)" rotator-criteria value for a code,
+// or "" if the code is unknown.
+func countryCriteriaValue(code string) string {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	if code == "UK" {
+		code = "GB"
+	}
+	if name, ok := countryNames[code]; ok {
+		return fmt.Sprintf("%s(%s)", name, code)
+	}
+	return ""
+}
+
+var rotatorCriteriaValuesCmd = &cobra.Command{
+	Use:   "criteria-values",
+	Short: "List valid rotator criteria values (e.g. the exact country strings)",
+	Long:  "Prints the value strings rules expect, so you never guess the `United States(US)` format. Filter with --search.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctype, _ := cmd.Flags().GetString("type")
+		search := strings.ToLower(mustString(cmd, "search"))
+		if ctype != "" && ctype != "country" {
+			return validationError("only --type country is supported")
+		}
+		rows := make([]map[string]interface{}, 0, len(countryNames))
+		for code, name := range countryNames {
+			if code == "GB-UK" {
+				continue
+			}
+			value := fmt.Sprintf("%s(%s)", name, code)
+			if search != "" && !strings.Contains(strings.ToLower(value), search) && !strings.Contains(strings.ToLower(code), search) {
+				continue
+			}
+			rows = append(rows, map[string]interface{}{"code": code, "name": name, "value": value})
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i]["name"].(string) < rows[j]["name"].(string) })
+		render(rowsToJSON(rows))
+		return nil
+	},
+}
+
+func init() {
+	rotatorCriteriaValuesCmd.Flags().String("type", "country", "Criteria type (country)")
+	rotatorCriteriaValuesCmd.Flags().String("search", "", "Filter values by substring")
+	rotatorCmd.AddCommand(rotatorCriteriaValuesCmd)
+}

--- a/go-cli/cmd/countries_test.go
+++ b/go-cli/cmd/countries_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "testing"
+
+func TestCountryCriteriaValue(t *testing.T) {
+	if v := countryCriteriaValue("US"); v != "United States(US)" {
+		t.Errorf("US -> %q, want United States(US)", v)
+	}
+	if v := countryCriteriaValue("uk"); v != "United Kingdom(GB)" { // UK normalizes to GB
+		t.Errorf("uk -> %q, want United Kingdom(GB)", v)
+	}
+	if v := countryCriteriaValue("ZZ"); v != "" {
+		t.Errorf("unknown code should return empty, got %q", v)
+	}
+}

--- a/go-cli/cmd/crosstab.go
+++ b/go-cli/cmd/crosstab.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"p202/internal/api"
+	"p202/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+// dimensionFilterParam maps a breakdown dimension to the entity-filter param
+// used to scope a second breakdown to one of its rows.
+var dimensionFilterParam = map[string]string{
+	"campaign":     "aff_campaign_id",
+	"aff_network":  "aff_network_id",
+	"ppc_account":  "ppc_account_id",
+	"ppc_network":  "ppc_network_id",
+	"landing_page": "landing_page_id",
+	"country":      "country_id",
+}
+
+var reportCrosstabCmd = &cobra.Command{
+	Use:   "crosstab",
+	Short: "Two-dimension breakdown (e.g. traffic source × country) for one metric",
+	Long: "Pivots one metric across two dimensions by fanning out a breakdown per row.\n" +
+		"Example: report crosstab --rows ppc_account --cols country --metric profit --aff_campaign_id 90008",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		rowDim := resolveDimension(mustString(cmd, "rows"))
+		colDim := resolveDimension(mustString(cmd, "cols"))
+		metric := resolveMetric(mustString(cmd, "metric"))
+		if rowDim == "" || colDim == "" {
+			return validationError("--rows and --cols are required")
+		}
+		if metric == "" {
+			metric = "total_net"
+		}
+		rowFilter := dimensionFilterParam[rowDim]
+		if rowFilter == "" {
+			return validationError("--rows %q can't be used as a crosstab axis (no entity filter)", rowDim)
+		}
+		limitRows, _ := cmd.Flags().GetInt("limit-rows")
+
+		base := collectReportParams(cmd)
+		base["breakdown"] = rowDim
+		rowRows, err := fetchBreakdownRows(c, base)
+		if err != nil {
+			return err
+		}
+		// Rank rows by the metric so the most significant appear first.
+		sortRowsBy(rowRows, metric, false)
+		if limitRows > 0 && len(rowRows) > limitRows {
+			rowRows = rowRows[:limitRows]
+		}
+
+		colSet := map[string]bool{}
+		matrix := make([]map[string]interface{}, 0, len(rowRows))
+		for _, rr := range rowRows {
+			rowID := fmt.Sprintf("%v", normalizeID(rr["id"]))
+			params := collectReportParams(cmd)
+			params["breakdown"] = colDim
+			params[rowFilter] = rowID
+			colRows, err := fetchBreakdownRows(c, params)
+			if err != nil {
+				continue
+			}
+			out := map[string]interface{}{rowDim: rr["name"]}
+			for _, cr := range colRows {
+				colName := fmt.Sprintf("%v", cr["name"])
+				colSet[colName] = true
+				out[colName] = round(toFloat(cr[metric]), 2)
+			}
+			matrix = append(matrix, out)
+		}
+
+		// Stable column order for the pivot.
+		cols := make([]string, 0, len(colSet))
+		for c := range colSet {
+			cols = append(cols, c)
+		}
+		sort.Strings(cols)
+		opts := renderOpts()
+		if len(opts.Fields) == 0 {
+			opts.Fields = append([]string{rowDim}, cols...)
+		}
+		out, _ := json.Marshal(map[string]interface{}{"data": matrix})
+		output.RenderWith(out, opts)
+		return nil
+	},
+}
+
+func init() {
+	addReportFilters(reportCrosstabCmd)
+	reportCrosstabCmd.Flags().String("rows", "", "Row dimension (ppc_account, country, campaign, ...)")
+	reportCrosstabCmd.Flags().String("cols", "", "Column dimension (country, device, ...)")
+	reportCrosstabCmd.Flags().String("metric", "total_net", "Metric to pivot (profit, roi, revenue, cost, clicks, conversions)")
+	reportCrosstabCmd.Flags().Int("limit-rows", 20, "Cap the number of rows fanned out")
+	reportCmd.AddCommand(reportCrosstabCmd)
+}

--- a/go-cli/cmd/crud.go
+++ b/go-cli/cmd/crud.go
@@ -86,6 +86,68 @@ func isNotFoundErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "404")
 }
 
+// deleteArgsValidator allows zero positional args when --ids is set, else one.
+func deleteArgsValidator(cmd *cobra.Command, args []string) error {
+	if ids, _ := cmd.Flags().GetString("ids"); strings.TrimSpace(ids) != "" {
+		return cobra.MaximumNArgs(0)(cmd, args)
+	}
+	return cobra.ExactArgs(1)(cmd, args)
+}
+
+// bulkOrSingleDelete deletes one id (positional) or many (--ids), honoring
+// --force, against endpoint/<id>. Shared so every delete has the same bulk
+// semantics. noun is used in confirmation and summary messages.
+func bulkOrSingleDelete(cmd *cobra.Command, endpoint, noun string) error {
+	c, err := api.NewFromConfig()
+	if err != nil {
+		return err
+	}
+	force, _ := cmd.Flags().GetBool("force")
+	idsFlag, _ := cmd.Flags().GetString("ids")
+	args := cmd.Flags().Args()
+
+	if strings.TrimSpace(idsFlag) != "" {
+		ids, perr := parseIDList(idsFlag)
+		if perr != nil {
+			return perr
+		}
+		if len(ids) == 0 {
+			return fmt.Errorf("--ids requires at least one ID")
+		}
+		if !force && !confirmPrompt("Delete %d %ss?", len(ids), noun) {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
+		deleted, failed := 0, 0
+		for _, id := range ids {
+			if err := c.Delete(endpoint + "/" + id); err != nil {
+				failed++
+				fmt.Fprintf(os.Stderr, "Failed to delete %s %s: %v\n", noun, id, err)
+				continue
+			}
+			deleted++
+		}
+		output.Success("Deleted %d of %d %ss.", deleted, len(ids), noun)
+		if failed > 0 {
+			return partialFailureError("failed to delete %d %ss", failed, noun)
+		}
+		return nil
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("provide a single id or use --ids")
+	}
+	if !force && !confirmPrompt("Delete %s %s?", noun, args[0]) {
+		fmt.Fprintln(os.Stderr, "Cancelled.")
+		return nil
+	}
+	if err := c.Delete(endpoint + "/" + args[0]); err != nil {
+		return err
+	}
+	output.Success("%s %s deleted.", capitalize(noun), args[0])
+	return nil
+}
+
 func getLongHelp(entity crudEntity) string {
 	if entity.PublicIDField == "" {
 		return ""

--- a/go-cli/cmd/crud.go
+++ b/go-cli/cmd/crud.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -69,12 +70,14 @@ func normalizeID(v interface{}) interface{} {
 // it resolves id as a public id and retries with the internal id.
 func getWithPublicFallback(c *api.Client, entity crudEntity, id string, forcePublic bool) ([]byte, error) {
 	if forcePublic {
-		if internal := resolvePublicID(c, entity, id); internal != "" {
-			id = internal
+		internal := resolvePublicID(c, entity, id)
+		if internal == "" {
+			return nil, validationError("no %s found with public %s=%s", entity.Name, entity.PublicIDField, id)
 		}
+		return c.Get(entity.Endpoint+"/"+internal, nil)
 	}
 	data, err := c.Get(entity.Endpoint+"/"+id, nil)
-	if err != nil && !forcePublic && isNotFoundErr(err) {
+	if err != nil && isNotFoundErr(err) {
 		if internal := resolvePublicID(c, entity, id); internal != "" {
 			return c.Get(entity.Endpoint+"/"+internal, nil)
 		}
@@ -82,8 +85,14 @@ func getWithPublicFallback(c *api.Client, entity crudEntity, id string, forcePub
 	return data, err
 }
 
+// isNotFoundErr reports whether err is a 404 from the API, preferring the
+// structured status over substring matching.
 func isNotFoundErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "404")
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Status == 404
+	}
+	return false
 }
 
 // deleteArgsValidator allows zero positional args when --ids is set, else one.

--- a/go-cli/cmd/crud.go
+++ b/go-cli/cmd/crud.go
@@ -24,12 +24,77 @@ type crudField struct {
 }
 
 type crudEntity struct {
-	Name       string
-	Aliases    []string
-	Plural     string
-	Endpoint   string
-	Fields     []crudField
-	ListParams []crudField
+	Name          string
+	Aliases       []string
+	Plural        string
+	Endpoint      string
+	Fields        []crudField
+	ListParams    []crudField
+	IDField       string // internal primary-key field (e.g. aff_campaign_id)
+	PublicIDField string // public-facing id field (e.g. aff_campaign_id_public)
+}
+
+// resolvePublicID treats id as a public id and returns the matching internal id
+// by filtering the list endpoint on the entity's PublicIDField. Returns "" when
+// the entity has no public-id mapping or no unique match is found.
+func resolvePublicID(c *api.Client, entity crudEntity, id string) string {
+	if entity.PublicIDField == "" || entity.IDField == "" {
+		return ""
+	}
+	data, err := c.Get(entity.Endpoint, map[string]string{"filter[" + entity.PublicIDField + "]": id})
+	if err != nil {
+		return ""
+	}
+	var resp struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if json.Unmarshal(data, &resp) != nil || len(resp.Data) != 1 {
+		return ""
+	}
+	if v, ok := resp.Data[0][entity.IDField]; ok {
+		return fmt.Sprintf("%v", normalizeID(v))
+	}
+	return ""
+}
+
+// normalizeID renders a numeric id without a trailing ".0".
+func normalizeID(v interface{}) interface{} {
+	if f, ok := v.(float64); ok && f == float64(int64(f)) {
+		return int64(f)
+	}
+	return v
+}
+
+// getWithPublicFallback fetches entity/<id>; on a 404 (or when forcePublic),
+// it resolves id as a public id and retries with the internal id.
+func getWithPublicFallback(c *api.Client, entity crudEntity, id string, forcePublic bool) ([]byte, error) {
+	if forcePublic {
+		if internal := resolvePublicID(c, entity, id); internal != "" {
+			id = internal
+		}
+	}
+	data, err := c.Get(entity.Endpoint+"/"+id, nil)
+	if err != nil && !forcePublic && isNotFoundErr(err) {
+		if internal := resolvePublicID(c, entity, id); internal != "" {
+			return c.Get(entity.Endpoint+"/"+internal, nil)
+		}
+	}
+	return data, err
+}
+
+func isNotFoundErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "404")
+}
+
+func getLongHelp(entity crudEntity) string {
+	if entity.PublicIDField == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Get a %s by id. Accepts the internal %s (from `%s list`). If you pass the\n"+
+			"public %s (the value in tracking links / the UI), it is resolved automatically;\n"+
+			"use --public to force the public lookup.",
+		entity.Name, entity.IDField, entity.Name, entity.PublicIDField)
 }
 
 type fkResolutionSpec struct {
@@ -355,6 +420,7 @@ func registerCRUD(entity crudEntity) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:   "get <id>",
 		Short: fmt.Sprintf("Get a %s by ID", entity.Name),
+		Long:  getLongHelp(entity),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 			done := metrics.Timer("get", entity.Endpoint)
@@ -363,13 +429,17 @@ func registerCRUD(entity crudEntity) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			data, err := c.Get(entity.Endpoint+"/"+args[0], nil)
+			forcePublic, _ := cmd.Flags().GetBool("public")
+			data, err := getWithPublicFallback(c, entity, args[0], forcePublic)
 			if err != nil {
 				return err
 			}
 			render(data)
 			return nil
 		},
+	}
+	if entity.PublicIDField != "" {
+		getCmd.Flags().Bool("public", false, fmt.Sprintf("Treat the id as the public %s", entity.PublicIDField))
 	}
 
 	// create
@@ -581,6 +651,8 @@ func init() {
 			Name:     "tracker",
 			Plural:   "trackers (tracking links that tie a traffic source to a campaign and landing page)",
 			Endpoint: "trackers",
+			IDField:  "tracker_id",
+			PublicIDField: "tracker_id_public",
 			Fields: []crudField{
 				{Name: "aff_campaign_id", Desc: "Campaign ID", Required: true},
 				{Name: "ppc_account_id", Desc: "PPC account ID"},
@@ -715,13 +787,22 @@ func init() {
 		getURLCmd := &cobra.Command{
 			Use:   "get-url <id>",
 			Short: "Get tracking URL for a tracker",
-			Args:  cobra.ExactArgs(1),
+			Long: "Accepts the internal tracker_id (from `tracker list`). If you pass the\n" +
+				"public tracker_id_public (the value in the tracking link), it is resolved\n" +
+				"automatically.",
+			Args: cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				c, err := api.NewFromConfig()
 				if err != nil {
 					return err
 				}
-				data, err := c.Get("trackers/"+args[0]+"/url", nil)
+				id := args[0]
+				data, err := c.Get("trackers/"+id+"/url", nil)
+				if err != nil && isNotFoundErr(err) {
+					if internal := resolvePublicID(c, trackerEntity, id); internal != "" {
+						data, err = c.Get("trackers/"+internal+"/url", nil)
+					}
+				}
 				if err != nil {
 					return err
 				}

--- a/go-cli/cmd/crud.go
+++ b/go-cli/cmd/crud.go
@@ -668,6 +668,7 @@ func init() {
 				{Name: "aff_campaign_id", QueryKey: "filter[aff_campaign_id]", Desc: "Filter by campaign ID"},
 				{Name: "ppc_account_id", QueryKey: "filter[ppc_account_id]", Desc: "Filter by PPC account ID"},
 				{Name: "landing_page_id", QueryKey: "filter[landing_page_id]", Desc: "Filter by landing page ID"},
+				{Name: "rotator_id", QueryKey: "filter[rotator_id]", Desc: "Filter by rotator ID"},
 			},
 		},
 		{

--- a/go-cli/cmd/dashboard.go
+++ b/go-cli/cmd/dashboard.go
@@ -45,7 +45,7 @@ func init() {
 	dashboardCmd.Flags().StringP("period", "p", "", "Period: today, yesterday, last7, last30, last90")
 	dashboardCmd.Flags().String("time_from", "", "Start timestamp (unix)")
 	dashboardCmd.Flags().String("time_to", "", "End timestamp (unix)")
-	dashboardCmd.Flags().String("aff_campaign_id", "", "Filter by campaign ID")
+	dashboardCmd.Flags().String("aff_campaign_id", "", "Filter by INTERNAL campaign id (from `campaign list`), not the public id in tracking URLs")
 	dashboardCmd.Flags().String("ppc_account_id", "", "Filter by PPC account ID")
 	dashboardCmd.Flags().String("aff_network_id", "", "Filter by affiliate network ID")
 	dashboardCmd.Flags().String("ppc_network_id", "", "Filter by PPC network ID")

--- a/go-cli/cmd/diff.go
+++ b/go-cli/cmd/diff.go
@@ -47,10 +47,8 @@ var diffCmd = &cobra.Command{
 			}
 		}
 
-		fromProfile, _ := cmd.Flags().GetString("from")
-		toProfile, _ := cmd.Flags().GetString("to")
-		fromProfile = strings.TrimSpace(fromProfile)
-		toProfile = strings.TrimSpace(toProfile)
+		fromProfile := firstFlag(cmd, "from", "source")
+		toProfile := firstFlag(cmd, "to", "target")
 		if fromProfile == "" || toProfile == "" {
 			return fmt.Errorf("--from and --to are required")
 		}
@@ -628,10 +626,10 @@ func loadProfileConnection(profileName string) (map[string]interface{}, error) {
 }
 
 func init() {
-	diffCmd.Flags().String("from", "", "Source profile name")
-	diffCmd.Flags().String("to", "", "Target profile name")
-	_ = diffCmd.MarkFlagRequired("from")
-	_ = diffCmd.MarkFlagRequired("to")
+	diffCmd.Flags().String("from", "", "Source profile name (alias: --source)")
+	diffCmd.Flags().String("to", "", "Target profile name (alias: --target)")
+	diffCmd.Flags().String("source", "", "Source profile (alias of --from)")
+	diffCmd.Flags().String("target", "", "Target profile (alias of --to)")
 
 	rootCmd.AddCommand(diffCmd)
 }

--- a/go-cli/cmd/exec.go
+++ b/go-cli/cmd/exec.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -171,10 +172,17 @@ func defaultExecProfileRunner(call execCall) execResult {
 	args = append(args, call.SubArgs...)
 
 	command := osexec.Command(executable, args...)
-	output, err := command.CombinedOutput()
+	// Capture stdout and stderr into distinct buffers so per-profile JSON on
+	// stdout parses cleanly and stderr (warnings, hints) is reported separately
+	// instead of being mixed in by CombinedOutput().
+	var stdoutBuf, stderrBuf bytes.Buffer
+	command.Stdout = &stdoutBuf
+	command.Stderr = &stderrBuf
+	err = command.Run()
 	result := execResult{
 		Profile: call.Profile,
-		Stdout:  string(output),
+		Stdout:  stdoutBuf.String(),
+		Stderr:  stderrBuf.String(),
 	}
 	if err == nil {
 		return result

--- a/go-cli/cmd/export.go
+++ b/go-cli/cmd/export.go
@@ -259,6 +259,6 @@ func rowDedupeKey(endpoint string, row map[string]interface{}) string {
 }
 
 func init() {
-	exportCmd.Flags().StringP("output", "o", "", "Output file path")
+	exportCmd.Flags().StringP("output", "O", "", "Output file path (-O; -o is reserved for --offset)")
 	rootCmd.AddCommand(exportCmd)
 }

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -124,8 +124,9 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		return validationError("unsupported interval %q. Choose from: %s", interval, strings.Join(forecast.ValidIntervals(), ", "))
 	}
 
-	history, _ := cmd.Flags().GetString("history")
-	history = strings.TrimSpace(history)
+	// --history is the canonical flag; --period/--days are accepted aliases so
+	// the time-window flag name is consistent with the report commands.
+	history := firstFlag(cmd, "history", "period", "days")
 	if history == "" {
 		history = "last90"
 	}
@@ -134,7 +135,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// so hourly windows longer than last30 (720 buckets) would silently drop
 	// the most recent hours — the ones forecasts anchor on.
 	if interval == "hour" {
-		if !cmd.Flags().Changed("history") {
+		if !cmd.Flags().Changed("history") && !cmd.Flags().Changed("period") && !cmd.Flags().Changed("days") {
 			history = "last30"
 		} else {
 			switch history {
@@ -797,7 +798,9 @@ func init() {
 	forecastCmd.Flags().String("method", "auto", "Forecasting method: auto, linear, sma, wma, holtwinters")
 	forecastCmd.Flags().IntP("horizon", "n", 7, "Number of periods to forecast forward")
 	forecastCmd.Flags().StringP("interval", "i", "day", "Forecast granularity: hour, day, week, month")
-	forecastCmd.Flags().String("history", "last90", "Historical data period: today, yesterday, last7, last30, last90")
+	forecastCmd.Flags().String("history", "last90", "Historical data period: today, yesterday, last7, last30, last90 (aliases: --period, --days)")
+	forecastCmd.Flags().String("period", "", "Alias of --history")
+	forecastCmd.Flags().String("days", "", "Alias of --history")
 	forecastCmd.Flags().Int("window", 0, "SMA/WMA window size (0 = auto-select)")
 	forecastCmd.Flags().Bool("seasonal", false, "Apply day-of-week seasonal adjustment from weekpart data")
 	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds (0.80, 0.90, 0.95, 0.99)")

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -125,10 +125,17 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	}
 
 	// --history is the canonical flag; --period/--days are accepted aliases so
-	// the time-window flag name is consistent with the report commands.
-	history := firstFlag(cmd, "history", "period", "days")
-	if history == "" {
-		history = "last90"
+	// the time-window flag name is consistent with the report commands. Because
+	// --history carries a non-empty default, only an *explicitly set* alias must
+	// win — so resolve by Changed(), not by the default value.
+	history := "last90"
+	for _, name := range []string{"history", "period", "days"} {
+		if cmd.Flags().Changed(name) {
+			if v, _ := cmd.Flags().GetString(name); strings.TrimSpace(v) != "" {
+				history = strings.TrimSpace(v)
+				break
+			}
+		}
 	}
 
 	// reports/timeseries returns at most 2000 buckets ordered oldest-first,

--- a/go-cli/cmd/optimize_campaign.go
+++ b/go-cli/cmd/optimize_campaign.go
@@ -51,6 +51,11 @@ var campaignOptimizeCmd = &cobra.Command{
 		// 2. Rank other offers by EPC over the same period (the salvage candidates).
 		portParams := collectReportParams(cmd)
 		portParams["breakdown"] = "campaign"
+		// The backend defaults to limit=50 sorted by clicks; raise the limit and
+		// sort by revenue so a high-EPC salvage offer isn't missed on page 1.
+		portParams["limit"] = "500"
+		portParams["sort"] = "total_income"
+		portParams["sort_dir"] = "DESC"
 		offers, _ := fetchBreakdownRows(c, portParams)
 		type cand struct {
 			name string

--- a/go-cli/cmd/optimize_campaign.go
+++ b/go-cli/cmd/optimize_campaign.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"p202/internal/api"
+
+	"github.com/spf13/cobra"
+)
+
+var campaignOptimizeCmd = &cobra.Command{
+	Use:   "optimize <campaign_id>",
+	Short: "Diagnose a campaign and recommend a salvage offer for its traffic",
+	Long: "Summarizes the campaign's break-even/ROI status and ranks other offers by EPC,\n" +
+		"so you can route losing traffic to the offer that monetizes it best.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		id := args[0]
+
+		// 1. This campaign's totals + payout.
+		payout, _ := fetchCampaignPayout(c, id)
+		params := collectReportParams(cmd)
+		params["aff_campaign_id"] = id
+		sumRaw, err := c.Get("reports/summary", params)
+		if err != nil {
+			return err
+		}
+		var sum struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		_ = json.Unmarshal(sumRaw, &sum)
+		s := sum.Data
+		clicks := toFloat(s["total_clicks"])
+		leads := toFloat(s["total_leads"])
+		cost := toFloat(s["total_cost"])
+		income := toFloat(s["total_income"])
+		net := income - cost
+		cvr, epc, be := 0.0, 0.0, 0.0
+		if clicks > 0 {
+			cvr = leads / clicks
+			epc = income / clicks
+		}
+		be = payout * cvr
+
+		// 2. Rank other offers by EPC over the same period (the salvage candidates).
+		portParams := collectReportParams(cmd)
+		portParams["breakdown"] = "campaign"
+		offers, _ := fetchBreakdownRows(c, portParams)
+		type cand struct {
+			name string
+			epc  float64
+		}
+		var best []cand
+		for _, o := range offers {
+			if fmt.Sprintf("%v", normalizeID(o["id"])) == id {
+				continue
+			}
+			oc := toFloat(o["total_clicks"])
+			if oc <= 0 {
+				continue
+			}
+			best = append(best, cand{fmt.Sprintf("%v", o["name"]), toFloat(o["total_income"]) / oc})
+		}
+		for i := 0; i < len(best); i++ {
+			for j := i + 1; j < len(best); j++ {
+				if best[j].epc > best[i].epc {
+					best[i], best[j] = best[j], best[i]
+				}
+			}
+		}
+
+		// Print a human report to stderr; emit the structured rows on stdout.
+		fmt.Fprintf(os.Stderr, "\nCampaign %s — %.0f clicks, %.0f conv (%.1f%% CVR), EPC $%.3f, break-even CPC $%.3f\n",
+			id, clicks, leads, cvr*100, epc, be)
+		fmt.Fprintf(os.Stderr, "P&L: revenue $%.2f − cost $%.2f = $%.2f  (%s)\n", income, cost, net,
+			map[bool]string{true: "PROFITABLE", false: "LOSING"}[net >= 0])
+		if net < 0 && len(best) > 0 {
+			top := best[0]
+			fmt.Fprintf(os.Stderr, "Recommendation: this offer is losing money. Highest-EPC alternative for this traffic is %q (EPC $%.3f, vs $%.3f here).\n",
+				top.name, top.epc, epc)
+			fmt.Fprintf(os.Stderr, "Next: create a rotator defaulting to the salvage offer, keep converting geos on this one:\n")
+			fmt.Fprintf(os.Stderr, "  p202 rotator create --name \"Salvage\" --default_campaign <salvage_id>\n")
+			fmt.Fprintf(os.Stderr, "  p202 rotator rule-create <rid> --rule_name \"US\" --country US --redirect-campaign %s\n\n", id)
+		} else if net >= 0 {
+			fmt.Fprintln(os.Stderr, "Recommendation: profitable — scale the winning sources (`report winners`).")
+		}
+
+		rows := make([]map[string]interface{}, 0, len(best))
+		for _, b := range best {
+			rows = append(rows, map[string]interface{}{"name": b.name, "epc": round(b.epc, 3)})
+		}
+		render(rowsToJSON(rows))
+		return nil
+	},
+}
+
+func init() {
+	addReportFilters(campaignOptimizeCmd)
+	if cc := findChildCommand("campaign"); cc != nil {
+		cc.AddCommand(campaignOptimizeCmd)
+	}
+}

--- a/go-cli/cmd/optimize_campaign.go
+++ b/go-cli/cmd/optimize_campaign.go
@@ -23,8 +23,12 @@ var campaignOptimizeCmd = &cobra.Command{
 		}
 		id := args[0]
 
-		// 1. This campaign's totals + payout.
-		payout, _ := fetchCampaignPayout(c, id)
+		// 1. This campaign's totals + payout. Surface a bad campaign id here
+		// rather than silently optimizing with payout 0.
+		payout, err := fetchCampaignPayout(c, id)
+		if err != nil {
+			return err
+		}
 		params := collectReportParams(cmd)
 		params["aff_campaign_id"] = id
 		sumRaw, err := c.Get("reports/summary", params)

--- a/go-cli/cmd/publicid_test.go
+++ b/go-cli/cmd/publicid_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A tracker fetched by its public id should 404 on the internal route, then
+// resolve via the tracker_id_public filter and retry with the internal id.
+func TestTrackerGetResolvesPublicId(t *testing.T) {
+	var hitInternal bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/trackers/28996586":
+			w.WriteHeader(404)
+			w.Write([]byte(`{"message":"not found"}`))
+		case r.URL.Path == "/api/v3/trackers" && r.URL.Query().Get("filter[tracker_id_public]") == "28996586":
+			w.WriteHeader(200)
+			w.Write([]byte(`{"data":[{"tracker_id":90029,"tracker_id_public":28996586}]}`))
+		case r.URL.Path == "/api/v3/trackers/90029":
+			hitInternal = true
+			w.WriteHeader(200)
+			w.Write([]byte(`{"data":{"tracker_id":90029,"tracker_id_public":28996586}}`))
+		default:
+			w.WriteHeader(404)
+			w.Write([]byte(`{"message":"unexpected"}`))
+		}
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("tracker", "get", "28996586", "--json")
+	if err != nil {
+		t.Fatalf("tracker get by public id failed: %v", err)
+	}
+	if !hitInternal {
+		t.Error("expected a retry against the internal id route after 404")
+	}
+	if !strings.Contains(stdout, "90029") {
+		t.Errorf("output should contain the resolved tracker, got:\n%s", stdout)
+	}
+}
+
+func TestNormalizeID(t *testing.T) {
+	if got := normalizeID(float64(90029)); got != int64(90029) {
+		t.Errorf("normalizeID(90029.0) = %v, want int64 90029", got)
+	}
+}

--- a/go-cli/cmd/render.go
+++ b/go-cli/cmd/render.go
@@ -1,11 +1,31 @@
 package cmd
 
-import "p202/internal/output"
+import (
+	"strings"
+
+	"p202/internal/output"
+)
+
+// renderOpts builds output.Opts from the global output flags.
+func renderOpts() output.Opts {
+	opts := output.Opts{
+		JSON:       jsonOutput,
+		CSV:        csvOutput,
+		Quiet:      quietOutput,
+		NDJSON:     ndjsonOutput,
+		Wide:       wideOutput,
+		RawHeaders: rawHeaders,
+	}
+	if strings.TrimSpace(fieldsFlag) != "" {
+		for _, f := range strings.Split(fieldsFlag, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				opts.Fields = append(opts.Fields, f)
+			}
+		}
+	}
+	return opts
+}
 
 func render(data []byte) {
-	if csvOutput {
-		output.RenderCSV(data)
-		return
-	}
-	output.Render(data, jsonOutput)
+	output.RenderWith(data, renderOpts())
 }

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -29,7 +29,7 @@ func addReportFilters(cmd *cobra.Command) {
 	cmd.Flags().StringP("period", "p", "", "Period: today, yesterday, last7, last30, last90")
 	cmd.Flags().String("time_from", "", "Start timestamp (unix)")
 	cmd.Flags().String("time_to", "", "End timestamp (unix)")
-	cmd.Flags().String("aff_campaign_id", "", "Filter by campaign ID")
+	cmd.Flags().String("aff_campaign_id", "", "Filter by INTERNAL campaign id (from `campaign list`), not the public id in tracking URLs")
 	cmd.Flags().String("ppc_account_id", "", "Filter by PPC account ID")
 	cmd.Flags().String("aff_network_id", "", "Filter by affiliate network ID")
 	cmd.Flags().String("ppc_network_id", "", "Filter by PPC network ID")

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -119,7 +119,7 @@ var reportBreakdownCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		render(data)
+		render(applyBreakdownFilters(cmd, data))
 		return nil
 	},
 }
@@ -195,6 +195,10 @@ func init() {
 	reportBreakdownCmd.Flags().String("sort-dir", "", "Alias for --sort_dir (matches `analytics --sort-dir`)")
 	reportBreakdownCmd.Flags().StringP("limit", "l", "", "Max results")
 	reportBreakdownCmd.Flags().StringP("offset", "o", "", "Pagination offset")
+	reportBreakdownCmd.Flags().Float64("min-clicks", 0, "Only rows with at least N clicks")
+	reportBreakdownCmd.Flags().Float64("min-cost", 0, "Only rows with at least $N cost")
+	reportBreakdownCmd.Flags().Bool("zero-leads", false, "Only rows with cost > 0 and zero conversions (pure waste)")
+	reportBreakdownCmd.Flags().String("having", "", "Post-filter rows: FIELD OP VALUE (e.g. 'total_leads=0', 'roi<0')")
 
 	addReportFilters(reportTimeseriesCmd)
 	reportTimeseriesCmd.Flags().StringP("interval", "i", "", "Interval: hour, day, week, month")

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -99,10 +99,8 @@ var reportBreakdownCmd = &cobra.Command{
 			params["breakdown"] = breakdown
 		}
 
+		// --sort-dir is accepted via the global flag normalizer (- == _).
 		sortDir, _ := cmd.Flags().GetString("sort_dir")
-		if sortDir == "" {
-			sortDir, _ = cmd.Flags().GetString("sort-dir")
-		}
 		if sortDir == "" {
 			sortDir = getConfigDefault("report", "sort_dir")
 		}
@@ -204,7 +202,6 @@ func init() {
 	reportBreakdownCmd.Flags().String("group-by", "", "Alias for --breakdown (matches `analytics --group-by`)")
 	reportBreakdownCmd.Flags().StringP("sort", "s", "", "Sort by: total_clicks, total_leads, total_income, total_cost, total_net, roi, epc, conv_rate")
 	reportBreakdownCmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC")
-	reportBreakdownCmd.Flags().String("sort-dir", "", "Alias for --sort_dir (matches `analytics --sort-dir`)")
 	reportBreakdownCmd.Flags().StringP("limit", "l", "", "Max results")
 	reportBreakdownCmd.Flags().StringP("offset", "o", "", "Pagination offset")
 	reportBreakdownCmd.Flags().Float64("min-clicks", 0, "Only rows with at least N clicks")

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"p202/internal/api"
 
 	"github.com/spf13/cobra"
@@ -93,10 +91,7 @@ var reportBreakdownCmd = &cobra.Command{
 		if breakdown == "" {
 			breakdown = getConfigDefault("report", "breakdown")
 		}
-		breakdown = strings.ToLower(strings.TrimSpace(breakdown))
-		if mapped, ok := analyticsGroupByAliases[breakdown]; ok {
-			breakdown = mapped
-		}
+		breakdown = resolveDimension(breakdown)
 		if breakdown != "" {
 			params["breakdown"] = breakdown
 		}
@@ -112,7 +107,10 @@ var reportBreakdownCmd = &cobra.Command{
 			params["sort_dir"] = sortDir
 		}
 
-		for _, f := range []string{"sort", "limit", "offset"} {
+		if v := getStringFlagOrDefault(cmd, "report", "sort"); v != "" {
+			params["sort"] = resolveMetric(v)
+		}
+		for _, f := range []string{"limit", "offset"} {
 			if v := getStringFlagOrDefault(cmd, "report", f); v != "" {
 				params[f] = v
 			}
@@ -156,11 +154,7 @@ var reportWeekpartCmd = &cobra.Command{
 			return err
 		}
 		params := collectReportParams(cmd)
-		for _, f := range []string{"sort", "sort_dir"} {
-			if v := getStringFlagOrDefault(cmd, "report", f); v != "" {
-				params[f] = v
-			}
-		}
+		applyReportSort(cmd, params)
 		data, err := c.Get("reports/weekpart", params)
 		if err != nil {
 			return err
@@ -179,11 +173,7 @@ var reportDaypartCmd = &cobra.Command{
 			return err
 		}
 		params := collectReportParams(cmd)
-		for _, f := range []string{"sort", "sort_dir"} {
-			if v := getStringFlagOrDefault(cmd, "report", f); v != "" {
-				params[f] = v
-			}
-		}
+		applyReportSort(cmd, params)
 		data, err := c.Get("reports/daypart", params)
 		if err != nil {
 			return err
@@ -210,12 +200,10 @@ func init() {
 	reportTimeseriesCmd.Flags().StringP("interval", "i", "", "Interval: hour, day, week, month")
 
 	addReportFilters(reportDaypartCmd)
-	reportDaypartCmd.Flags().StringP("sort", "s", "", "Sort by: hour_of_day, total_clicks, total_click_throughs, total_leads, total_income, total_cost, total_net, epc, avg_cpc, conv_rate, roi, cpa")
-	reportDaypartCmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC")
+	addSortFlags(reportDaypartCmd, "Sort by: hour_of_day, clicks, conversions, revenue, cost, profit, roi, epc, conv_rate, cpa, avg_cpc (friendly aliases ok)")
 
 	addReportFilters(reportWeekpartCmd)
-	reportWeekpartCmd.Flags().StringP("sort", "s", "", "Sort by: day_of_week, total_clicks, total_leads, total_income, total_cost, total_net, roi, epc, conv_rate")
-	reportWeekpartCmd.Flags().String("sort_dir", "", "Sort direction: ASC or DESC")
+	addSortFlags(reportWeekpartCmd, "Sort by: day_of_week, clicks, conversions, revenue, cost, profit, roi, epc, conv_rate (friendly aliases ok)")
 
 	reportCmd.AddCommand(reportSummaryCmd, reportBreakdownCmd, reportTimeseriesCmd, reportDaypartCmd, reportWeekpartCmd)
 	rootCmd.AddCommand(reportCmd)

--- a/go-cli/cmd/report.go
+++ b/go-cli/cmd/report.go
@@ -77,6 +77,9 @@ var reportBreakdownCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := rejectMultiProfile(cmd); err != nil {
+			return err
+		}
 		params := collectReportParams(cmd)
 
 		// Accept the analytics shorthand's friendly flags for consistency:
@@ -132,6 +135,9 @@ var reportTimeseriesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := rejectMultiProfile(cmd); err != nil {
+			return err
+		}
 		params := collectReportParams(cmd)
 		if v := getStringFlagOrDefault(cmd, "report", "interval"); v != "" {
 			params["interval"] = v
@@ -153,6 +159,9 @@ var reportWeekpartCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := rejectMultiProfile(cmd); err != nil {
+			return err
+		}
 		params := collectReportParams(cmd)
 		applyReportSort(cmd, params)
 		data, err := c.Get("reports/weekpart", params)
@@ -170,6 +179,9 @@ var reportDaypartCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := api.NewFromConfig()
 		if err != nil {
+			return err
+		}
+		if err := rejectMultiProfile(cmd); err != nil {
 			return err
 		}
 		params := collectReportParams(cmd)

--- a/go-cli/cmd/report_optimize.go
+++ b/go-cli/cmd/report_optimize.go
@@ -1,0 +1,289 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"p202/internal/api"
+
+	"github.com/spf13/cobra"
+)
+
+// toFloat coerces an API value (number or numeric string) to float64.
+func toFloat(v interface{}) float64 {
+	switch x := v.(type) {
+	case float64:
+		return x
+	case int:
+		return float64(x)
+	case string:
+		f, _ := strconv.ParseFloat(x, 64)
+		return f
+	default:
+		return 0
+	}
+}
+
+// fetchCampaignPayout returns the default payout for a campaign (internal id).
+func fetchCampaignPayout(c *api.Client, campaignID string) (float64, error) {
+	data, err := c.Get("campaigns/"+campaignID, nil)
+	if err != nil {
+		return 0, err
+	}
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return 0, err
+	}
+	return toFloat(resp.Data["aff_campaign_payout"]), nil
+}
+
+// fetchBreakdownRows runs a breakdown report and returns its rows.
+func fetchBreakdownRows(c *api.Client, params map[string]string) ([]map[string]interface{}, error) {
+	data, err := c.Get("reports/breakdown", params)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// enrichBreakeven adds breakeven_cpc, margin, and a verdict to each row.
+// breakeven_cpc = payout * (leads/clicks); margin = breakeven_cpc - avg_cpc.
+// When targetCPC > 0 it overrides the payout-derived breakeven.
+func enrichBreakeven(rows []map[string]interface{}, payout, targetCPC float64) {
+	for _, r := range rows {
+		clicks := toFloat(r["total_clicks"])
+		leads := toFloat(r["total_leads"])
+		cost := toFloat(r["total_cost"])
+		cvr := 0.0
+		if clicks > 0 {
+			cvr = leads / clicks
+		}
+		avgCPC := 0.0
+		if clicks > 0 {
+			avgCPC = cost / clicks
+		}
+		be := payout * cvr
+		if targetCPC > 0 {
+			be = targetCPC
+		}
+		margin := be - avgCPC
+		r["conv_rate"] = round(cvr*100, 2)
+		r["avg_cpc"] = round(avgCPC, 4)
+		r["breakeven_cpc"] = round(be, 4)
+		r["margin"] = round(margin, 4)
+		r["verdict"] = breakevenVerdict(leads, cost, margin)
+	}
+}
+
+func breakevenVerdict(leads, cost, margin float64) string {
+	if leads == 0 {
+		if cost > 0 {
+			return "NO-CONVERT"
+		}
+		return "NO-DATA"
+	}
+	if margin >= 0 {
+		return "PROFITABLE"
+	}
+	return "OVER-BID"
+}
+
+func round(f float64, places int) float64 {
+	p := 1.0
+	for i := 0; i < places; i++ {
+		p *= 10
+	}
+	return float64(int64(f*p+sign(f)*0.5)) / p
+}
+
+func sign(f float64) float64 {
+	if f < 0 {
+		return -1
+	}
+	return 1
+}
+
+func rowsToJSON(rows []map[string]interface{}) []byte {
+	out, _ := json.Marshal(map[string]interface{}{"data": rows})
+	return out
+}
+
+var reportBreakevenCmd = &cobra.Command{
+	Use:   "breakeven",
+	Short: "Break-even CPC per row: max biddable click price (payout × conversion rate)",
+	Long: "Computes the maximum profitable cost-per-click for each breakdown row.\n" +
+		"breakeven_cpc = campaign payout × (conversions / clicks); margin = breakeven_cpc − avg_cpc.\n" +
+		"Requires --aff_campaign_id (the INTERNAL id from `campaign list`) to read the payout.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		campaignID, _ := cmd.Flags().GetString("aff_campaign_id")
+		if campaignID == "" {
+			return validationError("--aff_campaign_id is required (the internal id from `campaign list`)")
+		}
+		maxCPC, _ := cmd.Flags().GetFloat64("max-cpc")
+
+		payout := maxCPC // if max-cpc set, payout isn't needed for the target
+		if maxCPC <= 0 {
+			payout, err = fetchCampaignPayout(c, campaignID)
+			if err != nil {
+				return err
+			}
+		}
+
+		params := collectReportParams(cmd)
+		breakdown, _ := cmd.Flags().GetString("breakdown")
+		if breakdown == "" {
+			breakdown = "keyword"
+		}
+		params["breakdown"] = resolveDimension(breakdown)
+
+		rows, err := fetchBreakdownRows(c, params)
+		if err != nil {
+			return err
+		}
+		enrichBreakeven(rows, payout, maxCPC)
+		sortRowsBy(rows, "margin", true) // worst margin first
+		render(rowsToJSON(rows))
+		return nil
+	},
+}
+
+// triageCmd builds `report losers` / `report winners`.
+func triageCmd(use, short string, wantWinners bool) *cobra.Command {
+	c := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := api.NewFromConfig()
+			if err != nil {
+				return err
+			}
+			minClicks, _ := cmd.Flags().GetFloat64("min-clicks")
+			maxCPC, _ := cmd.Flags().GetFloat64("max-cpc")
+			campaignID, _ := cmd.Flags().GetString("aff_campaign_id")
+
+			var payout float64
+			if maxCPC <= 0 && campaignID != "" {
+				payout, _ = fetchCampaignPayout(client, campaignID)
+			}
+
+			params := collectReportParams(cmd)
+			breakdown, _ := cmd.Flags().GetString("breakdown")
+			if breakdown == "" {
+				breakdown = "keyword"
+			}
+			params["breakdown"] = resolveDimension(breakdown)
+
+			rows, err := fetchBreakdownRows(client, params)
+			if err != nil {
+				return err
+			}
+
+			out := make([]map[string]interface{}, 0, len(rows))
+			for _, r := range rows {
+				clicks := toFloat(r["total_clicks"])
+				leads := toFloat(r["total_leads"])
+				cost := toFloat(r["total_cost"])
+				net := toFloat(r["total_net"])
+				if clicks < minClicks {
+					continue
+				}
+				avgCPC := 0.0
+				if clicks > 0 {
+					avgCPC = cost / clicks
+				}
+				bucket, reason := classify(clicks, leads, cost, net, avgCPC, payout, maxCPC)
+				keep := false
+				if wantWinners && bucket == "SCALE" {
+					keep = true
+				}
+				if !wantWinners && bucket == "CUT" {
+					keep = true
+				}
+				if !keep {
+					continue
+				}
+				row := map[string]interface{}{
+					"name":         r["name"],
+					"total_clicks": clicks,
+					"total_leads":  leads,
+					"total_cost":   round(cost, 2),
+					"total_net":    round(net, 2),
+					"avg_cpc":      round(avgCPC, 4),
+					"bucket":       bucket,
+					"reason":       reason,
+				}
+				if id, ok := r["id"]; ok {
+					row["id"] = id
+				}
+				out = append(out, row)
+			}
+			sortRowsBy(out, "total_net", !wantWinners) // losers: worst first; winners: best first
+			render(rowsToJSON(out))
+			return nil
+		},
+	}
+	return c
+}
+
+// classify buckets a row into SCALE / WATCH / CUT with a human reason.
+func classify(clicks, leads, cost, net, avgCPC, payout, maxCPC float64) (string, string) {
+	target := maxCPC
+	if target <= 0 && payout > 0 && clicks > 0 {
+		target = payout * (leads / clicks)
+	}
+	if leads == 0 && cost > 0 {
+		return "CUT", fmt.Sprintf("spent $%.2f, 0 conversions", cost)
+	}
+	if target > 0 && avgCPC > target {
+		return "CUT", fmt.Sprintf("CPC $%.2f > breakeven $%.2f", avgCPC, target)
+	}
+	if net > 0 && leads > 0 {
+		return "SCALE", fmt.Sprintf("profit +$%.2f, %d conv", net, int64(leads))
+	}
+	if net < 0 {
+		return "WATCH", fmt.Sprintf("loss $%.2f", net)
+	}
+	return "WATCH", "break-even"
+}
+
+// sortRowsBy sorts rows by a numeric field; asc=true sorts ascending.
+func sortRowsBy(rows []map[string]interface{}, field string, asc bool) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := toFloat(rows[i][field]), toFloat(rows[j][field])
+		if asc {
+			return a < b
+		}
+		return a > b
+	})
+}
+
+func init() {
+	addReportFilters(reportBreakevenCmd)
+	reportBreakevenCmd.Flags().StringP("breakdown", "b", "keyword", "Dimension: keyword, country, ppc_account, device, ... (alias: lp)")
+	reportBreakevenCmd.Flags().Float64("max-cpc", 0, "Override the payout-derived break-even CPC target")
+	reportCmd.AddCommand(reportBreakevenCmd)
+
+	losers := triageCmd("losers", "Rows to CUT: over-bid keywords/geos and zero-conversion spend", false)
+	winners := triageCmd("winners", "Rows to SCALE: profitable, converting keywords/geos", true)
+	for _, c := range []*cobra.Command{losers, winners} {
+		addReportFilters(c)
+		c.Flags().StringP("breakdown", "b", "keyword", "Dimension to triage (keyword, country, ppc_account, device, ...)")
+		c.Flags().Float64("min-clicks", 1, "Ignore rows with fewer than N clicks (significance floor)")
+		c.Flags().Float64("max-cpc", 0, "Break-even CPC target (else derived from campaign payout × CVR)")
+		reportCmd.AddCommand(c)
+	}
+}

--- a/go-cli/cmd/report_optimize_test.go
+++ b/go-cli/cmd/report_optimize_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import "testing"
+
+func TestEnrichBreakevenComputesMarginAndVerdict(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"total_clicks": 100.0, "total_leads": 20.0, "total_cost": 50.0}, // CVR 20%, CPC 0.50
+	}
+	enrichBreakeven(rows, 2.20, 0) // payout 2.20 -> breakeven 0.44
+	r := rows[0]
+	if be := toFloat(r["breakeven_cpc"]); be < 0.43 || be > 0.45 {
+		t.Errorf("breakeven_cpc = %v, want ~0.44", be)
+	}
+	if m := toFloat(r["margin"]); m > -0.05 || m < -0.07 { // 0.44 - 0.50 = -0.06
+		t.Errorf("margin = %v, want ~-0.06", m)
+	}
+	if r["verdict"] != "OVER-BID" {
+		t.Errorf("verdict = %v, want OVER-BID", r["verdict"])
+	}
+}
+
+func TestEnrichBreakevenProfitable(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"total_clicks": 100.0, "total_leads": 30.0, "total_cost": 10.0}, // CVR 30%, CPC 0.10
+	}
+	enrichBreakeven(rows, 2.20, 0) // breakeven 0.66 > 0.10
+	if rows[0]["verdict"] != "PROFITABLE" {
+		t.Errorf("verdict = %v, want PROFITABLE", rows[0]["verdict"])
+	}
+}
+
+func TestBreakevenVerdictNoConvert(t *testing.T) {
+	if v := breakevenVerdict(0, 50, -1); v != "NO-CONVERT" {
+		t.Errorf("zero leads with spend should be NO-CONVERT, got %v", v)
+	}
+	if v := breakevenVerdict(0, 0, 0); v != "NO-DATA" {
+		t.Errorf("zero leads no spend should be NO-DATA, got %v", v)
+	}
+}
+
+func TestClassifyBuckets(t *testing.T) {
+	// zero conversions with spend -> CUT
+	if b, _ := classify(100, 0, 50, -50, 0.5, 2.2, 0); b != "CUT" {
+		t.Errorf("zero-conv spend should be CUT, got %s", b)
+	}
+	// over-bid (CPC above breakeven) -> CUT
+	if b, _ := classify(100, 10, 60, -38, 0.6, 2.2, 0); b != "CUT" { // breakeven 0.22 < 0.60
+		t.Errorf("over-bid should be CUT, got %s", b)
+	}
+	// profitable -> SCALE
+	if b, _ := classify(100, 20, 10, 34, 0.1, 2.2, 0); b != "SCALE" {
+		t.Errorf("profitable should be SCALE, got %s", b)
+	}
+}
+
+func TestResolveDimensionAndMetric(t *testing.T) {
+	if resolveDimension("lp") != "landing_page" {
+		t.Error("lp should map to landing_page")
+	}
+	if resolveDimension("source") != "ppc_account" {
+		t.Error("source should map to ppc_account")
+	}
+	if resolveMetric("profit") != "total_net" {
+		t.Error("profit should map to total_net")
+	}
+	if resolveMetric("clicks") != "total_clicks" {
+		t.Error("clicks should map to total_clicks")
+	}
+}

--- a/go-cli/cmd/report_optimize_test.go
+++ b/go-cli/cmd/report_optimize_test.go
@@ -67,3 +67,26 @@ func TestResolveDimensionAndMetric(t *testing.T) {
 		t.Error("clicks should map to total_clicks")
 	}
 }
+
+func TestParseHaving(t *testing.T) {
+	f, op, v, ok := parseHaving("roi<0")
+	if !ok || f != "roi" || op != "<" || v != 0 {
+		t.Errorf("parseHaving(roi<0) = %q %q %v %v", f, op, v, ok)
+	}
+	f, op, _, ok = parseHaving("profit>=5")
+	if !ok || f != "total_net" || op != ">=" { // profit -> total_net alias
+		t.Errorf("parseHaving(profit>=5) field/op = %q %q", f, op)
+	}
+	if _, _, _, ok := parseHaving(""); ok {
+		t.Error("empty having should not parse")
+	}
+}
+
+func TestCompareNum(t *testing.T) {
+	if !compareNum(-5, "<", 0) || compareNum(5, "<", 0) {
+		t.Error("< comparison wrong")
+	}
+	if !compareNum(0, "=", 0) || !compareNum(3, ">=", 3) {
+		t.Error("=/>= comparison wrong")
+	}
+}

--- a/go-cli/cmd/root.go
+++ b/go-cli/cmd/root.go
@@ -14,6 +14,11 @@ import (
 
 var jsonOutput bool
 var csvOutput bool
+var quietOutput bool
+var ndjsonOutput bool
+var wideOutput bool
+var rawHeaders bool
+var fieldsFlag string
 var profileName string
 var groupName string
 
@@ -66,6 +71,11 @@ func SetVersion(version string) {
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output raw JSON instead of tables")
 	rootCmd.PersistentFlags().BoolVar(&csvOutput, "csv", false, "Output as CSV instead of tables")
+	rootCmd.PersistentFlags().BoolVarP(&quietOutput, "quiet", "q", false, "Print only ids, one per line (for scripting)")
+	rootCmd.PersistentFlags().BoolVar(&ndjsonOutput, "ndjson", false, "Output newline-delimited JSON (one row per line)")
+	rootCmd.PersistentFlags().BoolVar(&wideOutput, "wide", false, "Show all columns at full width (no truncation)")
+	rootCmd.PersistentFlags().BoolVar(&rawHeaders, "raw-headers", false, "Use raw API field names as table headers")
+	rootCmd.PersistentFlags().StringVar(&fieldsFlag, "fields", "", "Comma-separated columns to show, in order")
 	rootCmd.PersistentFlags().StringVar(&profileName, "profile", "", "Use a named configuration profile")
 	rootCmd.PersistentFlags().StringVar(&groupName, "group", "", "Use a tag group of profiles for multi-profile commands")
 }

--- a/go-cli/cmd/root.go
+++ b/go-cli/cmd/root.go
@@ -71,7 +71,16 @@ func SetVersion(version string) {
 	rootCmd.Version = version
 }
 
+// normalizeFlagName makes '-' and '_' interchangeable in every flag name, so
+// --aff-campaign-id and --aff_campaign_id (and --sort-dir / --sort_dir) refer to
+// the same flag. Names canonicalize to kebab-case (what help displays); the
+// snake_case API-style spelling keeps working everywhere.
+func normalizeFlagName(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
+}
+
 func init() {
+	rootCmd.SetGlobalNormalizationFunc(normalizeFlagName)
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output raw JSON instead of tables")
 	rootCmd.PersistentFlags().BoolVar(&csvOutput, "csv", false, "Output as CSV instead of tables")
 	rootCmd.PersistentFlags().BoolVarP(&quietOutput, "quiet", "q", false, "Print only ids, one per line (for scripting)")

--- a/go-cli/cmd/root.go
+++ b/go-cli/cmd/root.go
@@ -60,6 +60,9 @@ func Execute() {
 		} else {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 		}
+		if hint := api.HintFor(err); hint != "" {
+			fmt.Fprintf(os.Stderr, "Hint: %s\n", hint)
+		}
 		os.Exit(exitCodeForError(err))
 	}
 }

--- a/go-cli/cmd/rotator.go
+++ b/go-cli/cmd/rotator.go
@@ -217,6 +217,14 @@ var rotatorRuleCreateCmd = &cobra.Command{
 				return fmt.Errorf("invalid --criteria_json: %w", err)
 			}
 			body["criteria"] = criteria
+		} else if code, _ := cmd.Flags().GetString("country"); code != "" {
+			// Sugar: build a country criterion from an ISO code so the caller
+			// never has to know the exact "Name(CC)" value string.
+			value := countryCriteriaValue(code)
+			if value == "" {
+				return validationError("unknown country code %q (see `rotator criteria-values --search ...`); or use --criteria_json", code)
+			}
+			body["criteria"] = []map[string]string{{"type": "country", "statement": "is", "value": value}}
 		}
 		if v, _ := cmd.Flags().GetString("redirects_json"); v != "" {
 			var redirects interface{}
@@ -224,6 +232,9 @@ var rotatorRuleCreateCmd = &cobra.Command{
 				return fmt.Errorf("invalid --redirects_json: %w", err)
 			}
 			body["redirects"] = redirects
+		} else if camp, _ := cmd.Flags().GetString("redirect-campaign"); camp != "" {
+			// Sugar: a single-campaign redirect at full weight.
+			body["redirects"] = []map[string]string{{"redirect_campaign": camp, "weight": "100", "name": "to campaign " + camp}}
 		}
 		data, err := c.Post("rotators/"+args[0]+"/rules", body)
 		if err != nil {
@@ -387,8 +398,10 @@ func init() {
 
 	rotatorRuleCreateCmd.Flags().String("rule_name", "", "Rule name (required)")
 	rotatorRuleCreateCmd.Flags().String("splittest", "", "Enable split test (0|1)")
-	rotatorRuleCreateCmd.Flags().String("criteria_json", "", `Criteria JSON array, e.g. [{"type":"country","statement":"is","value":"US"}]`)
-	rotatorRuleCreateCmd.Flags().String("redirects_json", "", `Redirects JSON array, e.g. [{"redirect_url":"...","weight":"50","name":"A"}]`)
+	rotatorRuleCreateCmd.Flags().String("criteria_json", "", `Criteria JSON array, e.g. [{"type":"country","statement":"is","value":"United States(US)"}]`)
+	rotatorRuleCreateCmd.Flags().String("redirects_json", "", `Redirects JSON array, e.g. [{"redirect_campaign":"90008","weight":"100","name":"A"}]`)
+	rotatorRuleCreateCmd.Flags().String("country", "", "Sugar: ISO country code (e.g. US) -> a country `is` criterion; avoids hand-writing --criteria_json")
+	rotatorRuleCreateCmd.Flags().String("redirect-campaign", "", "Sugar: redirect to this campaign id at full weight; avoids hand-writing --redirects_json")
 
 	rotatorRuleDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	rotatorRuleDeleteCmd.Flags().String("ids", "", "Comma-separated rule IDs to delete in bulk")

--- a/go-cli/cmd/sync.go
+++ b/go-cli/cmd/sync.go
@@ -97,10 +97,8 @@ var syncStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show sync status and drift summary between profiles",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fromProfile, _ := cmd.Flags().GetString("from")
-		toProfile, _ := cmd.Flags().GetString("to")
-		fromProfile = strings.TrimSpace(fromProfile)
-		toProfile = strings.TrimSpace(toProfile)
+		fromProfile := firstFlag(cmd, "from", "source")
+		toProfile := firstFlag(cmd, "to", "target")
 		if fromProfile == "" || toProfile == "" {
 			return fmt.Errorf("--from and --to are required")
 		}
@@ -181,10 +179,8 @@ var syncHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Short: "Show sync history between profiles",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fromProfile, _ := cmd.Flags().GetString("from")
-		toProfile, _ := cmd.Flags().GetString("to")
-		fromProfile = strings.TrimSpace(fromProfile)
-		toProfile = strings.TrimSpace(toProfile)
+		fromProfile := firstFlag(cmd, "from", "source")
+		toProfile := firstFlag(cmd, "to", "target")
 		if fromProfile == "" || toProfile == "" {
 			return fmt.Errorf("--from and --to are required")
 		}
@@ -477,10 +473,8 @@ func runSyncProfiles(entities []string, fromProfile, toProfile string, opts sync
 }
 
 func readSyncFlags(cmd *cobra.Command) (syncOptions, string, string, error) {
-	fromProfile, _ := cmd.Flags().GetString("from")
-	toProfile, _ := cmd.Flags().GetString("to")
-	fromProfile = strings.TrimSpace(fromProfile)
-	toProfile = strings.TrimSpace(toProfile)
+	fromProfile := firstFlag(cmd, "from", "source")
+	toProfile := firstFlag(cmd, "to", "target")
 	if fromProfile == "" || toProfile == "" {
 		return syncOptions{}, "", "", fmt.Errorf("--from and --to are required")
 	}
@@ -656,13 +650,24 @@ func collectEntityIDs(entity string, rows []map[string]interface{}) map[string]b
 }
 
 func addSyncFlags(cmd *cobra.Command) {
-	cmd.Flags().String("from", "", "Source profile name")
-	cmd.Flags().String("to", "", "Target profile name")
+	cmd.Flags().String("from", "", "Source profile name (alias: --source)")
+	cmd.Flags().String("to", "", "Target profile name (alias: --target)")
+	cmd.Flags().String("source", "", "Source profile name (alias of --from)")
+	cmd.Flags().String("target", "", "Target profile name (alias of --to)")
 	cmd.Flags().Bool("dry-run", false, "Show sync actions without writing")
 	cmd.Flags().Bool("skip-errors", false, "Continue processing after record-level failures")
 	cmd.Flags().Bool("force-update", false, "Update mismatched target records")
-	_ = cmd.MarkFlagRequired("from")
-	_ = cmd.MarkFlagRequired("to")
+}
+
+// firstFlag returns the first non-empty value among the given flag names, so a
+// flag and its alias (e.g. --from / --source) resolve to one value.
+func firstFlag(cmd *cobra.Command, names ...string) string {
+	for _, n := range names {
+		if v, _ := cmd.Flags().GetString(n); strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
 }
 
 func tryServerSideSync(entityArg, fromProfile, toProfile string, opts syncOptions) (bool, error) {

--- a/go-cli/cmd/user.go
+++ b/go-cli/cmd/user.go
@@ -152,28 +152,10 @@ var userUpdateCmd = &cobra.Command{
 
 var userDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
-	Short: "Delete a user (soft-delete)",
-	Args:  cobra.ExactArgs(1),
+	Short: "Delete a user (soft-delete); supports --ids for bulk",
+	Args:  deleteArgsValidator,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := api.NewFromConfig()
-		if err != nil {
-			return err
-		}
-		force, _ := cmd.Flags().GetBool("force")
-		if !force {
-			fmt.Printf("Delete user %s? [y/N] ", args[0])
-			var answer string
-			fmt.Scanln(&answer)
-			if strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
-				fmt.Println("Cancelled.")
-				return nil
-			}
-		}
-		if err := c.Delete("users/" + args[0]); err != nil {
-			return err
-		}
-		output.Success("User %s deleted.", args[0])
-		return nil
+		return bulkOrSingleDelete(cmd, "users", "user")
 	},
 }
 
@@ -501,6 +483,7 @@ func init() {
 	userUpdateCmd.Flags().String("user_active", "", "1=active, 0=inactive")
 
 	userDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
+	userDeleteCmd.Flags().String("ids", "", "Comma-separated user IDs to delete in bulk")
 
 	// Role flags
 	userRoleAssignCmd.Flags().String("role_id", "", "Role ID (alternative to the second positional arg)")

--- a/go-cli/cmd/user.go
+++ b/go-cli/cmd/user.go
@@ -202,21 +202,21 @@ var userRoleListCmd = &cobra.Command{
 }
 
 var userRoleAssignCmd = &cobra.Command{
-	Use:   "assign <user_id>",
+	Use:   "assign <user_id> <role_id>",
 	Short: "Assign a role to a user",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := api.NewFromConfig()
 		if err != nil {
 			return err
 		}
-		roleIDStr, _ := cmd.Flags().GetString("role_id")
+		roleIDStr := roleIDFrom(cmd, args)
 		if roleIDStr == "" {
-			return fmt.Errorf("required flag --role_id is missing")
+			return fmt.Errorf("role id is required (pass it as the second argument or via --role_id)")
 		}
 		roleID, err := strconv.Atoi(roleIDStr)
 		if err != nil {
-			return fmt.Errorf("--role_id must be an integer: %s", roleIDStr)
+			return fmt.Errorf("role_id must be an integer: %s", roleIDStr)
 		}
 		data, err := c.Post("users/"+args[0]+"/roles", map[string]interface{}{
 			"role_id": roleID,
@@ -232,28 +232,36 @@ var userRoleAssignCmd = &cobra.Command{
 var userRoleRemoveCmd = &cobra.Command{
 	Use:   "remove <user_id> <role_id>",
 	Short: "Remove a role from a user",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := api.NewFromConfig()
 		if err != nil {
 			return err
 		}
-		force, _ := cmd.Flags().GetBool("force")
-		if !force {
-			fmt.Printf("Remove role %s from user %s? [y/N] ", args[1], args[0])
-			var answer string
-			fmt.Scanln(&answer)
-			if strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
-				fmt.Println("Cancelled.")
-				return nil
-			}
+		roleID := roleIDFrom(cmd, args)
+		if roleID == "" {
+			return fmt.Errorf("role id is required (pass it as the second argument or via --role_id)")
 		}
-		if err := c.Delete("users/" + args[0] + "/roles/" + args[1]); err != nil {
+		force, _ := cmd.Flags().GetBool("force")
+		if !force && !confirmPrompt("Remove role %s from user %s?", roleID, args[0]) {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
+		if err := c.Delete("users/" + args[0] + "/roles/" + roleID); err != nil {
 			return err
 		}
-		output.Success("Role %s removed from user %s.", args[1], args[0])
+		output.Success("Role %s removed from user %s.", roleID, args[0])
 		return nil
 	},
+}
+
+// roleIDFrom resolves the role id from the second positional arg or --role_id.
+func roleIDFrom(cmd *cobra.Command, args []string) string {
+	if len(args) >= 2 {
+		return args[1]
+	}
+	v, _ := cmd.Flags().GetString("role_id")
+	return strings.TrimSpace(v)
 }
 
 // --- API Key subcommands ---
@@ -495,7 +503,8 @@ func init() {
 	userDeleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
 	// Role flags
-	userRoleAssignCmd.Flags().String("role_id", "", "Role ID (required)")
+	userRoleAssignCmd.Flags().String("role_id", "", "Role ID (alternative to the second positional arg)")
+	userRoleRemoveCmd.Flags().String("role_id", "", "Role ID (alternative to the second positional arg)")
 	userRoleRemoveCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 
 	// API key flags

--- a/go-cli/cmd/verify.go
+++ b/go-cli/cmd/verify.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"p202/internal/api"
+	"p202/internal/config"
+
+	"github.com/spf13/cobra"
+)
+
+// geoIPs maps an ISO country code to a representative public IP, used to spoof
+// the visitor's geo (via X-Forwarded-For) for tracker test.
+var geoIPs = map[string]string{
+	"US": "8.8.8.8",
+	"CA": "24.48.0.1",
+	"GB": "81.2.69.142",
+	"UK": "81.2.69.142",
+	"AU": "1.128.0.1",
+	"DE": "85.214.132.117",
+	"NL": "94.142.241.111",
+	"FR": "90.84.144.1",
+	"BR": "200.160.2.3",
+	"IN": "103.48.196.1",
+	"MX": "201.144.0.1",
+}
+
+// deviceUAs maps a friendly device name to a representative User-Agent.
+var deviceUAs = map[string]string{
+	"mobile":  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+	"desktop": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+	"tablet":  "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+}
+
+// countryCodeFromValue extracts the ISO code from a criteria value formatted as
+// "United States(US)" -> "US".
+func countryCodeFromValue(v string) string {
+	open := strings.LastIndex(v, "(")
+	closeP := strings.LastIndex(v, ")")
+	if open >= 0 && closeP > open {
+		return strings.ToUpper(strings.TrimSpace(v[open+1 : closeP]))
+	}
+	return strings.ToUpper(strings.TrimSpace(v))
+}
+
+// rotatorDestination resolves which destination a visitor from geo hits, by
+// evaluating the rotator's active rules locally (mirroring rtr.php precedence:
+// first matching rule wins, else the default). Returns the matched rule name,
+// a destination description, and per-criteria explain lines.
+func rotatorDestination(data map[string]interface{}, geo string) (rule, dest string, explain []string) {
+	geo = strings.ToUpper(strings.TrimSpace(geo))
+	rules, _ := data["rules"].([]interface{})
+	for _, ri := range rules {
+		r, ok := ri.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if toFloat(r["status"]) != 1 {
+			continue
+		}
+		crits, _ := r["criteria"].([]interface{})
+		matched := true
+		for _, ci := range crits {
+			cr, _ := ci.(map[string]interface{})
+			ctype, _ := cr["type"].(string)
+			stmt, _ := cr["statement"].(string)
+			val, _ := cr["value"].(string)
+			ok := true
+			if ctype == "country" {
+				cc := countryCodeFromValue(val)
+				if stmt == "is_not" {
+					ok = geo != cc
+				} else {
+					ok = geo == cc
+				}
+				explain = append(explain, fmt.Sprintf("rule %q: country %s %s -> %v", r["rule_name"], stmt, cc, ok))
+			}
+			if !ok {
+				matched = false
+				break
+			}
+		}
+		if matched && len(crits) > 0 {
+			return fmt.Sprintf("%v", r["rule_name"]), redirectDest(r["redirects"]), explain
+		}
+	}
+	return "(default)", defaultDest(data), explain
+}
+
+func redirectDest(redirects interface{}) string {
+	arr, _ := redirects.([]interface{})
+	if len(arr) == 0 {
+		return "(no redirect)"
+	}
+	parts := make([]string, 0, len(arr))
+	for _, ri := range arr {
+		r, _ := ri.(map[string]interface{})
+		parts = append(parts, destOf(r["redirect_campaign"], r["redirect_url"], r["redirect_lp"], r["weight"]))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func defaultDest(data map[string]interface{}) string {
+	return destOf(data["default_campaign"], data["default_url"], data["default_lp"], nil)
+}
+
+func destOf(campaign, url, lp, weight interface{}) string {
+	w := ""
+	if ws := fmt.Sprintf("%v", weight); weight != nil && ws != "" && ws != "0" && ws != "100" {
+		w = " (w" + ws + ")"
+	}
+	if c := toFloat(campaign); c > 0 {
+		return fmt.Sprintf("campaign %d%s", int64(c), w)
+	}
+	if s, _ := url.(string); s != "" {
+		return s + w
+	}
+	if l := toFloat(lp); l > 0 {
+		return fmt.Sprintf("landing_page %d%s", int64(l), w)
+	}
+	return "(none)"
+}
+
+var rotatorTestCmd = &cobra.Command{
+	Use:   "test <rotator_id>",
+	Short: "Show where a rotator routes traffic per geo (local rule evaluation)",
+	Long: "Evaluates the rotator's active rules locally and prints the destination a\n" +
+		"visitor from each --geo would reach. --explain shows per-criteria pass/fail,\n" +
+		"which surfaces the Name(CC) country-format mismatches that silently break rules.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		raw, err := c.Get("rotators/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			return err
+		}
+
+		geos := splitCSV(mustString(cmd, "geo"))
+		if len(geos) == 0 {
+			geos = []string{"US", "GB", "CA", "AU", "BR", "IN"}
+		}
+		explain, _ := cmd.Flags().GetBool("explain")
+
+		rows := make([]map[string]interface{}, 0, len(geos))
+		for _, g := range geos {
+			rule, dest, ex := rotatorDestination(resp.Data, g)
+			row := map[string]interface{}{"geo": strings.ToUpper(g), "matched_rule": rule, "destination": dest}
+			if explain {
+				row["criteria"] = strings.Join(ex, "; ")
+			}
+			rows = append(rows, row)
+		}
+		render(rowsToJSON(rows))
+		return nil
+	},
+}
+
+var trackerTestCmd = &cobra.Command{
+	Use:   "test <tracker_id>",
+	Short: "Resolve a tracking link's live destination (follows the redirect)",
+	Long: "Fetches the tracker's link and issues a real request per --geo/--device,\n" +
+		"reporting the HTTP status and final destination. Flags a blank/dropped link.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		urlData, err := c.Get("trackers/"+args[0]+"/url", nil)
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			Data struct {
+				DirectURL string `json:"direct_url"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(urlData, &resp); err != nil {
+			return err
+		}
+		link := resp.Data.DirectURL
+		if link == "" {
+			return validationError("tracker has no resolvable link")
+		}
+		if !strings.HasPrefix(link, "http") {
+			scheme := "http"
+			if prof, _, perr := config.LoadProfileWithName(profileName); perr == nil && strings.HasPrefix(prof.URL, "https") {
+				scheme = "https"
+			}
+			link = scheme + "://" + link
+		}
+
+		geos := splitCSV(mustString(cmd, "geo"))
+		if len(geos) == 0 {
+			geos = []string{""} // single request with the local geo
+		}
+		device, _ := cmd.Flags().GetString("device")
+
+		client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+		rows := make([]map[string]interface{}, 0, len(geos))
+		for _, g := range geos {
+			req, _ := http.NewRequest("GET", link+"&t202kw=test", nil)
+			if g != "" {
+				if ip, ok := geoIPs[strings.ToUpper(g)]; ok {
+					req.Header.Set("X-Forwarded-For", ip)
+				}
+			}
+			if ua, ok := deviceUAs[strings.ToLower(device)]; ok {
+				req.Header.Set("User-Agent", ua)
+			}
+			row := map[string]interface{}{"geo": strings.ToUpper(g)}
+			if g == "" {
+				row["geo"] = "(local)"
+			}
+			res, err := client.Do(req)
+			if err != nil {
+				row["status"] = "ERR"
+				row["destination"] = err.Error()
+			} else {
+				loc := res.Header.Get("Location")
+				row["status"] = fmt.Sprintf("%d", res.StatusCode)
+				if loc == "" {
+					row["destination"] = "(blank — click dropped!)"
+				} else {
+					row["destination"] = loc
+				}
+				res.Body.Close()
+			}
+			rows = append(rows, row)
+		}
+		render(rowsToJSON(rows))
+		return nil
+	},
+}
+
+func splitCSV(s string) []string {
+	out := []string{}
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func mustString(cmd *cobra.Command, name string) string {
+	v, _ := cmd.Flags().GetString(name)
+	return v
+}
+
+func init() {
+	rotatorTestCmd.Flags().String("geo", "", "Comma-separated country codes to evaluate (default: a tier-1+rest sample)")
+	rotatorTestCmd.Flags().Bool("explain", false, "Show per-criteria pass/fail for each geo")
+	rotatorCmd.AddCommand(rotatorTestCmd)
+
+	trackerTestCmd.Flags().String("geo", "", "Comma-separated country codes to simulate (spoofs X-Forwarded-For)")
+	trackerTestCmd.Flags().String("device", "", "Device to simulate: mobile, desktop, tablet")
+	// The tracker command is built dynamically in crud.go's init() (which runs
+	// before this file's init), so look it up by name to attach the subcommand.
+	if tc := findChildCommand("tracker"); tc != nil {
+		tc.AddCommand(trackerTestCmd)
+	}
+}
+
+// findChildCommand returns the direct subcommand of rootCmd with the given name.
+func findChildCommand(name string) *cobra.Command {
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/go-cli/cmd/verify.go
+++ b/go-cli/cmd/verify.go
@@ -260,7 +260,101 @@ func mustString(cmd *cobra.Command, name string) string {
 	return v
 }
 
+// rotatorIssues returns config problems for a single rotator's data.
+func rotatorIssues(d map[string]interface{}) []string {
+	var issues []string
+	rules, _ := d["rules"].([]interface{})
+	activeRules := 0
+	for _, ri := range rules {
+		r, _ := ri.(map[string]interface{})
+		if toFloat(r["status"]) == 1 {
+			activeRules++
+		}
+		if reds, _ := r["redirects"].([]interface{}); len(reds) == 0 {
+			issues = append(issues, fmt.Sprintf("rule %q has no redirect", r["rule_name"]))
+		}
+	}
+	hasDefault := defaultDest(d) != "(none)"
+	if activeRules == 0 && !hasDefault {
+		issues = append(issues, "no active rules and no default — every click is dropped")
+	}
+	return issues
+}
+
+var rotatorCheckCmd = &cobra.Command{
+	Use:   "check [rotator_id]",
+	Short: "Health-check rotators: flag missing defaults, ruleless rotators, empty rules",
+	Long:  "Exits non-zero if any checked rotator has a configuration problem, so it can gate a deploy.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		var datas []map[string]interface{}
+		if len(args) == 1 {
+			raw, err := c.Get("rotators/"+args[0], nil)
+			if err != nil {
+				return err
+			}
+			var resp struct {
+				Data map[string]interface{} `json:"data"`
+			}
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return err
+			}
+			datas = append(datas, resp.Data)
+		} else {
+			list, err := c.Get("rotators", map[string]string{"limit": "500"})
+			if err != nil {
+				return err
+			}
+			var resp struct {
+				Data []map[string]interface{} `json:"data"`
+			}
+			if err := json.Unmarshal(list, &resp); err != nil {
+				return err
+			}
+			for _, r := range resp.Data {
+				full, err := c.Get(fmt.Sprintf("rotators/%v", normalizeID(r["id"])), nil)
+				if err != nil {
+					continue
+				}
+				var fr struct {
+					Data map[string]interface{} `json:"data"`
+				}
+				if json.Unmarshal(full, &fr) == nil {
+					datas = append(datas, fr.Data)
+				}
+			}
+		}
+
+		rows := make([]map[string]interface{}, 0, len(datas))
+		failed := 0
+		for _, d := range datas {
+			issues := rotatorIssues(d)
+			status := "OK"
+			if len(issues) > 0 {
+				status = "ISSUES"
+				failed++
+			}
+			rows = append(rows, map[string]interface{}{
+				"id":     normalizeID(d["id"]),
+				"name":   d["name"],
+				"status": status,
+				"reason": strings.Join(issues, "; "),
+			})
+		}
+		render(rowsToJSON(rows))
+		if failed > 0 {
+			return partialFailureError("%d rotator(s) have configuration issues", failed)
+		}
+		return nil
+	},
+}
+
 func init() {
+	rotatorCmd.AddCommand(rotatorCheckCmd)
 	rotatorTestCmd.Flags().String("geo", "", "Comma-separated country codes to evaluate (default: a tier-1+rest sample)")
 	rotatorTestCmd.Flags().Bool("explain", false, "Show per-criteria pass/fail for each geo")
 	rotatorCmd.AddCommand(rotatorTestCmd)

--- a/go-cli/cmd/verify.go
+++ b/go-cli/cmd/verify.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"p202/internal/api"
@@ -353,8 +354,152 @@ var rotatorCheckCmd = &cobra.Command{
 	},
 }
 
+var rotatorTraceCmd = &cobra.Command{
+	Use:   "trace <rotator_id>",
+	Short: "Show the trackers that feed a rotator and where it routes",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		raw, err := c.Get("rotators/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		var rot struct {
+			Data map[string]interface{} `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &rot); err != nil {
+			return err
+		}
+		trk, err := c.Get("trackers", map[string]string{"filter[rotator_id]": args[0]})
+		if err != nil {
+			return err
+		}
+		var tr struct {
+			Data []map[string]interface{} `json:"data"`
+		}
+		_ = json.Unmarshal(trk, &tr)
+
+		fmt.Fprintf(os.Stderr, "Rotator %s %q — default %s, %d rule(s), fed by %d tracker(s)\n",
+			args[0], fmt.Sprintf("%v", rot.Data["name"]), defaultDest(rot.Data),
+			len(asSlice(rot.Data["rules"])), len(tr.Data))
+		rows := make([]map[string]interface{}, 0, len(tr.Data))
+		for _, t := range tr.Data {
+			rows = append(rows, map[string]interface{}{
+				"tracker_id":        normalizeID(t["tracker_id"]),
+				"tracker_id_public": normalizeID(t["tracker_id_public"]),
+				"ppc_account_id":    normalizeID(t["ppc_account_id"]),
+				"click_cpc":         t["click_cpc"],
+			})
+		}
+		render(rowsToJSON(rows))
+		return nil
+	},
+}
+
+func asSlice(v interface{}) []interface{} {
+	s, _ := v.([]interface{})
+	return s
+}
+
+// resolveTrackerLink fetches and follows a tracker's link, returning status and
+// destination (used by tracker test and tracker check).
+func resolveTrackerLink(c *api.Client, id, geo, device string) (status, dest string) {
+	urlData, err := c.Get("trackers/"+id+"/url", nil)
+	if err != nil {
+		return "ERR", err.Error()
+	}
+	var resp struct {
+		Data struct {
+			DirectURL string `json:"direct_url"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(urlData, &resp) != nil || resp.Data.DirectURL == "" {
+		return "ERR", "no link"
+	}
+	link := resp.Data.DirectURL
+	if !strings.HasPrefix(link, "http") {
+		scheme := "http"
+		if prof, _, perr := config.LoadProfileWithName(profileName); perr == nil && strings.HasPrefix(prof.URL, "https") {
+			scheme = "https"
+		}
+		link = scheme + "://" + link
+	}
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	req, _ := http.NewRequest("GET", link+"&t202kw=test", nil)
+	if ip, ok := geoIPs[strings.ToUpper(geo)]; ok {
+		req.Header.Set("X-Forwarded-For", ip)
+	}
+	if ua, ok := deviceUAs[strings.ToLower(device)]; ok {
+		req.Header.Set("User-Agent", ua)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return "ERR", err.Error()
+	}
+	defer res.Body.Close()
+	loc := res.Header.Get("Location")
+	if loc == "" {
+		return fmt.Sprintf("%d", res.StatusCode), "(blank — click dropped!)"
+	}
+	return fmt.Sprintf("%d", res.StatusCode), loc
+}
+
+var trackerCheckCmd = &cobra.Command{
+	Use:   "check [tracker_id]",
+	Short: "Resolve tracker links and flag blank/dropped destinations",
+	Long:  "Exits non-zero if any checked tracker resolves to a blank Location or a non-3xx status.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := api.NewFromConfig()
+		if err != nil {
+			return err
+		}
+		var ids []string
+		if len(args) == 1 {
+			ids = append(ids, args[0])
+		} else {
+			list, err := c.Get("trackers", map[string]string{"limit": "500"})
+			if err != nil {
+				return err
+			}
+			var resp struct {
+				Data []map[string]interface{} `json:"data"`
+			}
+			_ = json.Unmarshal(list, &resp)
+			for _, t := range resp.Data {
+				ids = append(ids, fmt.Sprintf("%v", normalizeID(t["tracker_id"])))
+			}
+		}
+		rows := make([]map[string]interface{}, 0, len(ids))
+		failed := 0
+		for _, id := range ids {
+			status, dest := resolveTrackerLink(c, id, "", "")
+			ok := strings.HasPrefix(status, "3")
+			if !ok {
+				failed++
+			}
+			rows = append(rows, map[string]interface{}{
+				"tracker_id":  id,
+				"status":      status,
+				"destination": dest,
+			})
+		}
+		render(rowsToJSON(rows))
+		if failed > 0 {
+			return partialFailureError("%d tracker(s) did not resolve to a redirect", failed)
+		}
+		return nil
+	},
+}
+
 func init() {
-	rotatorCmd.AddCommand(rotatorCheckCmd)
+	rotatorCmd.AddCommand(rotatorCheckCmd, rotatorTraceCmd)
+	if tc := findChildCommand("tracker"); tc != nil {
+		tc.AddCommand(trackerCheckCmd)
+	}
 	rotatorTestCmd.Flags().String("geo", "", "Comma-separated country codes to evaluate (default: a tier-1+rest sample)")
 	rotatorTestCmd.Flags().Bool("explain", false, "Show per-criteria pass/fail for each geo")
 	rotatorCmd.AddCommand(rotatorTestCmd)

--- a/go-cli/cmd/verify.go
+++ b/go-cli/cmd/verify.go
@@ -6,12 +6,32 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"p202/internal/api"
 	"p202/internal/config"
 
 	"github.com/spf13/cobra"
 )
+
+// probeClient is the HTTP client used to resolve tracking links: it follows no
+// redirects (so we read the Location header) and has a timeout so a stalled
+// host can't hang the command.
+func probeClient() *http.Client {
+	return &http.Client{
+		Timeout:       15 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+// appendTrackingKW appends the test keyword param using the correct separator
+// whether or not the link already has a query string.
+func appendTrackingKW(link string) string {
+	if strings.Contains(link, "?") {
+		return link + "&t202kw=test"
+	}
+	return link + "?t202kw=test"
+}
 
 // geoIPs maps an ISO country code to a representative public IP, used to spoof
 // the visitor's geo (via X-Forwarded-For) for tracker test.
@@ -36,8 +56,8 @@ var deviceUAs = map[string]string{
 	"tablet":  "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
 }
 
-// countryCodeFromValue extracts the ISO code from a criteria value formatted as
-// "United States(US)" -> "US".
+// countryCodeFromValue extracts the ISO code from a single criteria token
+// formatted as "United States(US)" -> "US".
 func countryCodeFromValue(v string) string {
 	open := strings.LastIndex(v, "(")
 	closeP := strings.LastIndex(v, ")")
@@ -45,6 +65,28 @@ func countryCodeFromValue(v string) string {
 		return strings.ToUpper(strings.TrimSpace(v[open+1 : closeP]))
 	}
 	return strings.ToUpper(strings.TrimSpace(v))
+}
+
+// countryCodesFromValue parses a criteria value into the set of country codes,
+// mirroring rtr.php which splits the value on commas (a rule criterion may list
+// several countries, e.g. "United States(US),Canada(CA)").
+func countryCodesFromValue(v string) []string {
+	out := []string{}
+	for _, tok := range strings.Split(v, ",") {
+		if tok = strings.TrimSpace(tok); tok != "" {
+			out = append(out, countryCodeFromValue(tok))
+		}
+	}
+	return out
+}
+
+func contains(list []string, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // rotatorDestination resolves which destination a visitor from geo hits, by
@@ -64,28 +106,46 @@ func rotatorDestination(data map[string]interface{}, geo string) (rule, dest str
 		}
 		crits, _ := r["criteria"].([]interface{})
 		matched := true
+		unsupported := ""
 		for _, ci := range crits {
 			cr, _ := ci.(map[string]interface{})
 			ctype, _ := cr["type"].(string)
 			stmt, _ := cr["statement"].(string)
 			val, _ := cr["value"].(string)
 			ok := true
-			if ctype == "country" {
-				cc := countryCodeFromValue(val)
+			switch {
+			case strings.EqualFold(strings.TrimSpace(val), "ALL"):
+				ok = true // catch-all criterion matches any visitor
+				explain = append(explain, fmt.Sprintf("rule %q: %s ALL -> true", r["rule_name"], stmt))
+			case ctype == "country":
+				codes := countryCodesFromValue(val)
+				inList := contains(codes, geo)
 				if stmt == "is_not" {
-					ok = geo != cc
+					ok = !inList
 				} else {
-					ok = geo == cc
+					ok = inList
 				}
-				explain = append(explain, fmt.Sprintf("rule %q: country %s %s -> %v", r["rule_name"], stmt, cc, ok))
+				explain = append(explain, fmt.Sprintf("rule %q: country %s %s -> %v", r["rule_name"], stmt, strings.Join(codes, ","), ok))
+			default:
+				// device/browser/platform/ip/region/city criteria can't be
+				// evaluated locally. Don't silently treat them as a match — flag
+				// the rule as unverified so the result is never over-claimed.
+				unsupported = ctype
+				explain = append(explain, fmt.Sprintf("rule %q: %s criteria can't be evaluated locally — use `tracker test`", r["rule_name"], ctype))
 			}
 			if !ok {
 				matched = false
 				break
 			}
 		}
-		if matched && len(crits) > 0 {
-			return fmt.Sprintf("%v", r["rule_name"]), redirectDest(r["redirects"]), explain
+		// rtr.php treats a rule with zero criteria as a match (the criteria loop
+		// runs zero times and count==count holds), so do the same.
+		if matched {
+			dest := redirectDest(r["redirects"])
+			if unsupported != "" {
+				dest += fmt.Sprintf(" (unverified: %s criteria)", unsupported)
+			}
+			return fmt.Sprintf("%v", r["rule_name"]), dest, explain
 		}
 	}
 	return "(default)", defaultDest(data), explain
@@ -209,10 +269,13 @@ var trackerTestCmd = &cobra.Command{
 		}
 		device, _ := cmd.Flags().GetString("device")
 
-		client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+		client := probeClient()
 		rows := make([]map[string]interface{}, 0, len(geos))
 		for _, g := range geos {
-			req, _ := http.NewRequest("GET", link+"&t202kw=test", nil)
+			req, reqErr := http.NewRequest("GET", appendTrackingKW(link), nil)
+			if reqErr != nil {
+				return fmt.Errorf("building request: %w", reqErr)
+			}
 			if g != "" {
 				if ip, ok := geoIPs[strings.ToUpper(g)]; ok {
 					req.Header.Set("X-Forwarded-For", ip)
@@ -427,8 +490,11 @@ func resolveTrackerLink(c *api.Client, id, geo, device string) (status, dest str
 		}
 		link = scheme + "://" + link
 	}
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
-	req, _ := http.NewRequest("GET", link+"&t202kw=test", nil)
+	client := probeClient()
+	req, reqErr := http.NewRequest("GET", appendTrackingKW(link), nil)
+	if reqErr != nil {
+		return "ERR", reqErr.Error()
+	}
 	if ip, ok := geoIPs[strings.ToUpper(geo)]; ok {
 		req.Header.Set("X-Forwarded-For", ip)
 	}

--- a/go-cli/cmd/verify_test.go
+++ b/go-cli/cmd/verify_test.go
@@ -62,3 +62,46 @@ func TestRotatorIssues(t *testing.T) {
 		t.Errorf("rotator with a default should be OK, got %v", rotatorIssues(ok))
 	}
 }
+
+func TestRotatorDestinationEmptyCriteriaMatches(t *testing.T) {
+	// rtr.php treats a rule with no criteria as a match.
+	data := map[string]interface{}{
+		"default_campaign": 90007.0,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"rule_name": "catch-all", "status": 1.0,
+				"criteria":  []interface{}{},
+				"redirects": []interface{}{map[string]interface{}{"redirect_campaign": 90008.0}},
+			},
+		},
+	}
+	if _, dest, _ := rotatorDestination(data, "BR"); dest != "campaign 90008" {
+		t.Errorf("empty-criteria rule should match any geo, got %q", dest)
+	}
+}
+
+func TestRotatorDestinationMultiCountryValue(t *testing.T) {
+	data := map[string]interface{}{
+		"default_campaign": 90007.0,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"rule_name": "tier1", "status": 1.0,
+				"criteria":  []interface{}{map[string]interface{}{"type": "country", "statement": "is", "value": "United States(US),Canada(CA)"}},
+				"redirects": []interface{}{map[string]interface{}{"redirect_campaign": 90008.0}},
+			},
+		},
+	}
+	if _, dest, _ := rotatorDestination(data, "CA"); dest != "campaign 90008" {
+		t.Errorf("CA should match a US,CA rule, got %q", dest)
+	}
+	if _, dest, _ := rotatorDestination(data, "BR"); dest != "campaign 90007" {
+		t.Errorf("BR should fall to default, got %q", dest)
+	}
+}
+
+func TestCountryCodesFromValue(t *testing.T) {
+	got := countryCodesFromValue("United States(US),Canada(CA)")
+	if len(got) != 2 || got[0] != "US" || got[1] != "CA" {
+		t.Errorf("countryCodesFromValue = %v, want [US CA]", got)
+	}
+}

--- a/go-cli/cmd/verify_test.go
+++ b/go-cli/cmd/verify_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import "testing"
+
+func TestCountryCodeFromValue(t *testing.T) {
+	cases := map[string]string{
+		"United States(US)": "US",
+		"Netherlands(NL)":   "NL",
+		"US":                "US",
+	}
+	for in, want := range cases {
+		if got := countryCodeFromValue(in); got != want {
+			t.Errorf("countryCodeFromValue(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRotatorDestinationRoutesByGeo(t *testing.T) {
+	data := map[string]interface{}{
+		"default_campaign": 90007.0,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"rule_name": "US -> SJ", "status": 1.0,
+				"criteria":  []interface{}{map[string]interface{}{"type": "country", "statement": "is", "value": "United States(US)"}},
+				"redirects": []interface{}{map[string]interface{}{"redirect_campaign": 90008.0, "weight": "100"}},
+			},
+		},
+	}
+	if rule, dest, _ := rotatorDestination(data, "US"); dest != "campaign 90008" {
+		t.Errorf("US should route to campaign 90008, got rule=%q dest=%q", rule, dest)
+	}
+	if _, dest, _ := rotatorDestination(data, "BR"); dest != "campaign 90007" {
+		t.Errorf("BR should fall to default campaign 90007, got %q", dest)
+	}
+}
+
+func TestRotatorDestinationInactiveRuleSkipped(t *testing.T) {
+	data := map[string]interface{}{
+		"default_campaign": 90007.0,
+		"rules": []interface{}{
+			map[string]interface{}{
+				"rule_name": "US (paused)", "status": 0.0,
+				"criteria":  []interface{}{map[string]interface{}{"type": "country", "statement": "is", "value": "United States(US)"}},
+				"redirects": []interface{}{map[string]interface{}{"redirect_campaign": 90008.0}},
+			},
+		},
+	}
+	if _, dest, _ := rotatorDestination(data, "US"); dest != "campaign 90007" {
+		t.Errorf("paused US rule should be skipped -> default, got %q", dest)
+	}
+}

--- a/go-cli/cmd/verify_test.go
+++ b/go-cli/cmd/verify_test.go
@@ -49,3 +49,16 @@ func TestRotatorDestinationInactiveRuleSkipped(t *testing.T) {
 		t.Errorf("paused US rule should be skipped -> default, got %q", dest)
 	}
 }
+
+func TestRotatorIssues(t *testing.T) {
+	// no rules and no default -> flagged
+	bad := map[string]interface{}{"rules": []interface{}{}}
+	if len(rotatorIssues(bad)) == 0 {
+		t.Error("ruleless rotator with no default should be flagged")
+	}
+	// has default campaign -> OK
+	ok := map[string]interface{}{"default_campaign": 90007.0, "rules": []interface{}{}}
+	if len(rotatorIssues(ok)) != 0 {
+		t.Errorf("rotator with a default should be OK, got %v", rotatorIssues(ok))
+	}
+}

--- a/go-cli/internal/api/client.go
+++ b/go-cli/internal/api/client.go
@@ -88,6 +88,33 @@ func ErrorCategory(err error) string {
 	return ""
 }
 
+// HintFor returns an actionable recovery hint for an error, or "" when there is
+// nothing useful to add. It augments — never replaces — the error message.
+func HintFor(err error) string {
+	if err == nil {
+		return ""
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Status == 401 || apiErr.Status == 403:
+			return "Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong."
+		case apiErr.Status == 404:
+			return "Not found. Run the matching `... list` to find valid ids (ids are internal — not the public ones in tracking links; some commands accept --public)."
+		case apiErr.Status == 422 && len(apiErr.FieldErrors) > 0:
+			return "Fix the field(s) listed above and retry."
+		}
+		return ""
+	}
+	var reqErr *RequestError
+	if errors.As(err, &reqErr) {
+		if reqErr.Kind == "network" {
+			return "Check the server URL (`p202 config get`) and that the instance is reachable."
+		}
+	}
+	return ""
+}
+
 func NewFromConfig() (*Client, error) {
 	profile, _, err := config.LoadProfileWithName("")
 	if err != nil {

--- a/go-cli/internal/api/client_test.go
+++ b/go-cli/internal/api/client_test.go
@@ -463,3 +463,18 @@ func TestRequestErrorCarriesCategory(t *testing.T) {
 		t.Fatalf("unexpected error format: %q", reqErr.Error())
 	}
 }
+
+func TestHintFor(t *testing.T) {
+	if h := HintFor(&APIError{Status: 404}); h == "" {
+		t.Error("404 should produce a hint")
+	}
+	if h := HintFor(&APIError{Status: 401}); h == "" {
+		t.Error("401 should produce a hint")
+	}
+	if h := HintFor(&APIError{Status: 200}); h != "" {
+		t.Error("200 should produce no hint")
+	}
+	if h := HintFor(nil); h != "" {
+		t.Error("nil should produce no hint")
+	}
+}

--- a/go-cli/internal/output/output.go
+++ b/go-cli/internal/output/output.go
@@ -461,11 +461,9 @@ func renderTableCSV(items []interface{}, opts Opts) {
 	keys = orderColumns(keys, opts)
 
 	writer := csv.NewWriter(os.Stdout)
-	headers := make([]string, len(keys))
-	for i, k := range keys {
-		headers[i] = headerFor(k, opts.RawHeaders)
-	}
-	if err := writer.Write(headers); err != nil {
+	// CSV headers stay raw field names — CSV is machine-facing and scripts key
+	// on stable column names. The human table uses the friendly names.
+	if err := writer.Write(keys); err != nil {
 		fmt.Fprintln(os.Stderr, "Error writing CSV header:", err)
 		return
 	}

--- a/go-cli/internal/output/output.go
+++ b/go-cli/internal/output/output.go
@@ -42,10 +42,11 @@ var friendlyHeaders = map[string]string{
 // metricOrder is the fixed business sequence for metric columns so the row
 // label stays left and numbers read in a consistent order across commands.
 var metricOrder = []string{
-	"name", "keyword",
+	"geo", "device", "name", "keyword",
 	"total_clicks", "total_click_throughs", "total_leads", "conv_rate",
 	"total_income", "total_cost", "total_net", "roi", "epc", "cpa", "avg_cpc",
 	"breakeven_cpc", "margin", "verdict", "bucket", "reason",
+	"matched_rule", "status", "destination", "criteria",
 }
 
 const maxColWidth = 42 // cap wide columns unless --wide

--- a/go-cli/internal/output/output.go
+++ b/go-cli/internal/output/output.go
@@ -10,22 +10,73 @@ import (
 	"text/tabwriter"
 )
 
+// Opts controls how a response is rendered. The zero value renders a human
+// table to stdout; flags select JSON/CSV/quiet/ndjson and column shaping.
+type Opts struct {
+	JSON       bool
+	CSV        bool
+	Quiet      bool     // id-only: one id per line, no header (for scripting)
+	NDJSON     bool     // newline-delimited JSON, one row per line
+	Wide       bool     // show all columns (no width cap)
+	RawHeaders bool     // keep raw API keys as headers instead of friendly names
+	Fields     []string // explicit column selection (in order)
+}
+
+// friendlyHeaders maps raw API field names to human-readable column headers.
+var friendlyHeaders = map[string]string{
+	"total_clicks":         "Clicks",
+	"total_click_throughs": "Clickthroughs",
+	"total_leads":          "Conversions",
+	"total_income":         "Revenue",
+	"total_cost":           "Cost",
+	"total_net":            "Profit",
+	"roi":                  "ROI %",
+	"epc":                  "EPC",
+	"cpa":                  "CPA",
+	"avg_cpc":              "Avg CPC",
+	"conv_rate":            "Conv %",
+	"breakeven_cpc":        "Breakeven CPC",
+	"margin":               "Margin",
+}
+
+// metricOrder is the fixed business sequence for metric columns so the row
+// label stays left and numbers read in a consistent order across commands.
+var metricOrder = []string{
+	"name", "keyword",
+	"total_clicks", "total_click_throughs", "total_leads", "conv_rate",
+	"total_income", "total_cost", "total_net", "roi", "epc", "cpa", "avg_cpc",
+	"breakeven_cpc", "margin", "verdict", "bucket", "reason",
+}
+
+const maxColWidth = 42 // cap wide columns unless --wide
+
 // Render outputs API response data as either raw JSON or a formatted table.
+// Retained for the many existing call sites; delegates to RenderWith.
 func Render(data []byte, jsonMode bool) {
-	if jsonMode {
-		var parsed interface{}
-		if json.Unmarshal(data, &parsed) == nil {
-			pretty, err := json.MarshalIndent(parsed, "", "  ")
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Error formatting JSON:", err)
-				os.Stdout.Write(data)
-				return
-			}
-			fmt.Println(string(pretty))
-		} else {
-			os.Stdout.Write(data)
-			fmt.Println()
-		}
+	RenderWith(data, Opts{JSON: jsonMode})
+}
+
+// RenderCSV outputs API response data as CSV. Retained for call sites.
+func RenderCSV(data []byte) {
+	RenderWith(data, Opts{CSV: true})
+}
+
+// RenderWith renders data according to opts.
+func RenderWith(data []byte, opts Opts) {
+	if opts.Quiet {
+		renderQuiet(data)
+		return
+	}
+	if opts.NDJSON {
+		renderNDJSON(data)
+		return
+	}
+	if opts.JSON {
+		renderJSON(data)
+		return
+	}
+	if opts.CSV {
+		renderCSVData(data, opts)
 		return
 	}
 
@@ -38,12 +89,12 @@ func Render(data []byte, jsonMode bool) {
 
 	switch v := parsed.(type) {
 	case []interface{}:
-		renderTable(v)
+		renderTable(v, opts)
 	case map[string]interface{}:
 		if items, ok := v["data"].([]interface{}); ok {
-			renderTable(items)
+			renderTable(items, opts)
 			if pg, ok := v["pagination"].(map[string]interface{}); ok {
-				renderPagination(pg, jsonMode)
+				renderPagination(pg)
 			}
 		} else if inner, ok := v["data"].(map[string]interface{}); ok {
 			renderObject(inner)
@@ -55,44 +106,143 @@ func Render(data []byte, jsonMode bool) {
 	}
 }
 
-// RenderCSV outputs API response data as CSV.
-func RenderCSV(data []byte) {
+func renderJSON(data []byte) {
 	var parsed interface{}
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		os.Stdout.Write(data)
-		if len(data) == 0 || data[len(data)-1] != '\n' {
-			fmt.Println()
+	if json.Unmarshal(data, &parsed) == nil {
+		pretty, err := json.MarshalIndent(parsed, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error formatting JSON:", err)
+			os.Stdout.Write(data)
+			return
 		}
+		fmt.Println(string(pretty))
 		return
 	}
+	os.Stdout.Write(data)
+	fmt.Println()
+}
 
-	switch v := parsed.(type) {
-	case []interface{}:
-		renderTableCSV(v)
-	case map[string]interface{}:
-		if items, ok := v["data"].([]interface{}); ok {
-			renderTableCSV(items)
-		} else if inner, ok := v["data"].(map[string]interface{}); ok {
-			renderObjectCSV(inner)
-		} else {
-			renderObjectCSV(v)
-		}
-	default:
-		os.Stdout.Write(data)
-		if len(data) == 0 || data[len(data)-1] != '\n' {
-			fmt.Println()
+// renderQuiet prints one id per row (no header) for scripting pipelines.
+func renderQuiet(data []byte) {
+	for _, obj := range rowsOf(data) {
+		if id := idOf(obj); id != "" {
+			fmt.Println(id)
 		}
 	}
 }
 
-// Success prints a success message for void operations (delete, etc).
-func Success(format string, args ...interface{}) {
-	fmt.Printf(format+"\n", args...)
+// renderNDJSON prints one compact JSON object per row.
+func renderNDJSON(data []byte) {
+	for _, obj := range rowsOf(data) {
+		if b, err := json.Marshal(obj); err == nil {
+			fmt.Println(string(b))
+		}
+	}
 }
 
-func renderTable(items []interface{}) {
+// rowsOf extracts the list of row objects from any of the response shapes.
+func rowsOf(data []byte) []map[string]interface{} {
+	var parsed interface{}
+	if json.Unmarshal(data, &parsed) != nil {
+		return nil
+	}
+	var items []interface{}
+	switch v := parsed.(type) {
+	case []interface{}:
+		items = v
+	case map[string]interface{}:
+		if arr, ok := v["data"].([]interface{}); ok {
+			items = arr
+		} else if inner, ok := v["data"].(map[string]interface{}); ok {
+			return []map[string]interface{}{inner}
+		} else {
+			return []map[string]interface{}{v}
+		}
+	}
+	out := make([]map[string]interface{}, 0, len(items))
+	for _, it := range items {
+		if obj, ok := it.(map[string]interface{}); ok {
+			out = append(out, obj)
+		}
+	}
+	return out
+}
+
+// idOf returns the best identifier field for a row (id, or a known primary key).
+func idOf(obj map[string]interface{}) string {
+	for _, k := range []string{"id", "aff_campaign_id", "tracker_id", "ppc_account_id",
+		"aff_network_id", "ppc_network_id", "landing_page_id", "text_ad_id", "conv_id",
+		"rotator_id", "user_id", "click_id"} {
+		if v, ok := obj[k]; ok {
+			return formatValue(v)
+		}
+	}
+	return ""
+}
+
+// Success prints a success message for void operations (delete, etc) to stderr
+// so it does not corrupt piped data on stdout.
+func Success(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}
+
+// orderColumns returns the display column order: id first, then the configured
+// business sequence for known fields, then remaining keys alphabetically.
+func orderColumns(keys []string, opts Opts) []string {
+	if len(opts.Fields) > 0 {
+		present := map[string]bool{}
+		for _, k := range keys {
+			present[k] = true
+		}
+		out := make([]string, 0, len(opts.Fields))
+		for _, f := range opts.Fields {
+			if present[f] {
+				out = append(out, f)
+			}
+		}
+		return out
+	}
+
+	has := map[string]bool{}
+	for _, k := range keys {
+		has[k] = true
+	}
+	used := map[string]bool{}
+	ordered := make([]string, 0, len(keys))
+
+	if has["id"] {
+		ordered = append(ordered, "id")
+		used["id"] = true
+	}
+	for _, k := range metricOrder {
+		if has[k] && !used[k] {
+			ordered = append(ordered, k)
+			used[k] = true
+		}
+	}
+	rest := make([]string, 0)
+	for _, k := range keys {
+		if !used[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	return append(ordered, rest...)
+}
+
+func headerFor(key string, raw bool) string {
+	if raw {
+		return key
+	}
+	if h, ok := friendlyHeaders[key]; ok {
+		return h
+	}
+	return key
+}
+
+func renderTable(items []interface{}, opts Opts) {
 	if len(items) == 0 {
-		fmt.Println("No results.")
+		fmt.Fprintln(os.Stderr, "No results.")
 		return
 	}
 
@@ -104,28 +254,33 @@ func renderTable(items []interface{}) {
 			}
 		}
 	}
-
 	keys := make([]string, 0, len(keySet))
 	for k := range keySet {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
-
-	// Move "id" to front if present
-	for i, k := range keys {
-		if k == "id" {
-			keys = append([]string{"id"}, append(keys[:i], keys[i+1:]...)...)
-			break
-		}
-	}
+	keys = orderColumns(keys, opts)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	headers := make([]string, len(keys))
+	for i, k := range keys {
+		headers[i] = truncate(headerFor(k, opts.RawHeaders), opts.Wide)
+	}
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
 
+	// Separator sized to each column's display width (header vs widest value),
+	// so the underline spans the full column instead of just the key length.
 	seps := make([]string, len(keys))
 	for i, k := range keys {
-		seps[i] = strings.Repeat("-", len(k))
+		width := len([]rune(headers[i]))
+		for _, item := range items {
+			obj, _ := item.(map[string]interface{})
+			cell := truncate(formatValue(obj[k]), opts.Wide)
+			if n := len([]rune(cell)); n > width {
+				width = n
+			}
+		}
+		seps[i] = strings.Repeat("-", width)
 	}
 	fmt.Fprintln(w, strings.Join(seps, "\t"))
 
@@ -136,12 +291,22 @@ func renderTable(items []interface{}) {
 		}
 		vals := make([]string, len(keys))
 		for i, k := range keys {
-			vals[i] = formatValue(obj[k])
+			vals[i] = truncate(formatValue(obj[k]), opts.Wide)
 		}
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
-
 	w.Flush()
+}
+
+func truncate(s string, wide bool) string {
+	if wide {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= maxColWidth {
+		return s
+	}
+	return string(r[:maxColWidth-1]) + "…"
 }
 
 func renderObject(obj map[string]interface{}) {
@@ -158,7 +323,9 @@ func renderObject(obj map[string]interface{}) {
 	w.Flush()
 }
 
-func renderPagination(pg map[string]interface{}, jsonMode bool) {
+// renderPagination writes the page summary and the truncation warning to
+// stderr, keeping stdout strictly data.
+func renderPagination(pg map[string]interface{}) {
 	parts := []string{}
 	if total, ok := pg["total"]; ok {
 		parts = append(parts, fmt.Sprintf("Total: %v", total))
@@ -170,11 +337,7 @@ func renderPagination(pg map[string]interface{}, jsonMode bool) {
 		parts = append(parts, fmt.Sprintf("Offset: %v", offset))
 	}
 	if len(parts) > 0 {
-		fmt.Printf("\n%s\n", strings.Join(parts, " | "))
-	}
-
-	if jsonMode {
-		return
+		fmt.Fprintf(os.Stderr, "%s\n", strings.Join(parts, " | "))
 	}
 
 	total, hasTotal := numericValue(pg["total"])
@@ -186,7 +349,6 @@ func renderPagination(pg map[string]interface{}, jsonMode bool) {
 	if !hasOffset {
 		offset = 0
 	}
-
 	shown := limit
 	if offset+limit > total {
 		shown = total - offset
@@ -222,8 +384,8 @@ func numericValue(raw interface{}) (float64, bool) {
 			return 0, false
 		}
 		var parsed float64
-		_, err := fmt.Sscanf(v, "%f", &parsed)
-		if err != nil {
+		n, err := fmt.Sscanf(v, "%f", &parsed)
+		if err != nil || n != 1 {
 			return 0, false
 		}
 		return parsed, true
@@ -232,11 +394,38 @@ func numericValue(raw interface{}) (float64, bool) {
 	}
 }
 
-func renderTableCSV(items []interface{}) {
+func renderCSVData(data []byte, opts Opts) {
+	var parsed interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		os.Stdout.Write(data)
+		if len(data) == 0 || data[len(data)-1] != '\n' {
+			fmt.Println()
+		}
+		return
+	}
+	switch v := parsed.(type) {
+	case []interface{}:
+		renderTableCSV(v, opts)
+	case map[string]interface{}:
+		if items, ok := v["data"].([]interface{}); ok {
+			renderTableCSV(items, opts)
+		} else if inner, ok := v["data"].(map[string]interface{}); ok {
+			renderObjectCSV(inner)
+		} else {
+			renderObjectCSV(v)
+		}
+	default:
+		os.Stdout.Write(data)
+		if len(data) == 0 || data[len(data)-1] != '\n' {
+			fmt.Println()
+		}
+	}
+}
+
+func renderTableCSV(items []interface{}, opts Opts) {
 	if len(items) == 0 {
 		return
 	}
-
 	keySet := map[string]bool{}
 	for _, item := range items {
 		if obj, ok := item.(map[string]interface{}); ok {
@@ -245,27 +434,21 @@ func renderTableCSV(items []interface{}) {
 			}
 		}
 	}
-
 	keys := make([]string, 0, len(keySet))
 	for k := range keySet {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
-
-	// Move "id" to front if present.
-	for i, k := range keys {
-		if k == "id" {
-			keys = append([]string{"id"}, append(keys[:i], keys[i+1:]...)...)
-			break
-		}
-	}
+	keys = orderColumns(keys, opts)
 
 	writer := csv.NewWriter(os.Stdout)
-	if err := writer.Write(keys); err != nil {
+	headers := make([]string, len(keys))
+	for i, k := range keys {
+		headers[i] = headerFor(k, opts.RawHeaders)
+	}
+	if err := writer.Write(headers); err != nil {
 		fmt.Fprintln(os.Stderr, "Error writing CSV header:", err)
 		return
 	}
-
 	for _, item := range items {
 		obj, ok := item.(map[string]interface{})
 		if !ok {
@@ -280,7 +463,6 @@ func renderTableCSV(items []interface{}) {
 			return
 		}
 	}
-
 	writer.Flush()
 	if err := writer.Error(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error finalizing CSV output:", err)
@@ -299,14 +481,12 @@ func renderObjectCSV(obj map[string]interface{}) {
 		fmt.Fprintln(os.Stderr, "Error writing CSV header:", err)
 		return
 	}
-
 	for _, k := range keys {
 		if err := writer.Write([]string{k, formatValue(obj[k])}); err != nil {
 			fmt.Fprintln(os.Stderr, "Error writing CSV row:", err)
 			return
 		}
 	}
-
 	writer.Flush()
 	if err := writer.Error(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error finalizing CSV output:", err)

--- a/go-cli/internal/output/output.go
+++ b/go-cli/internal/output/output.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 )
@@ -292,11 +293,29 @@ func renderTable(items []interface{}, opts Opts) {
 		}
 		vals := make([]string, len(keys))
 		for i, k := range keys {
-			vals[i] = truncate(formatValue(obj[k]), opts.Wide)
+			vals[i] = truncate(trimLongDecimal(formatValue(obj[k])), opts.Wide)
 		}
 		fmt.Fprintln(w, strings.Join(vals, "\t"))
 	}
 	w.Flush()
+}
+
+// trimLongDecimal shortens noisy long-decimal numeric strings (e.g. the API's
+// "0.288613861" or "-54.807953180") to 4 decimal places for the human table,
+// trimming trailing zeros. Non-numeric strings and integers pass through. Only
+// applied to the table view; JSON/CSV keep the raw values for machine consumers.
+func trimLongDecimal(s string) string {
+	dot := strings.IndexByte(s, '.')
+	if dot < 0 || len(s)-dot-1 <= 4 {
+		return s
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return s
+	}
+	out := strconv.FormatFloat(f, 'f', 4, 64)
+	out = strings.TrimRight(out, "0")
+	return strings.TrimRight(out, ".")
 }
 
 func truncate(s string, wide bool) string {

--- a/go-cli/internal/output/output_test.go
+++ b/go-cli/internal/output/output_test.go
@@ -514,3 +514,18 @@ func TestRenderNDJSON(t *testing.T) {
 		t.Errorf("ndjson should emit one compact object per line, got:\n%s", out)
 	}
 }
+
+func TestTrimLongDecimal(t *testing.T) {
+	cases := map[string]string{
+		"0.288613861":   "0.2886",
+		"-54.807953180": "-54.808",
+		"2.20":          "2.20",   // <=4 decimals untouched
+		"90008":         "90008",  // integer untouched
+		"Bing - Search": "Bing - Search",
+	}
+	for in, want := range cases {
+		if got := trimLongDecimal(in); got != want {
+			t.Errorf("trimLongDecimal(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/go-cli/internal/output/output_test.go
+++ b/go-cli/internal/output/output_test.go
@@ -32,6 +32,29 @@ func captureStdout(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
+// captureStderr captures everything written to os.Stderr during fn().
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+
+	return buf.String()
+}
+
 func TestRenderJSONModePrettyPrints(t *testing.T) {
 	input := `{"id":1,"name":"test"}`
 	out := captureStdout(t, func() {
@@ -142,8 +165,11 @@ func TestRenderTableWithDataAndPagination(t *testing.T) {
 	out := captureStdout(t, func() {
 		Render([]byte(input), false)
 	})
+	errOut := captureStderr(t, func() {
+		Render([]byte(input), false)
+	})
 
-	// Should render the data table
+	// Should render the data table to stdout
 	if !strings.Contains(out, "Item 1") {
 		t.Errorf("should contain 'Item 1', got:\n%s", out)
 	}
@@ -151,15 +177,15 @@ func TestRenderTableWithDataAndPagination(t *testing.T) {
 		t.Errorf("should contain 'Item 2', got:\n%s", out)
 	}
 
-	// Should render pagination info
-	if !strings.Contains(out, "Total: 50") {
-		t.Errorf("should contain 'Total: 50', got:\n%s", out)
+	// Pagination info goes to stderr
+	if !strings.Contains(errOut, "Total: 50") {
+		t.Errorf("stderr should contain 'Total: 50', got:\n%s", errOut)
 	}
-	if !strings.Contains(out, "Limit: 10") {
-		t.Errorf("should contain 'Limit: 10', got:\n%s", out)
+	if !strings.Contains(errOut, "Limit: 10") {
+		t.Errorf("stderr should contain 'Limit: 10', got:\n%s", errOut)
 	}
-	if !strings.Contains(out, "Offset: 0") {
-		t.Errorf("should contain 'Offset: 0', got:\n%s", out)
+	if !strings.Contains(errOut, "Offset: 0") {
+		t.Errorf("stderr should contain 'Offset: 0', got:\n%s", errOut)
 	}
 }
 
@@ -215,28 +241,30 @@ func TestRenderSingleObjectWrappedInData(t *testing.T) {
 
 func TestRenderEmptyArray(t *testing.T) {
 	input := `[]`
-	out := captureStdout(t, func() {
+	// "No results." goes to stderr so stdout stays strictly data.
+	out := captureStderr(t, func() {
 		Render([]byte(input), false)
 	})
 
 	if !strings.Contains(out, "No results.") {
-		t.Errorf("empty array should show 'No results.', got:\n%s", out)
+		t.Errorf("empty array should show 'No results.' on stderr, got:\n%s", out)
 	}
 }
 
 func TestRenderEmptyDataArray(t *testing.T) {
 	input := `{"data":[],"pagination":{"total":0,"limit":50,"offset":0}}`
-	out := captureStdout(t, func() {
+	out := captureStderr(t, func() {
 		Render([]byte(input), false)
 	})
 
 	if !strings.Contains(out, "No results.") {
-		t.Errorf("empty data array should show 'No results.', got:\n%s", out)
+		t.Errorf("empty data array should show 'No results.' on stderr, got:\n%s", out)
 	}
 }
 
 func TestSuccess(t *testing.T) {
-	out := captureStdout(t, func() {
+	// Success messages go to stderr so they don't corrupt piped data.
+	out := captureStderr(t, func() {
 		Success("Campaign %s deleted.", "42")
 	})
 
@@ -247,7 +275,7 @@ func TestSuccess(t *testing.T) {
 }
 
 func TestSuccessNoArgs(t *testing.T) {
-	out := captureStdout(t, func() {
+	out := captureStderr(t, func() {
 		Success("Operation completed.")
 	})
 
@@ -397,12 +425,12 @@ func TestRenderTableMissingFieldsInSomeRows(t *testing.T) {
 func TestRenderPaginationPartialFields(t *testing.T) {
 	// pagination with only some fields present
 	input := `{"data":[{"id":1}],"pagination":{"total":10}}`
-	out := captureStdout(t, func() {
+	out := captureStderr(t, func() {
 		Render([]byte(input), false)
 	})
 
 	if !strings.Contains(out, "Total: 10") {
-		t.Errorf("should contain 'Total: 10', got:\n%s", out)
+		t.Errorf("should contain 'Total: 10' on stderr, got:\n%s", out)
 	}
 	// Should NOT contain "Limit" since limit is not present
 	lines := strings.Split(out, "\n")
@@ -417,5 +445,72 @@ func TestRenderPaginationPartialFields(t *testing.T) {
 	}
 	if !paginationFound {
 		t.Error("pagination line with 'Total:' not found")
+	}
+}
+
+func TestRenderQuietIdOnly(t *testing.T) {
+	input := `{"data":[{"aff_campaign_id":90008,"name":"A"},{"aff_campaign_id":90010,"name":"B"}]}`
+	out := captureStdout(t, func() {
+		RenderWith([]byte(input), Opts{Quiet: true})
+	})
+	if strings.TrimSpace(out) != "90008\n90010" {
+		t.Errorf("quiet output = %q, want two ids one per line", out)
+	}
+}
+
+func TestRenderFieldsSelection(t *testing.T) {
+	input := `[{"id":1,"name":"A","total_net":5,"roi":10}]`
+	out := captureStdout(t, func() {
+		RenderWith([]byte(input), Opts{Fields: []string{"id", "roi"}, RawHeaders: true})
+	})
+	if !strings.Contains(out, "roi") || strings.Contains(out, "name") {
+		t.Errorf("fields selection should include roi, exclude name, got:\n%s", out)
+	}
+}
+
+func TestRenderFriendlyHeaders(t *testing.T) {
+	input := `[{"id":1,"total_net":5}]`
+	out := captureStdout(t, func() {
+		RenderWith([]byte(input), Opts{})
+	})
+	if !strings.Contains(out, "Profit") {
+		t.Errorf("total_net should render as friendly header 'Profit', got:\n%s", out)
+	}
+	rawOut := captureStdout(t, func() {
+		RenderWith([]byte(input), Opts{RawHeaders: true})
+	})
+	if !strings.Contains(rawOut, "total_net") {
+		t.Errorf("--raw-headers should keep 'total_net', got:\n%s", rawOut)
+	}
+}
+
+func TestRenderSeparatorSpansColumnWidth(t *testing.T) {
+	// The dash separator under a wide value column must span the value width,
+	// not just the (short) header length.
+	input := `[{"id":1,"name":"A Very Long Campaign Name Here"}]`
+	out := captureStdout(t, func() {
+		RenderWith([]byte(input), Opts{})
+	})
+	var sepLine string
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, "----") {
+			sepLine = ln
+		}
+	}
+	// "name" header is 4 chars but the value is long; separator must be wider.
+	dashes := strings.Count(sepLine, "-")
+	if dashes < len("A Very Long Campaign Name Here") {
+		t.Errorf("separator should span the widest cell, got %d dashes in %q", dashes, sepLine)
+	}
+}
+
+func TestRenderNDJSON(t *testing.T) {
+	input := `{"data":[{"id":1},{"id":2}]}`
+	out := captureStdout(t, func() {
+		RenderWith([]byte(input), Opts{NDJSON: true})
+	})
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 || !strings.Contains(lines[0], "\"id\":1") {
+		t.Errorf("ndjson should emit one compact object per line, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Implements **every item** in the CLI friction audit, across 19 self-contained commits. `go test ./...` (9 pkgs) green throughout; marketer E2E 32/32; new behavior unit-tested.

## New capabilities
`report breakeven` / `losers` / `winners` / `crosstab`; `campaign optimize`; `rotator test` / `tracker test`; `rotator check` / `tracker check`; `rotator trace` + `tracker list --rotator_id`; `rotator criteria-values` + `rule-create --country/--redirect-campaign` sugar; `conversion simulate` / `conversion postback-url`; `report breakdown --zero-leads/--having/--min-*`.

## Ergonomics & consistency
- `-q/--quiet`, `--ndjson`, `--fields`, `--wide`, `--raw-headers`; non-data → stderr; full-width separator; id-first business column order; friendly headers; long-decimal trimming in the table (JSON/CSV stay raw).
- **Public-id resolution**: `tracker get`/`get-url` auto-resolve `tracker_id_public` on 404 (+`--public`).
- **Kebab-case everywhere via a global flag normalizer** — `--aff-campaign-id` and `--aff_campaign_id` (and `--sort-dir`/`--sort_dir`) are the same flag; a `consistency_test` walk enforces kebab-case visible flags. No script breakage.
- Shared metric/dimension aliases; `--sort-dir` + friendly `--sort` on every report subcommand; one time-window flag (`--period`/`--days`/`--history` aliased); `--source`/`--target` on sync/diff; `user role` positional-or-flag id; `conversion list --aff_campaign_id`.
- Error hints on 404/401/422/network; `exec --all-profiles --json` stdout/stderr split; `--group` rejected where it doesn't fan out; bulk `--ids` delete on user/attribution; export `-O`.

## Verified non-issue
The reported `conversion --click_id_public` "data bug" is correct as-is — the endpoint's click_id IS the public subid (confirmed by a working postback).

## Spun out
Implementing `conversion simulate` surfaced a **critical production bug**: `gpb.php` (the S2S postback handler) crashed on NULL click fields, so server-to-server conversions never recorded. Fixed in **#135**.

## Breaking change
`export` short flag is now `-O` (was `-o`), reserving `-o` for `--offset`. `--output` unchanged.

https://claude.ai/code/session_015vuv7cgTTHcRKnHKURdwVZ