### PR TITLE
Bandit bridge v2 follow-up: CAS-persist markDirty and the ctx_key backfill (Codex round 5)

### DIFF
--- a/202-config/Bandit/DimensionSync.php
+++ b/202-config/Bandit/DimensionSync.php
@@ -68,23 +68,32 @@ final class DimensionSync
                 return;
             }
 
-            $state = json_decode((string) ($row['bandit_bridge_config'] ?? ''), true);
-            $state = is_array($state) ? $state : [];
-            $state['dims_dirty'] = true;
-            // Strictly monotonic per-save token (see the docblock): a save
-            // landing in the same second as the previous one must still
-            // produce a new value, or clearDirty() could not tell it apart
-            // from the save whose snapshot was already pushed.
-            $state['dims_dirty_at'] = max(time(), (int) ($state['dims_dirty_at'] ?? 0) + 1);
+            // Persist through the byte-guarded CAS (fresh re-read inside):
+            // an unconditional UPDATE from the row read above would clobber
+            // any pref write landing in between — e.g. the six-hour pull's
+            // freshly fetched config/fetched_at/ctx_key, and EventBridge
+            // routing reads config.enabled_events from this same JSON. The
+            // save-path hook is one-shot (no cron re-applies it), so a guard
+            // miss retries with fresh bytes instead of dropping the flag
+            // until the nightly full sync.
+            for ($attempt = 0; $attempt < 3; $attempt++) {
+                $landed = self::casMutateState($conn, $userId, static function (array $state): array {
+                    $state['dims_dirty'] = true;
+                    // Strictly monotonic per-save token (see the docblock),
+                    // recomputed from the FRESH state on every attempt: a
+                    // save landing in the same second as the previous one
+                    // must still produce a new value, or clearDirty() could
+                    // not tell it apart from the save whose snapshot was
+                    // already pushed.
+                    $state['dims_dirty_at'] = max(time(), (int) ($state['dims_dirty_at'] ?? 0) + 1);
 
-            $stateJson = json_encode($state);
-            if ($stateJson === false) {
-                return;
+                    return $state;
+                });
+                if ($landed) {
+                    return;
+                }
             }
-
-            $update = $conn->prepareWrite('UPDATE 202_users_pref SET bandit_bridge_config = ? WHERE user_id = ?');
-            $conn->bind($update, 'si', [$stateJson, $userId]);
-            $conn->executeUpdate($update);
+            error_log('DimensionSync::markDirty user ' . $userId . ': dirty flag did not land after 3 CAS attempts');
         } catch (Throwable $e) {
             // Pre-upgrade schemas miss the bandit columns entirely — that is
             // the expected quiet case, not worth log noise on every save.
@@ -155,16 +164,21 @@ final class DimensionSync
      * mid-pull markDirty()'s dims_dirty — the hourly dimension push
      * would then skip the user until the nightly full sync.
      *
-     * Single attempt by design, mirroring clearDirty(): a guard miss
-     * means another writer changed the state in the microseconds between
-     * the re-read and the UPDATE, so the caller's change simply does not
-     * land this pass. Every caller is a recurring job (the 6-hour pull,
-     * the ctx_key backfill) that re-applies on its next run; what is
-     * guaranteed is that OTHER writers' keys are never clobbered.
+     * Single attempt, mirroring clearDirty(): a guard miss means another
+     * writer changed the state in the microseconds between the re-read and
+     * the UPDATE, so the caller's change simply does not land this pass.
+     * Recurring jobs (the 6-hour pull, the ctx_key backfill) re-apply on
+     * their next run and may ignore the return value; one-shot callers
+     * (markDirty on an admin save) check it and retry with fresh bytes.
+     * What is guaranteed either way is that OTHER writers' keys are never
+     * clobbered.
      *
      * @param callable(array): array $mutate pure, idempotent transform of the decoded state
+     * @return bool true when the mutated state is persisted (or the pref
+     *              already had the desired bytes); false on a guard miss,
+     *              a missing pref row, or a failed re-encode
      */
-    public static function casMutateState(Connection $conn, int $userId, callable $mutate): void
+    public static function casMutateState(Connection $conn, int $userId, callable $mutate): bool
     {
         $stmt = $conn->prepareRead(
             'SELECT bandit_bridge_config FROM 202_users_pref WHERE user_id = ? LIMIT 1'
@@ -172,7 +186,7 @@ final class DimensionSync
         $conn->bind($stmt, 'i', [$userId]);
         $row = $conn->fetchOne($stmt);
         if ($row === null) {
-            return;
+            return false;
         }
 
         $rawJson = (string) ($row['bandit_bridge_config'] ?? '');
@@ -180,15 +194,19 @@ final class DimensionSync
         $state = is_array($state) ? $state : [];
 
         $stateJson = json_encode($mutate($state));
-        if ($stateJson === false || $stateJson === $rawJson) {
-            return; // re-encode failed, or already in the desired shape
+        if ($stateJson === false) {
+            return false;
+        }
+        if ($stateJson === $rawJson) {
+            return true; // already in the desired shape
         }
 
         $update = $conn->prepareWrite(
             'UPDATE 202_users_pref SET bandit_bridge_config = ? WHERE user_id = ? AND bandit_bridge_config = ?'
         );
         $conn->bind($update, 'sis', [$stateJson, $userId, $rawJson]);
-        $conn->executeUpdate($update);
+
+        return $conn->executeUpdate($update) > 0;
     }
 
     /**
@@ -239,16 +257,25 @@ final class DimensionSync
         }
 
         // Backfill the derived t202ctx key for pre-ctx_token pairings — the
-        // secret is already loaded, so this costs one UPDATE at most once.
-        // $state carries any dims_dirty flags through the re-encode intact.
+        // secret is already loaded, so this costs one guarded write at most
+        // once. $bridgeConfigJson was selected by the cron before the
+        // per-user work started (possibly minutes stale behind a SaaS
+        // fetch), so the persist goes through casMutateState: a bare UPDATE
+        // from that stale decode would drop anything written in between — a
+        // fresh 6-hour config pull, or an admin save's dims_dirty (and with
+        // it the failed-push retry). The callback re-checks on the fresh
+        // bytes; if another writer already backfilled, the mutation is a
+        // byte-identical no-op. Single attempt: this is a recurring-job
+        // path, the next run re-applies.
         if (preg_match('/^[0-9a-f]{64}$/', (string) ($state['ctx_key'] ?? '')) !== 1) {
-            $state['ctx_key'] = bin2hex(CtxToken::deriveKey($webhookSecret));
-            $stateJson = json_encode($state);
-            if ($stateJson !== false) {
-                $persist = $conn->prepareWrite('UPDATE 202_users_pref SET bandit_bridge_config = ? WHERE user_id = ?');
-                $conn->bind($persist, 'si', [$stateJson, $userId]);
-                $conn->executeUpdate($persist);
-            }
+            $ctxKeyHex = bin2hex(CtxToken::deriveKey($webhookSecret));
+            self::casMutateState($conn, $userId, static function (array $fresh) use ($ctxKeyHex): array {
+                if (preg_match('/^[0-9a-f]{64}$/', (string) ($fresh['ctx_key'] ?? '')) !== 1) {
+                    $fresh['ctx_key'] = $ctxKeyHex;
+                }
+
+                return $fresh;
+            });
         }
 
         $snapshot = self::buildSnapshot($conn, $userId);

--- a/202-config/Database/Connection.php
+++ b/202-config/Database/Connection.php
@@ -272,7 +272,13 @@ final class Connection
         try {
             $affected = $stmt->affected_rows;
         } catch (\Error) {
-            $affected = 0;
+            // Native mysqli_stmt::$affected_rows is a virtual property whose
+            // read throws on statements that skipped the real constructor
+            // (the test fakes; same constraint as ::$error). Those fakes can
+            // expose the count through a plain method instead — callers like
+            // the DimensionSync CAS persist branch on it to detect guard
+            // misses, so it must be fakeable.
+            $affected = method_exists($stmt, 'affectedRowsFallback') ? $stmt->affectedRowsFallback() : 0;
         }
 
         $stmt->close();

--- a/tests/Bandit/ApiDictionaryDirtyTest.php
+++ b/tests/Bandit/ApiDictionaryDirtyTest.php
@@ -98,6 +98,7 @@ final class ApiDictionaryDirtyTest extends TestCase
             $db->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
                 ['bandit_bridge_config' => '{"webhook_id":3}'],
             ]); // markDirty persists via the CAS, which re-reads fresh bytes
+            $db->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 1); // the guarded write lands first try
 
             $this->landingPagesController($db)->delete(18);
 
@@ -121,6 +122,7 @@ final class ApiDictionaryDirtyTest extends TestCase
             $db->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
                 ['bandit_bridge_config' => '{"webhook_id":3}'],
             ]); // markDirty persists via the CAS, which re-reads fresh bytes
+            $db->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 1); // the guarded write lands first try
 
             $this->landingPagesController($db)->update(18, ['landing_page_nickname' => 'Renamed LP']);
 

--- a/tests/Bandit/ApiDictionaryDirtyTest.php
+++ b/tests/Bandit/ApiDictionaryDirtyTest.php
@@ -95,6 +95,9 @@ final class ApiDictionaryDirtyTest extends TestCase
             $db->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
                 ['bandit_status' => 'active', 'bandit_bridge_config' => '{"webhook_id":3}'],
             ]);
+            $db->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+                ['bandit_bridge_config' => '{"webhook_id":3}'],
+            ]); // markDirty persists via the CAS, which re-reads fresh bytes
 
             $this->landingPagesController($db)->delete(18);
 
@@ -115,6 +118,9 @@ final class ApiDictionaryDirtyTest extends TestCase
             $db->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
                 ['bandit_status' => 'active', 'bandit_bridge_config' => '{"webhook_id":3}'],
             ]);
+            $db->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+                ['bandit_bridge_config' => '{"webhook_id":3}'],
+            ]); // markDirty persists via the CAS, which re-reads fresh bytes
 
             $this->landingPagesController($db)->update(18, ['landing_page_nickname' => 'Renamed LP']);
 

--- a/tests/Bandit/DimensionSyncTest.php
+++ b/tests/Bandit/DimensionSyncTest.php
@@ -41,10 +41,15 @@ final class DimensionSyncTest extends TestCase
 
     public function testMarkDirtyFlagsInsideBridgeConfigPreservingExistingKeys(): void
     {
+        $rawPref = '{"webhook_id":3,"ctx_key":"' . self::CTX_KEY_HEX . '"}';
         $fake = new FakeMysqliConnection();
         $fake->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
-            ['bandit_status' => 'active', 'bandit_bridge_config' => '{"webhook_id":3,"ctx_key":"' . self::CTX_KEY_HEX . '"}'],
+            ['bandit_status' => 'active', 'bandit_bridge_config' => $rawPref],
         ]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => $rawPref],
+        ]);
+        $fake->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 1);
 
         DimensionSync::markDirty($fake, 7);
 
@@ -57,14 +62,27 @@ final class DimensionSyncTest extends TestCase
         self::assertIsInt($state['dims_dirty_at']);
         self::assertEqualsWithDelta(time(), $state['dims_dirty_at'], 5);
         self::assertSame(7, $updates[0]->boundValues[1]);
+
+        // The write is the byte-guarded CAS, not an unconditional UPDATE: a
+        // bridge-config persist landing between markDirty's reads and this
+        // write must miss the guard instead of being overwritten with the
+        // older JSON (EventBridge routing reads config.enabled_events from
+        // these same bytes).
+        self::assertStringContainsString('AND bandit_bridge_config = ?', $updates[0]->sql);
+        self::assertSame($rawPref, $updates[0]->boundValues[2], 'guarded on the exact fresh bytes read');
     }
 
     public function testMarkDirtyBumpsDirtyAtOnEverySaveSoMidPushChangesSurvive(): void
     {
+        $rawPref = '{"webhook_id":3,"dims_dirty":true,"dims_dirty_at":100}';
         $fake = new FakeMysqliConnection();
         $fake->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
-            ['bandit_status' => 'active', 'bandit_bridge_config' => '{"webhook_id":3,"dims_dirty":true,"dims_dirty_at":100}'],
+            ['bandit_status' => 'active', 'bandit_bridge_config' => $rawPref],
         ]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => $rawPref],
+        ]);
+        $fake->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 1);
 
         DimensionSync::markDirty($fake, 7);
 
@@ -84,10 +102,15 @@ final class DimensionSyncTest extends TestCase
         // pass both clearDirty guards and clear a flag whose snapshot
         // missed this save. The token must be strictly monotonic instead.
         $now = time();
+        $rawPref = '{"webhook_id":3,"dims_dirty":true,"dims_dirty_at":' . $now . '}';
         $fake = new FakeMysqliConnection();
         $fake->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
-            ['bandit_status' => 'active', 'bandit_bridge_config' => '{"webhook_id":3,"dims_dirty":true,"dims_dirty_at":' . $now . '}'],
+            ['bandit_status' => 'active', 'bandit_bridge_config' => $rawPref],
         ]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => $rawPref],
+        ]);
+        $fake->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 1);
 
         DimensionSync::markDirty($fake, 7);
 
@@ -95,6 +118,60 @@ final class DimensionSyncTest extends TestCase
         self::assertCount(1, $updates);
         $state = json_decode((string) $updates[0]->boundValues[0], true);
         self::assertGreaterThan($now, $state['dims_dirty_at'], 'same-second saves must still produce a new token');
+    }
+
+    public function testMarkDirtyCarriesAConcurrentConfigWriteInsteadOfClobberingIt(): void
+    {
+        // Between the status read and the persist, the six-hour pull saved a
+        // fresh remote config into the pref. markDirty's CAS re-read sees
+        // those bytes, so the dirty keys are layered ONTO them — the old
+        // unconditional UPDATE would have written the config-less decode
+        // back and silently disabled event routing until the next pull.
+        $stalePref = '{"webhook_id":3}';
+        $freshPref = '{"webhook_id":3,"config":{"enabled_events":["*"]},"fetched_at":12345}';
+        $fake = new FakeMysqliConnection();
+        $fake->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
+            ['bandit_status' => 'active', 'bandit_bridge_config' => $stalePref],
+        ]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => $freshPref],
+        ]);
+        $fake->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 1);
+
+        DimensionSync::markDirty($fake, 7);
+
+        $updates = $fake->statementsContaining('UPDATE 202_users_pref SET bandit_bridge_config');
+        self::assertCount(1, $updates);
+        $state = json_decode((string) $updates[0]->boundValues[0], true);
+        self::assertSame(['enabled_events' => ['*']], $state['config'], 'the mid-save config pull survives the dirty-marking');
+        self::assertSame(12345, $state['fetched_at']);
+        self::assertTrue($state['dims_dirty']);
+        self::assertSame($freshPref, $updates[0]->boundValues[2], 'the guard binds the FRESH bytes, not the status-read decode');
+    }
+
+    public function testMarkDirtyRetriesGuardMissesAndNeverThrows(): void
+    {
+        // Every CAS attempt loses its race (affected_rows stays 0): the
+        // one-shot save hook retries with fresh bytes instead of giving up
+        // on the first miss, then degrades to the nightly backstop quietly.
+        $rawPref = '{"webhook_id":3}';
+        $fake = new FakeMysqliConnection();
+        $fake->whenQueryContainsReturnRows('SELECT bandit_status, bandit_bridge_config', [
+            ['bandit_status' => 'active', 'bandit_bridge_config' => $rawPref],
+        ]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => $rawPref],
+        ]);
+        $fake->whenQueryContainsAffectedRows('UPDATE 202_users_pref', 0);
+
+        DimensionSync::markDirty($fake, 7);
+
+        self::assertCount(
+            3,
+            $fake->statementsContaining('UPDATE 202_users_pref SET bandit_bridge_config'),
+            'a guard miss on the one-shot save path retries (bounded) rather than dropping the flag'
+        );
+        $this->addToAssertionCount(1); // reaching here proves the admin save survived the misses
     }
 
     public function testMarkDirtyIsANoOpUnlessActivelyPaired(): void
@@ -268,16 +345,26 @@ final class DimensionSyncTest extends TestCase
         self::assertStringContainsString('LIMIT 128', $fake->statementsContaining('FROM 202_landing_pages')[0]->sql);
     }
 
-    public function testPushForUserBackfillsCtxKeyWithoutDroppingTheDirtyFlag(): void
+    public function testPushForUserBackfillsCtxKeyThroughTheCasWithoutDroppingConcurrentWrites(): void
     {
+        // The cron selected this user's pref before the per-user work
+        // started; by backfill time an admin save has set dims_dirty and
+        // the 6-hour pull has stored a config. The backfill must layer
+        // ctx_key onto THOSE fresh bytes via the guarded CAS — the old bare
+        // UPDATE from the stale cron decode dropped both (and with the
+        // dirty flag, the failed-push retry).
+        $freshPref = '{"webhook_id":5,"dims_dirty":true,"dims_dirty_at":100,"config":{"enabled_events":["*"]}}';
         $fake = new FakeMysqliConnection();
         $fake->whenQueryContainsReturnRows('FROM 202_ltv_webhooks', [['webhook_secret' => 'secret-abc']]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => $freshPref],
+        ]);
 
         DimensionSync::pushForUser(
             new Connection($fake),
             $this->client(),
             7,
-            '{"webhook_id":5,"dims_dirty":true,"dims_dirty_at":100}',
+            '{"webhook_id":5}', // the cron's stale decode: no dirty flag, no config yet
             'hash-1'
         );
 
@@ -285,8 +372,33 @@ final class DimensionSyncTest extends TestCase
         self::assertCount(1, $updates);
         $state = json_decode((string) $updates[0]->boundValues[0], true);
         self::assertSame(bin2hex(CtxToken::deriveKey('secret-abc')), $state['ctx_key']);
-        self::assertTrue($state['dims_dirty'], 'the backfill re-encode must carry the dirty flag through');
+        self::assertTrue($state['dims_dirty'], 'the backfill must carry the mid-cron dirty flag through');
         self::assertSame(100, $state['dims_dirty_at']);
+        self::assertSame(['enabled_events' => ['*']], $state['config'], 'the mid-cron config pull survives too');
+        self::assertStringContainsString('AND bandit_bridge_config = ?', $updates[0]->sql);
+        self::assertSame($freshPref, $updates[0]->boundValues[2], 'guarded on the fresh bytes, not the cron decode');
+    }
+
+    public function testPushForUserSkipsTheBackfillWhenAnotherWriterAlreadyLandedIt(): void
+    {
+        // The stale cron decode lacks ctx_key, but by backfill time another
+        // run already wrote it: the CAS callback re-checks on fresh bytes
+        // and the mutation is a byte-identical no-op — no write at all.
+        $fake = new FakeMysqliConnection();
+        $fake->whenQueryContainsReturnRows('FROM 202_ltv_webhooks', [['webhook_secret' => 'secret-abc']]);
+        $fake->whenQueryContainsReturnRows('SELECT bandit_bridge_config', [
+            ['bandit_bridge_config' => '{"webhook_id":5,"ctx_key":"' . self::CTX_KEY_HEX . '"}'],
+        ]);
+
+        DimensionSync::pushForUser(
+            new Connection($fake),
+            $this->client(),
+            7,
+            '{"webhook_id":5}',
+            'hash-1'
+        );
+
+        self::assertSame([], $fake->statementsContaining('UPDATE 202_users_pref'), 'an already-backfilled fresh state must not be rewritten');
     }
 
     public function testPushForUserThrowsWhenThePairingHasNoWebhook(): void

--- a/tests/Support/FakeMysqliConnection.php
+++ b/tests/Support/FakeMysqliConnection.php
@@ -158,7 +158,13 @@ final class FakeMysqliConnection extends mysqli
             }
         }
 
-        return 1;
+        // Default 0, matching the contract every existing test was written
+        // against (the native property read always threw on fakes and
+        // Connection::executeUpdate reported 0): atomic-claim, scoped-delete
+        // and race-loser tests rely on an unconfigured UPDATE matching
+        // nothing. Tests that need a write to land opt in via
+        // whenQueryContainsAffectedRows().
+        return 0;
     }
 
     private function resolveExecuteReturn(string $query): bool

--- a/tests/Support/FakeMysqliConnection.php
+++ b/tests/Support/FakeMysqliConnection.php
@@ -186,7 +186,6 @@ final class FakeMysqliStatement extends mysqli_stmt
     public int $executeCount = 0;
     public int $closeCount = 0;
     public string|int $insert_id = 0;
-    public string|int $affected_rows = 0;
     public string $error = '';
 
     /**
@@ -242,6 +241,19 @@ final class FakeMysqliStatement extends mysqli_stmt
     {
         $this->closeCount++;
         return true;
+    }
+
+    /**
+     * Native mysqli_stmt::$affected_rows (like ::$error) cannot be written
+     * or even read on constructor-skipping fakes — PHP 8.4+ virtual
+     * property reads throw "Property access is not allowed yet".
+     * Connection::executeUpdate() falls back to this method inside its
+     * existing \Error guard, so tests can express guard misses (0) and
+     * landed writes (>0) via whenQueryContainsAffectedRows().
+     */
+    public function affectedRowsFallback(): int
+    {
+        return $this->executeCount > 0 ? $this->configuredAffectedRows : 0;
     }
 }
 


### PR DESCRIPTION
Rescues the #138 round-5 review fixes that missed the squash-merge by minutes: Codex posted two P2s on the bridge-config write family at 06:16Z, the fix commit landed on `bandit-bridge-v2` at ~06:30Z, but #138 had been squash-merged at 06:21:58Z (head c4765e80), stranding the commit on the merged branch. This PR cherry-picks it onto current master (clean, no conflicts; no overlap with #139).

**The two findings (both confirmed real, thread replies on #138):**
- `DimensionSync::markDirty()` re-encoded the whole `bandit_bridge_config` pref from a stale decode with an unconditional UPDATE — a concurrent `bridge_config.php` CAS persist landing in the window lost its fresh `config`/`fetched_at`/`ctx_key`, and `EventBridge::isEventEnabled()` reads `config.enabled_events` from those same bytes, so paired installs could stop emitting until the next six-hour pull. Now persists through `casMutateState()` (fresh re-read, byte-guarded UPDATE, monotonic `dims_dirty_at` recomputed per attempt) with a bounded 3-attempt retry since the save-path hook is one-shot.
- `pushForUser()`'s ctx_key backfill wrote pref bytes the cron had selected before the per-user work began, dropping a mid-cron config pull or an admin save's `dims_dirty` (and with it the failed-push retry). Now backfills through `casMutateState()` with the presence re-checked on fresh bytes; already-backfilled state is a byte-identical no-op.

`casMutateState()` now returns whether the mutation landed so one-shot callers can retry; recurring-job callers may ignore it. Test plumbing: native `mysqli_stmt::$affected_rows` can neither be written nor read on constructor-skipping fakes (PHP 8.4+ virtual property), so `Connection::executeUpdate()`'s existing \Error guard falls back to a plain `affectedRowsFallback()` method — making `whenQueryContainsAffectedRows()` functional and guard misses expressible in tests.

**Gates on this branch (master + fix):** php -l clean on all five touched files; `phpunit tests/Bandit tests/Bridge tests/StaticEndpoint` OK (37 tests, 147 assertions); CtxToken fixtures untouched.

Refs: #138 review threads (comments 3563419717, 3563419720).

https://claude.ai/code/session_0151abiSittQKPmnwuuCfDV3