### PR TITLE
JSON report transport for the flat Analyze reports (off by default), and fix pagination counts

### DIFF
--- a/202-config-sample.php
+++ b/202-config-sample.php
@@ -8,6 +8,24 @@ $dbhost = 'localhosthere'; // 99% chance you won't need to change this value
 $dbhostro = 'localhostreplica'; // Only change this to use a read replica for reading data
 $mchost = 'localhostmemcache'; // this is the memcache server host, if you don't know what this is, don't touch it.
 
+// ** Optional: JSON report transport ** //
+// Off by default. When enabled, the Analyze reports fetch their data as JSON from
+// tracking202/ajax/report_dispatch.php and render client-side, and the bounded filter
+// dropdowns (country/region/isp/device/browser/platform) are rendered server-side
+// instead of via six AJAX round-trips. Any transport error falls back to the legacy
+// HTML path automatically, so this is safe to toggle. Uncomment to enable:
+//
+// NOTE: these define() calls must come *after* the declare(strict_types=1) above —
+// declare must be the first statement in the file or PHP fatals on load.
+//
+// define('TRACKING202_JSON_ARCHITECTURE_ENABLED', true);
+//
+// Guardrails for the server-rendered filters. A dropdown larger than MAX_OPTIONS is
+// left on the legacy AJAX path, and if the six of them together would exceed MAX_BYTES
+// of HTML they are all left on it — a big ISP or region table should not bloat the page.
+// define('TRACKING202_STATIC_FILTER_SSR_MAX_OPTIONS', 1500);
+// define('TRACKING202_STATIC_FILTER_SSR_MAX_BYTES', 65536);
+
 /*---DONT EDIT ANYTHING BELOW THIS LINE!---*/
 
 //Database connection class

--- a/202-config/DataEngine/GroupedReportDefinition.php
+++ b/202-config/DataEngine/GroupedReportDefinition.php
@@ -13,29 +13,29 @@ namespace Prosper202\DataEngine;
 final class GroupedReportDefinition
 {
     /**
+     * Pagination counts the report's own GROUP BY over these same joins, so a report
+     * needs no separate count strategy — see DataEngine::countReportGroups(). The old
+     * $countColumn / $usesRefererCount pair described a count that ran against a
+     * different set of rows than the report itself, which is what made totalRows
+     * disagree with the rows returned.
+     *
      * @param string  $labelSelect       Dimension column(s) for the SELECT list,
      *                                   e.g. "country_name,country_code".
      * @param string  $joins             Report-specific JOIN clause against the
      *                                   `2st` (202_dataengine) alias.
-     * @param string  $groupBy           GROUP BY expression.
-     * @param ?string $countColumn       2st column counted (DISTINCT) for
-     *                                   pagination, or null when the report
-     *                                   uses the referer-specific count.
+     * @param string  $groupBy           GROUP BY expression. May name an alias
+     *                                   defined in $labelSelect.
      * @param bool    $includeFilterJoin Whether the user-preference filter JOIN
      *                                   is prepended. The keyword report must
      *                                   not include it: it already joins
      *                                   202_keywords under the same `2k` alias
      *                                   the filter join would introduce.
-     * @param bool    $usesRefererCount  Pagination count via the referer
-     *                                   domain-grouping subquery.
      */
     public function __construct(
         public readonly string $labelSelect,
         public readonly string $joins,
         public readonly string $groupBy,
-        public readonly ?string $countColumn,
         public readonly bool $includeFilterJoin = true,
-        public readonly bool $usesRefererCount = false,
     ) {
     }
 }

--- a/202-config/DataEngine/GroupedReportRegistry.php
+++ b/202-config/DataEngine/GroupedReportRegistry.php
@@ -24,79 +24,66 @@ final class GroupedReportRegistry
                 labelSelect: '`keyword`',
                 joins: ' LEFT JOIN 202_keywords as 2k on (2st.keyword_id= 2k.keyword_id) ',
                 groupBy: 'keyword',
-                countColumn: 'keyword_id',
                 includeFilterJoin: false,
             ),
             'textad' => new GroupedReportDefinition(
                 labelSelect: '`text_ad_name`',
                 joins: ' LEFT JOIN 202_text_ads on (2st.text_ad_id= 202_text_ads.text_ad_id) ',
                 groupBy: 'text_ad_name',
-                countColumn: 'text_ad_id',
             ),
             'referer' => new GroupedReportDefinition(
                 labelSelect: 'site_domain_host as referer_name',
                 joins: ' LEFT JOIN 202_site_urls on (2st.click_referer_site_url_id = 202_site_urls.site_url_id)'
                     . ' LEFT JOIN 202_site_domains on (202_site_domains.site_domain_id = 202_site_urls.site_domain_id) ',
                 groupBy: 'referer_name',
-                countColumn: null,
-                usesRefererCount: true,
             ),
             'ip' => new GroupedReportDefinition(
                 labelSelect: 'IFNULL(' . $inet6Ntoa . '(2i6.ip_address),2i.ip_address) as ip_address',
                 joins: ' LEFT JOIN 202_ips AS 2i on (2st.ip_id = 2i.ip_id)'
                     . ' LEFT JOIN 202_ips_v6 AS 2i6 ON (2i6.ip_id = 2i.ip_address COLLATE utf8mb4_general_ci) ',
                 groupBy: 'ip_address',
-                countColumn: 'ip_id',
             ),
             'country' => new GroupedReportDefinition(
                 labelSelect: 'country_name,country_code',
                 joins: ' LEFT JOIN 202_locations_country on (2st.country_id = 202_locations_country.country_id) ',
                 groupBy: 'country_name',
-                countColumn: 'country_id',
             ),
             'region' => new GroupedReportDefinition(
                 labelSelect: 'region_name,country_code',
                 joins: ' LEFT JOIN 202_locations_region on (2st.region_id = 202_locations_region.region_id)'
                     . ' LEFT JOIN 202_locations_country on (202_locations_region.main_country_id = 202_locations_country.country_id) ',
                 groupBy: 'region_name',
-                countColumn: 'region_id',
             ),
             'city' => new GroupedReportDefinition(
                 labelSelect: 'city_name,country_code',
                 joins: ' LEFT JOIN 202_locations_city on (2st.city_id = 202_locations_city.city_id)'
                     . ' LEFT JOIN 202_locations_country on (202_locations_city.main_country_id = 202_locations_country.country_id) ',
                 groupBy: 'city_name',
-                countColumn: 'city_id',
             ),
             'isp' => new GroupedReportDefinition(
                 labelSelect: 'isp_name',
                 joins: ' LEFT JOIN 202_locations_isp on (2st.isp_id = 202_locations_isp.isp_id) ',
                 groupBy: 'isp_name',
-                countColumn: 'isp_id',
             ),
             'landingpage' => new GroupedReportDefinition(
                 labelSelect: 'landing_page_nickname',
                 joins: ' LEFT JOIN 202_landing_pages on (2st.landing_page_id = 202_landing_pages.landing_page_id) ',
                 groupBy: 'landing_page_nickname',
-                countColumn: 'landing_page_id',
             ),
             'device' => new GroupedReportDefinition(
                 labelSelect: 'device_name',
                 joins: ' LEFT JOIN 202_device_models on (2st.device_id = 202_device_models.device_id) ',
                 groupBy: 'device_name',
-                countColumn: 'device_id',
             ),
             'browser' => new GroupedReportDefinition(
                 labelSelect: 'browser_name',
                 joins: ' LEFT JOIN 202_browsers on (2st.browser_id = 202_browsers.browser_id) ',
                 groupBy: 'browser_name',
-                countColumn: 'browser_id',
             ),
             'platform' => new GroupedReportDefinition(
                 labelSelect: 'platform_name',
                 joins: ' LEFT JOIN 202_platforms on (2st.platform_id = 202_platforms.platform_id) ',
                 groupBy: 'platform_name',
-                countColumn: 'platform_id',
             ),
             default => null,
         };

--- a/202-config/class-dataengine.php
+++ b/202-config/class-dataengine.php
@@ -119,53 +119,53 @@ class DataEngine
     }
 
     /**
-     * Count distinct values for pagination without SQL_CALC_FOUND_ROWS.
-     * Runs a simple COUNT(DISTINCT ...) on 202_dataengine — no lookup JOINs,
-     * no aggregates — so it can use covering indexes.
+     * The FROM/JOIN/WHERE shared by a grouped report and its pagination count.
      *
-     * COUNT(DISTINCT ...) ignores NULLs, but a NULL dimension renders as its
-     * own report group ("[no keyword]" etc.), so one is added back whenever
-     * any row has a NULL key — otherwise the last page was unreachable.
+     * Both queries must see exactly the same rows, so they build this fragment from
+     * the same place. Note $filters['join'] is conditional: the keyword report already
+     * owns the 2k alias that the keyword preference filter joins under, so including
+     * it there would be a duplicate-alias SQL error.
      *
-     * @param array{join?: string, filter?: string} $filters
+     * @param array{join: string, filter: string} $filters
      */
-    private function countGroups(string $fkColumn, string $from, string $to, array $filters): int
+    private function groupedReportFrom(GroupedReportDefinition $definition, string $from, string $to, array $filters): string
     {
-        if (!isset($filters['join'], $filters['filter'])) {
-            return 0;
-        }
-
-        $countSql = "SELECT COUNT(DISTINCT 2st." . $fkColumn . ") + IFNULL(MAX(2st." . $fkColumn . " IS NULL), 0) AS cnt FROM 202_dataengine AS 2st "
-            . $filters['join']
+        return ' FROM 202_dataengine as 2st '
+            . ($definition->includeFilterJoin ? $filters['join'] : '')
+            . $definition->joins
             . $this->mysql['user_id_query']
-            . " AND click_time >= " . $from
-            . " AND click_time <= " . $to
+            . ' AND click_time >= ' . $from
+            . ' AND click_time <= ' . $to
             . $filters['filter'];
-
-        return $this->runCountQuery($countSql);
     }
 
     /**
+     * Count the groups a grouped report produces, for pagination.
+     *
+     * This counts the report's own GROUP BY, over the report's own joins. The previous
+     * implementation counted DISTINCT foreign keys on 202_dataengine instead — a cheaper
+     * query, but a different one: reports group by the *joined name* (region_name,
+     * text_ad_name, …), not the id. Any two ids sharing a name, or several ids with no
+     * lookup row (which all collapse into a single NULL-name group), made the count
+     * exceed the number of rows actually returned. That inflated totalRows and could
+     * advertise a trailing page that renders empty. Counting the real grouping cannot
+     * disagree with the rows by construction.
+     *
      * @param array{join?: string, filter?: string} $filters
      */
-    private function countRefererGroups(string $from, string $to, array $filters): int
+    private function countReportGroups(GroupedReportDefinition $definition, string $from, string $to, array $filters): int
     {
         if (!isset($filters['join'], $filters['filter'])) {
             return 0;
         }
 
-        $countSql = "SELECT COUNT(*) AS cnt FROM (
-                SELECT 2sd.site_domain_host
-                FROM 202_dataengine AS 2st "
-            . $filters['join']
-            . " LEFT JOIN 202_site_urls AS 2su ON (2st.click_referer_site_url_id = 2su.site_url_id)
-                LEFT JOIN 202_site_domains AS 2sd ON (2sd.site_domain_id = 2su.site_domain_id)"
-            . $this->mysql['user_id_query']
-            . " AND click_time >= " . $from
-            . " AND click_time <= " . $to
-            . $filters['filter']
-            . " GROUP BY 2sd.site_domain_host
-            ) AS referer_groups";
+        // The inner SELECT is the report's labelSelect so that a groupBy naming a SELECT
+        // alias (the ip and referer reports) still resolves.
+        $countSql = 'SELECT COUNT(*) AS cnt FROM ('
+            . ' SELECT ' . $definition->labelSelect
+            . $this->groupedReportFrom($definition, $from, $to, $filters)
+            . ' GROUP BY ' . $definition->groupBy
+            . ') AS report_groups';
 
         return $this->runCountQuery($countSql);
     }
@@ -427,24 +427,14 @@ class DataEngine
         $filters = $this->getFilters();
 
         $sql = 'SELECT ' . $definition->labelSelect . ',' . MetricsSql::GROUPED_SELECT
-            . ' FROM 202_dataengine as 2st '
-            . ($definition->includeFilterJoin ? $filters['join'] : '')
-            . $definition->joins
-            . $this->mysql['user_id_query']
-            . ' AND click_time >= ' . $clickFrom
-            . ' AND click_time <= ' . $clickTo
-            . $filters['filter']
+            . $this->groupedReportFrom($definition, (string) $clickFrom, (string) $clickTo, $filters)
             . ' group by ' . $definition->groupBy
             . $this->sortOrder()
             . $filters['limit'];
 
         $data = $this->collectRows($sql, $cpv);
 
-        if ($definition->usesRefererCount) {
-            self::$found_rows = $this->countRefererGroups((string) $clickFrom, (string) $clickTo, $filters);
-        } elseif ($definition->countColumn !== null) {
-            self::$found_rows = $this->countGroups($definition->countColumn, (string) $clickFrom, (string) $clickTo, $filters);
-        }
+        self::$found_rows = $this->countReportGroups($definition, (string) $clickFrom, (string) $clickTo, $filters);
 
         return $data;
     }

--- a/202-config/connect.php
+++ b/202-config/connect.php
@@ -200,6 +200,81 @@ if (file_exists(ROOT_PATH  . '202-config.php')) {
     die();
 }
 include_once(ROOT_PATH  . '202-config.php');
+
+if (!defined('TRACKING202_JSON_ARCHITECTURE_ENABLED')) {
+    define('TRACKING202_JSON_ARCHITECTURE_ENABLED', false);
+}
+
+if (!defined('TRACKING202_STATIC_FILTER_SSR_MAX_OPTIONS')) {
+    define('TRACKING202_STATIC_FILTER_SSR_MAX_OPTIONS', 1500);
+}
+
+if (!defined('TRACKING202_STATIC_FILTER_SSR_MAX_BYTES')) {
+    define('TRACKING202_STATIC_FILTER_SSR_MAX_BYTES', 65536);
+}
+
+if (!function_exists('tracking202NormalizeBooleanFlag')) {
+    function tracking202NormalizeBooleanFlag(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (in_array($normalized, ['1', 'true', 'on', 'yes'], true)) {
+            return true;
+        }
+
+        if (in_array($normalized, ['0', 'false', 'off', 'no'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}
+
+if (!function_exists('tracking202JsonArchitectureEnabled')) {
+    function tracking202JsonArchitectureEnabled(): bool
+    {
+        $override = tracking202NormalizeBooleanFlag($_GET['tracking_json_mode'] ?? null);
+        if ($override !== null) {
+            return $override;
+        }
+
+        return (bool) TRACKING202_JSON_ARCHITECTURE_ENABLED;
+    }
+}
+
+if (!function_exists('tracking202StaticFilterSsrEnabled')) {
+    function tracking202StaticFilterSsrEnabled(): bool
+    {
+        // Deliberately ignores the ?tracking_json_mode override. Enabling static-filter
+        // SSR runs six extra GROUP BY queries (country/region/isp/device/browser/platform)
+        // on every display_calendar() page, and 202_locations_region and 202_locations_isp
+        // are large. A query-string parameter any logged-in user can set must not be able
+        // to turn that on, so this reads the deploy-time constant only.
+        return (bool) TRACKING202_JSON_ARCHITECTURE_ENABLED;
+    }
+}
+
+if (!function_exists('tracking202StaticFilterSsrMaxOptions')) {
+    function tracking202StaticFilterSsrMaxOptions(): int
+    {
+        return (int) TRACKING202_STATIC_FILTER_SSR_MAX_OPTIONS;
+    }
+}
+
+if (!function_exists('tracking202StaticFilterSsrMaxBytes')) {
+    function tracking202StaticFilterSsrMaxBytes(): int
+    {
+        return (int) TRACKING202_STATIC_FILTER_SSR_MAX_BYTES;
+    }
+}
+
 // Composer dependencies provide the PSR-4 classes used by tracking, install,
 // and the API. A missing vendor/ almost always means the app was deployed from
 // a raw git clone without running `composer install`. Fail loudly with guidance

--- a/202-config/functions-tracking202.php
+++ b/202-config/functions-tracking202.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tracking202\Data\StaticFilterOptionsProvider;
 use UAParser\Parser;
 
 // This function will return true, if a user is logged in correctly, and false, if they are not.
@@ -133,6 +134,7 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
     $show_filters = $options['show_filters'] ?? false;
     $show_avg_cpc = $options['show_avg_cpc'] ?? false;
     $skip_publisher_check = $options['skip_publisher_check'] ?? false;
+    $json_bootstrap_dependent_filters = $options['json_bootstrap_dependent_filters'] ?? false;
     $hide_publisher_sections = !$skip_publisher_check && !empty($_SESSION['publisher']);
 
     $userId = (int) ($_SESSION['user_id'] ?? 0);
@@ -185,6 +187,26 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
     $html['user_pref_device_id'] = htmlentities((string) ($user_row['user_pref_device_id'] ?? ''), ENT_QUOTES, 'UTF-8');
     $html['user_pref_browser_id'] = htmlentities((string) ($user_row['user_pref_browser_id'] ?? ''), ENT_QUOTES, 'UTF-8');
     $html['user_pref_platform_id'] = htmlentities((string) ($user_row['user_pref_platform_id'] ?? ''), ENT_QUOTES, 'UTF-8');
+
+    $ssr_static_filters = [
+        'country' => ['enabled' => false, 'option_count' => 0, 'estimated_bytes' => 0, 'options_html' => ''],
+        'region' => ['enabled' => false, 'option_count' => 0, 'estimated_bytes' => 0, 'options_html' => ''],
+        'isp' => ['enabled' => false, 'option_count' => 0, 'estimated_bytes' => 0, 'options_html' => ''],
+        'device' => ['enabled' => false, 'option_count' => 0, 'estimated_bytes' => 0, 'options_html' => ''],
+        'browser' => ['enabled' => false, 'option_count' => 0, 'estimated_bytes' => 0, 'options_html' => ''],
+        'platform' => ['enabled' => false, 'option_count' => 0, 'estimated_bytes' => 0, 'options_html' => ''],
+    ];
+
+    if ($show_adv && tracking202StaticFilterSsrEnabled()) {
+        $ssr_static_filters = StaticFilterOptionsProvider::build([
+            'country' => $html['user_pref_country_id'],
+            'region' => $html['user_pref_region_id'],
+            'isp' => $html['user_pref_isp_id'],
+            'device' => $html['user_pref_device_id'],
+            'browser' => $html['user_pref_browser_id'],
+            'platform' => $html['user_pref_platform_id'],
+        ]);
+    }
 
     // --- SSR: Pre-render small/bounded filter dropdowns to eliminate AJAX round-trips ---
     // PPC Networks (user-scoped, bounded)
@@ -432,12 +454,13 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
                                                     <label>Device type: </label>
                                                     <div class="form-group">
                                                         <img id="device_id_div_loading" class="loading"
-                                                            style="right: 0px; left: 5px;"
+                                                            style="<?php if ($ssr_static_filters['device']['enabled']) { echo 'display: none; '; } ?>right: 0px; left: 5px;"
                                                             src="<?php echo get_absolute_url(); ?>202-img/loader-small.gif" />
                                                         <div id="device_id_div" style="top: -12px; font-size: 10px;">
                                                             <select class="form-control input-sm" name="device_id"
                                                                 id="device_id">
-                                                                <option value="0">--</option>
+                                                                <option value="0" <?php if ($html['user_pref_device_id'] === '' || $html['user_pref_device_id'] === '0') echo 'selected=""'; ?>>--</option>
+                                                                <?php echo $ssr_static_filters['device']['options_html']; ?>
                                                             </select>
                                                         </div>
                                                     </div>
@@ -447,13 +470,14 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
                                                     <label>Country: </label>
                                                     <div class="form-group">
                                                         <img id="country_id_div_loading" class="loading"
-                                                            style="right: 0px; left: 5px;"
+                                                            style="<?php if ($ssr_static_filters['country']['enabled']) { echo 'display: none; '; } ?>right: 0px; left: 5px;"
                                                             src="<?php echo get_absolute_url(); ?>202-img/loader-small.gif" />
                                                         <div id="country_id_div"
                                                             style="top: -12px; font-size: 10px;">
                                                             <select class="form-control input-sm" name="country_id"
                                                                 id="country_id">
-                                                                <option value="0">--</option>
+                                                                <option value="0" <?php if ($html['user_pref_country_id'] === '' || $html['user_pref_country_id'] === '0') echo 'selected=""'; ?>>--</option>
+                                                                <?php echo $ssr_static_filters['country']['options_html']; ?>
                                                             </select>
                                                         </div>
                                                     </div>
@@ -483,13 +507,14 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
                                                     <label>Browser: </label>
                                                     <div class="form-group">
                                                         <img id="browser_id_div_loading" class="loading"
-                                                            style="right: 0px; left: 5px;"
+                                                            style="<?php if ($ssr_static_filters['browser']['enabled']) { echo 'display: none; '; } ?>right: 0px; left: 5px;"
                                                             src="<?php echo get_absolute_url(); ?>202-img/loader-small.gif" />
                                                         <div id="browser_id_div"
                                                             style="top: -12px; font-size: 10px;">
                                                             <select class="form-control input-sm" name="browser_id"
                                                                 id="browser_id">
-                                                                <option value="0">--</option>
+                                                                <option value="0" <?php if ($html['user_pref_browser_id'] === '' || $html['user_pref_browser_id'] === '0') echo 'selected=""'; ?>>--</option>
+                                                                <?php echo $ssr_static_filters['browser']['options_html']; ?>
                                                             </select>
                                                         </div>
                                                     </div>
@@ -498,12 +523,13 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
                                                     <label>Region: </label>
                                                     <div class="form-group">
                                                         <img id="region_id_div_loading" class="loading"
-                                                            style="right: 0px; left: 5px;"
+                                                            style="<?php if ($ssr_static_filters['region']['enabled']) { echo 'display: none; '; } ?>right: 0px; left: 5px;"
                                                             src="<?php echo get_absolute_url(); ?>202-img/loader-small.gif" />
                                                         <div id="region_id_div" style="top: -12px; font-size: 10px;">
                                                             <select class="form-control input-sm" name="region_id"
                                                                 id="region_id">
-                                                                <option value="0">--</option>
+                                                                <option value="0" <?php if ($html['user_pref_region_id'] === '' || $html['user_pref_region_id'] === '0') echo 'selected=""'; ?>>--</option>
+                                                                <?php echo $ssr_static_filters['region']['options_html']; ?>
                                                             </select>
                                                         </div>
                                                     </div>
@@ -530,13 +556,14 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
                                                     <label>Platforms: </label>
                                                     <div class="form-group">
                                                         <img id="platform_id_div_loading" class="loading"
-                                                            style="right: 0px; left: 5px;"
+                                                            style="<?php if ($ssr_static_filters['platform']['enabled']) { echo 'display: none; '; } ?>right: 0px; left: 5px;"
                                                             src="<?php echo get_absolute_url(); ?>202-img/loader-small.gif" />
                                                         <div id="platform_id_div"
                                                             style="top: -12px; font-size: 10px;">
                                                             <select class="form-control input-sm" name="platform_id"
                                                                 id="platform_id">
-                                                                <option value="0">--</option>
+                                                                <option value="0" <?php if ($html['user_pref_platform_id'] === '' || $html['user_pref_platform_id'] === '0') echo 'selected=""'; ?>>--</option>
+                                                                <?php echo $ssr_static_filters['platform']['options_html']; ?>
                                                             </select>
                                                         </div>
                                                     </div>
@@ -545,12 +572,13 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
                                                     <label>ISP/Carrier: </label>
                                                     <div class="form-group">
                                                         <img id="isp_id_div_loading" class="loading"
-                                                            style="right: 0px; left: 5px;"
+                                                            style="<?php if ($ssr_static_filters['isp']['enabled']) { echo 'display: none; '; } ?>right: 0px; left: 5px;"
                                                             src="<?php echo get_absolute_url(); ?>202-img/loader-small.gif" />
                                                         <div id="isp_id_div" style="top: -12px; font-size: 10px;">
                                                             <select class="form-control input-sm" name="isp_id"
                                                                 id="isp_id">
-                                                                <option value="0">--</option>
+                                                                <option value="0" <?php if ($html['user_pref_isp_id'] === '' || $html['user_pref_isp_id'] === '0') echo 'selected=""'; ?>>--</option>
+                                                                <?php echo $ssr_static_filters['isp']['options_html']; ?>
                                                             </select>
                                                         </div>
                                                     </div>
@@ -1005,31 +1033,35 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
         $("#aff_network_id").select2();
         $("#method_of_promotion").select2();
 
-        // Cascading filters: still load via AJAX when user has saved preferences
+        // Cascading filters: still load via AJAX when user has saved preferences.
+        // PPC account stays on the legacy AJAX path — it is not part of the JSON payload.
         <?php if ($html['user_pref_ppc_account_id'] != '') { ?>
             load_ppc_account_id('<?php echo $html['user_pref_ppc_network_id']; ?>', '<?php echo $html['user_pref_ppc_account_id']; ?>');
         <?php } ?>
 
-        <?php if ($html['user_pref_aff_campaign_id'] != '') { ?>
-            load_aff_campaign_id('<?php echo $html['user_pref_aff_network_id']; ?>', '<?php echo $html['user_pref_aff_campaign_id']; ?>');
-        <?php } ?>
+        <?php if (!$json_bootstrap_dependent_filters) { ?>
+            <?php if ($html['user_pref_aff_campaign_id'] != '') { ?>
+                load_aff_campaign_id('<?php echo $html['user_pref_aff_network_id']; ?>', '<?php echo $html['user_pref_aff_campaign_id']; ?>');
+            <?php } ?>
 
-        <?php if ($html['user_pref_text_ad_id'] != '') { ?>
-            load_text_ad_id('<?php echo $html['user_pref_aff_campaign_id']; ?>', '<?php echo $html['user_pref_text_ad_id']; ?>');
-            load_ad_preview('<?php echo $html['user_pref_text_ad_id']; ?>');
-        <?php } ?>
+            <?php if ($html['user_pref_text_ad_id'] != '') { ?>
+                load_text_ad_id('<?php echo $html['user_pref_aff_campaign_id']; ?>', '<?php echo $html['user_pref_text_ad_id']; ?>');
+                load_ad_preview('<?php echo $html['user_pref_text_ad_id']; ?>');
+            <?php } ?>
 
-        <?php if ($html['user_pref_landing_page_id'] != '') { ?>
-            load_landing_page('<?php echo $html['user_pref_aff_campaign_id']; ?>', '<?php echo $html['user_pref_landing_page_id']; ?>', '<?php echo $html['user_pref_method_of_promotion']; ?>s');
+            <?php if ($html['user_pref_landing_page_id'] != '') { ?>
+                load_landing_page('<?php echo $html['user_pref_aff_campaign_id']; ?>', '<?php echo $html['user_pref_landing_page_id']; ?>', '<?php echo $html['user_pref_method_of_promotion']; ?>s');
+            <?php } ?>
         <?php } ?>
 
         <?php if ($show_adv != false) { ?>
-            load_country_id('<?php echo $html['user_pref_country_id']; ?>');
-            load_region_id('<?php echo $html['user_pref_region_id']; ?>');
-            load_isp_id('<?php echo $html['user_pref_isp_id']; ?>');
-            load_device_id('<?php echo $html['user_pref_device_id']; ?>');
-            load_browser_id('<?php echo $html['user_pref_browser_id']; ?>');
-            load_platform_id('<?php echo $html['user_pref_platform_id']; ?>');
+            <?php foreach (['country', 'region', 'isp', 'device', 'browser', 'platform'] as $ssr_filter_key) { ?>
+                <?php if ($ssr_static_filters[$ssr_filter_key]['enabled']) { ?>
+                    $("#<?php echo $ssr_filter_key; ?>_id").select2();
+                <?php } else { ?>
+                    load_<?php echo $ssr_filter_key; ?>_id('<?php echo $html['user_pref_' . $ssr_filter_key . '_id']; ?>');
+                <?php } ?>
+            <?php } ?>
         <?php } ?>
     </script>
 <?php
@@ -1037,6 +1069,93 @@ function display_calendar($page, $show_time, $show_adv, $show_bottom, $show_limi
 }
 
 function display_calendar2(...$args) { return display_calendar(...$args); }
+
+/**
+ * Build the client-side config for the JSON report transport.
+ *
+ * $reportType must be one of ReportDispatchRequest::SUPPORTED_REPORT_TYPES. When the
+ * JSON architecture flag is off, 'enabled' is false and 202-js/tracking-report.js hands
+ * control straight back to the legacy loadContent() path.
+ *
+ * @return array<string, mixed>
+ */
+function tracking202_report_canary_config(string $reportType, string $legacyPageUrl): array
+{
+    $database = DB::getInstance();
+    $db = $database->getConnection();
+
+    $enabled = tracking202JsonArchitectureEnabled();
+
+    $dispatchUrl = get_absolute_url() . 'tracking202/ajax/report_dispatch.php';
+    $override = tracking202NormalizeBooleanFlag($_GET['tracking_json_mode'] ?? null);
+    if ($override !== null) {
+        $dispatchUrl .= '?tracking_json_mode=' . ($override ? '1' : '0');
+    }
+
+    $userId = $db->real_escape_string((string) ($_SESSION['user_id'] ?? 0));
+    $sql = "SELECT
+                user_pref_aff_network_id,
+                user_pref_aff_campaign_id,
+                user_pref_text_ad_id,
+                user_pref_method_of_promotion,
+                user_pref_landing_page_id
+            FROM 202_users_pref
+            WHERE user_id='" . $userId . "'";
+    $result = _mysqli_query($sql);
+    if (!$result instanceof mysqli_result) {
+        // Fail loudly: a swallowed prefs read would hand the client an empty dependent-filter
+        // bootstrap, silently dropping the user's saved campaign/text-ad/landing-page filters.
+        record_mysql_error($sql);
+    }
+    $prefs = $result->fetch_assoc() ?? [];
+
+    return [
+        'enabled' => $enabled,
+        'reportType' => $reportType,
+        'legacyPageUrl' => $legacyPageUrl,
+        'dispatchUrl' => $dispatchUrl,
+        'loaderUrl' => get_absolute_url() . '202-img/loader-small.gif',
+        'excelIconUrl' => get_absolute_url() . '202-img/icons/16x16/page_white_excel.png',
+        'dependentFilters' => [
+            'jsonBootstrap' => $enabled && empty($_SESSION['publisher']),
+            'publisherHidden' => !empty($_SESSION['publisher']),
+            'affNetworkId' => (string) ($prefs['user_pref_aff_network_id'] ?? ''),
+            'affCampaignId' => (string) ($prefs['user_pref_aff_campaign_id'] ?? ''),
+            'textAdId' => (string) ($prefs['user_pref_text_ad_id'] ?? ''),
+            'landingPageId' => (string) ($prefs['user_pref_landing_page_id'] ?? ''),
+            'methodOfPromotion' => (string) ($prefs['user_pref_method_of_promotion'] ?? ''),
+        ],
+    ];
+}
+
+/**
+ * Emit the JSON transport bootstrap for a report page.
+ *
+ * @param array<string, mixed> $config
+ */
+function tracking202_render_report_canary(array $config): void
+{
+    // JSON_HEX_* stops a stray "</script>" in any value from escaping the inline script
+    // context. JSON_THROW_ON_ERROR because an unchecked encode failure would emit
+    // "window.… = ;" — a syntax error that would kill the whole inline block.
+    try {
+        $json = json_encode(
+            $config,
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+        );
+    } catch (JsonException $e) {
+        // Emit nothing: the page keeps the legacy transport, which renders the same data.
+        error_log('tracking202 report canary config encoding failed: ' . $e->getMessage());
+        return;
+    }
+    ?>
+    <script type="text/javascript">
+        window.tracking202ReportCanaryConfig = <?php echo $json; ?>;
+    </script>
+    <script type="text/javascript" src="<?php echo get_absolute_url(); ?>202-js/tracking-report.js"></script>
+    <?php
+}
 
 function grab_timeframe($unused = null): array
 {

--- a/202-js/tracking-report.js
+++ b/202-js/tracking-report.js
@@ -1,0 +1,475 @@
+(function (window, document, $) {
+    'use strict';
+
+    var config = window.tracking202ReportCanaryConfig || null;
+    if (!config || typeof window.loadContent !== 'function') {
+        return;
+    }
+
+    var legacyLoadContent = window.loadContent;
+    var state = {
+        legacyMode: !config.enabled,
+        firstLoadPending: true,
+    };
+
+    function normalizePath(url) {
+        if (!url) {
+            return '';
+        }
+
+        var anchor = document.createElement('a');
+        anchor.href = url;
+
+        return (anchor.pathname || '').replace(/\/+$/, '');
+    }
+
+    function matchesLegacyPage(page) {
+        var candidate = page || config.legacyPageUrl;
+
+        return normalizePath(candidate) === normalizePath(config.legacyPageUrl);
+    }
+
+    function escapeHtml(value) {
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function decodeHtmlEntities(value) {
+        var textarea = document.createElement('textarea');
+        textarea.innerHTML = String(value || '');
+
+        return textarea.value;
+    }
+
+    function safeTone(value) {
+        switch (value) {
+            case 'primary':
+            case 'important':
+            case 'info':
+            case 'default':
+                return value;
+            default:
+                return 'default';
+        }
+    }
+
+    function normalizeOffset(offset) {
+        if (offset === null || offset === undefined || offset === '') {
+            return 0;
+        }
+
+        var numericOffset = parseInt(offset, 10);
+        if (isNaN(numericOffset) || numericOffset < 0) {
+            return 0;
+        }
+
+        return numericOffset;
+    }
+
+    function normalizeOrder(order) {
+        if (typeof order !== 'string') {
+            return '';
+        }
+
+        return order;
+    }
+
+    function showLoading() {
+        $('#m-content').html(
+            '<div class="loading-stats">' +
+                '<span class="infotext">Loading stats...</span> ' +
+                '<img src="' + escapeHtml(config.loaderUrl) + '">' +
+            '</div>'
+        );
+    }
+
+    function initializeSelect2(selector) {
+        if (!$ || !$.fn || typeof $.fn.select2 !== 'function') {
+            return;
+        }
+
+        var element = $(selector);
+        if (element.length === 0) {
+            return;
+        }
+
+        element.select2();
+    }
+
+    function renderFragment(targetId, html) {
+        if (!targetId) {
+            return;
+        }
+
+        $('#' + targetId).html(html || '');
+    }
+
+    function normalizedDependentFilterConfig() {
+        var dependentFilters = config.dependentFilters || {};
+        var methodOfPromotion = dependentFilters.methodOfPromotion || '';
+
+        if (methodOfPromotion === 'landingpage') {
+            methodOfPromotion = 'landingpages';
+        }
+
+        return {
+            jsonBootstrap: !!dependentFilters.jsonBootstrap,
+            publisherHidden: !!dependentFilters.publisherHidden,
+            affNetworkId: dependentFilters.affNetworkId || '',
+            affCampaignId: dependentFilters.affCampaignId || '',
+            textAdId: dependentFilters.textAdId || '',
+            landingPageId: dependentFilters.landingPageId || '',
+            methodOfPromotion: methodOfPromotion
+        };
+    }
+
+    function bootstrapLegacyDependentFilters() {
+        var dependentFilters = normalizedDependentFilterConfig();
+
+        if (!dependentFilters.jsonBootstrap || dependentFilters.publisherHidden) {
+            return;
+        }
+
+        if (dependentFilters.affCampaignId && typeof window.load_aff_campaign_id === 'function') {
+            window.load_aff_campaign_id(dependentFilters.affNetworkId, dependentFilters.affCampaignId);
+        }
+
+        if (dependentFilters.textAdId && typeof window.load_text_ad_id === 'function') {
+            window.load_text_ad_id(dependentFilters.affCampaignId, dependentFilters.textAdId);
+        }
+
+        if (dependentFilters.textAdId && typeof window.load_ad_preview === 'function') {
+            window.load_ad_preview(dependentFilters.textAdId);
+        }
+
+        if (
+            dependentFilters.landingPageId &&
+            dependentFilters.methodOfPromotion &&
+            typeof window.load_landing_page === 'function'
+        ) {
+            window.load_landing_page(
+                dependentFilters.affCampaignId,
+                dependentFilters.landingPageId,
+                dependentFilters.methodOfPromotion
+            );
+        }
+    }
+
+    function applyDependentFilters(dependentFilters) {
+        if (!dependentFilters || !dependentFilters.requested) {
+            return;
+        }
+
+        if (!dependentFilters.included) {
+            bootstrapLegacyDependentFilters();
+            return;
+        }
+
+        var fragments = dependentFilters.fragments || {};
+
+        if (fragments.affCampaign) {
+            renderFragment(fragments.affCampaign.targetId, fragments.affCampaign.html);
+            initializeSelect2('#aff_campaign_id');
+        }
+
+        if (fragments.textAd) {
+            renderFragment(fragments.textAd.targetId, fragments.textAd.html);
+            initializeSelect2('#text_ad_id');
+        }
+
+        if (fragments.landingPage) {
+            renderFragment(fragments.landingPage.targetId, fragments.landingPage.html);
+            initializeSelect2('#landing_page_id');
+        }
+
+        if (fragments.adPreview) {
+            renderFragment(fragments.adPreview.targetId, fragments.adPreview.html);
+        }
+    }
+
+    function enablePermanentLegacyMode(reason) {
+        if (window.console && typeof window.console.warn === 'function') {
+            window.console.warn('Tracking JSON canary falling back to legacy mode:', reason);
+        }
+
+        state.legacyMode = true;
+    }
+
+    function renderMetricCell(columnId, cell) {
+        var display = decodeHtmlEntities(cell && cell.display ? cell.display : '');
+        var escapedDisplay = escapeHtml(display);
+        var tone = safeTone(cell && cell.tone ? cell.tone : 'default');
+
+        if (columnId === 'income' || columnId === 'cost' || columnId === 'net' || columnId === 'roi') {
+            return '<span class="label label-' + tone + '">' + escapedDisplay + '</span>';
+        }
+
+        return escapedDisplay;
+    }
+
+    function renderFeatureCell(feature) {
+        var text = decodeHtmlEntities(feature && feature.text ? feature.text : '');
+        var title = decodeHtmlEntities(feature && feature.title ? feature.title : text);
+        var variant = feature && feature.variant ? feature.variant : 'plain_text';
+        var maxWidthPx = feature && feature.maxWidthPx ? parseInt(feature.maxWidthPx, 10) : 250;
+        var flagUrl = feature && feature.flagUrl ? feature.flagUrl : '';
+
+        if (variant === 'truncated_text') {
+            return '<div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap; width: ' +
+                maxWidthPx +
+                'px;" title="' + escapeHtml(title) + '">' + escapeHtml(text) + '</div>';
+        }
+
+        if (variant === 'flagged_location') {
+            return '<img src="' + escapeHtml(flagUrl) + '"> ' + escapeHtml(text);
+        }
+
+        return escapeHtml(text);
+    }
+
+    function renderPagination(report) {
+        var pagination = report && report.pagination ? report.pagination : null;
+        if (!pagination || !pagination.serverPaginated) {
+            return '';
+        }
+        // Single-page reports need no pager, but keep it when the requested offset is past
+        // the end: the table is empty and the "prev" link is the only way back to real data.
+        if (pagination.pageCount <= 1 && !pagination.outOfRange) {
+            return '';
+        }
+
+        var parts = [
+            '<div class="row">',
+            '<div class="col-xs-12 text-center">',
+            '<div class="pagination" id="table-pages">',
+            '<ul>'
+        ];
+
+        var previousOffset = pagination.hasPreviousPage ? pagination.previousOffset : pagination.currentOffset;
+        parts.push(
+            '<li class="previous"><a href="#" data-tracking-report-page-link="1" data-offset="' +
+                escapeHtml(previousOffset) +
+                '" data-order="' +
+                escapeHtml(pagination.orderToken || '') +
+                '"><span class="fui-arrow-left"></span></a></li>'
+        );
+
+        var start = Math.max(pagination.currentOffset - 10, 0);
+        var end = Math.min(pagination.currentOffset + 10, pagination.pageCount - 1);
+        for (var i = start; i <= end; i++) {
+            var activeClass = i === pagination.currentOffset ? ' class="active"' : '';
+            parts.push(
+                '<li' + activeClass + '><a href="#" data-tracking-report-page-link="1" data-offset="' +
+                    escapeHtml(i) +
+                    '" data-order="' +
+                    escapeHtml(pagination.orderToken || '') +
+                    '">' +
+                    escapeHtml(i + 1) +
+                    '</a></li>'
+            );
+        }
+
+        var nextOffset = pagination.hasNextPage ? pagination.nextOffset : pagination.currentOffset;
+        parts.push(
+            '<li class="next"><a href="#" data-tracking-report-page-link="1" data-offset="' +
+                escapeHtml(nextOffset) +
+                '" data-order="' +
+                escapeHtml(pagination.orderToken || '') +
+                '"><span class="fui-arrow-right"></span></a></li>'
+        );
+
+        parts.push('</ul></div></div></div>');
+
+        return parts.join('');
+    }
+
+    function renderReport(report) {
+        var parts = [];
+
+        if (report.download && report.download.url) {
+            parts.push(
+                '<div class="row">' +
+                    '<div class="col-xs-12 text-right" style="padding-bottom: 10px;">' +
+                        '<img style="margin-bottom:2px;" src="' + escapeHtml(config.excelIconUrl) + '"/>' +
+                        '<a style="font-size:12px;" target="_new" href="' + escapeHtml(report.download.url) + '">' +
+                            '<strong>' + escapeHtml(report.download.label || 'Download to excel') + '</strong>' +
+                        '</a>' +
+                    '</div>' +
+                '</div>'
+            );
+        }
+
+        parts.push('<table class="table table-bordered table-hover" id="stats-table">');
+        parts.push('<thead><tr style="background-color: #f2fbfa;">');
+
+        for (var i = 0; i < report.columns.length; i++) {
+            var column = report.columns[i];
+            if (column.id === 'feature') {
+                parts.push(
+                    '<th colspan="' + escapeHtml(column.colspan || 1) + '" style="text-align:left">' +
+                        escapeHtml(column.label) +
+                    '</th>'
+                );
+            } else {
+                parts.push('<th>' + escapeHtml(column.label) + '</th>');
+            }
+        }
+
+        parts.push('</tr></thead><tbody>');
+
+        for (var rowIndex = 0; rowIndex < report.rows.length; rowIndex++) {
+            var row = report.rows[rowIndex];
+            parts.push('<tr>');
+            parts.push('<td colspan="4" style="text-align:left; padding-left:10px">' + renderFeatureCell(row.feature) + '</td>');
+
+            parts.push('<td>' + renderMetricCell('clicks', row.metrics.clicks) + '</td>');
+            parts.push('<td>' + renderMetricCell('clickOut', row.metrics.clickOut) + '</td>');
+            parts.push('<td>' + renderMetricCell('ctr', row.metrics.ctr) + '</td>');
+            parts.push('<td>' + renderMetricCell('leads', row.metrics.leads) + '</td>');
+            parts.push('<td>' + renderMetricCell('avgSu', row.metrics.avgSu) + '</td>');
+            parts.push('<td>' + renderMetricCell('avgPayout', row.metrics.avgPayout) + '</td>');
+            parts.push('<td>' + renderMetricCell('avgEpc', row.metrics.avgEpc) + '</td>');
+            parts.push('<td>' + renderMetricCell('avgCpc', row.metrics.avgCpc) + '</td>');
+            parts.push('<td>' + renderMetricCell('income', row.metrics.income) + '</td>');
+            parts.push('<td>' + renderMetricCell('cost', row.metrics.cost) + '</td>');
+            parts.push('<td>' + renderMetricCell('net', row.metrics.net) + '</td>');
+            parts.push('<td>' + renderMetricCell('roi', row.metrics.roi) + '</td>');
+            parts.push('</tr>');
+        }
+
+        var totals = report.totals;
+        parts.push('<tr style="background-color: #F8F8F8;" id="totals" class="no-sort">');
+        parts.push('<td colspan="4" style="text-align:left; padding-left:10px;"><strong>' + renderFeatureCell(totals.feature) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('clicks', totals.metrics.clicks) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('clickOut', totals.metrics.clickOut) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('ctr', totals.metrics.ctr) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('leads', totals.metrics.leads) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('avgSu', totals.metrics.avgSu) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('avgPayout', totals.metrics.avgPayout) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('avgEpc', totals.metrics.avgEpc) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('avgCpc', totals.metrics.avgCpc) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('income', totals.metrics.income) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('cost', totals.metrics.cost) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('net', totals.metrics.net) + '</strong></td>');
+        parts.push('<td><strong>' + renderMetricCell('roi', totals.metrics.roi) + '</strong></td>');
+        parts.push('</tr></tbody></table>');
+
+        parts.push(renderPagination(report));
+
+        return parts.join('');
+    }
+
+    function initializeTablesort() {
+        if (typeof window.Tablesort !== 'function') {
+            return;
+        }
+
+        var table = document.getElementById('stats-table');
+        if (!table) {
+            return;
+        }
+
+        new window.Tablesort(table, {
+            descending: true
+        });
+    }
+
+    function fetchAndRender(page, offset, order) {
+        var requestBody = {
+            reportType: config.reportType,
+            offset: normalizeOffset(offset),
+            order: normalizeOrder(order),
+            includeDependentFilters: state.firstLoadPending
+        };
+
+        state.firstLoadPending = false;
+        showLoading();
+
+        return window.fetch(config.dispatchUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(requestBody)
+        })
+            .then(function (response) {
+                return response.text().then(function (text) {
+                    return {
+                        ok: response.ok,
+                        status: response.status,
+                        text: text
+                    };
+                });
+            })
+            .then(function (response) {
+                var payload;
+
+                try {
+                    payload = JSON.parse(response.text);
+                } catch (error) {
+                    throw new Error('Dispatch response was not valid JSON.');
+                }
+
+                if (!response.ok || !payload.ok || !payload.report) {
+                    var message = payload && payload.error && payload.error.message
+                        ? payload.error.message
+                        : 'Dispatch request failed with status ' + response.status + '.';
+                    throw new Error(message);
+                }
+
+                $('#m-content').html(renderReport(payload.report));
+                $('#m-content').css('opacity', '1');
+                initializeTablesort();
+                applyDependentFilters(payload.report.dependentFilters || null);
+
+                return payload;
+            })
+            .catch(function (error) {
+                enablePermanentLegacyMode(error && error.message ? error.message : 'unknown transport failure');
+                bootstrapLegacyDependentFilters();
+                return legacyLoadContent(page, offset, order);
+            });
+    }
+
+    function interceptedLoadContent(page, offset, order) {
+        if (state.legacyMode || !config.enabled || !matchesLegacyPage(page) || typeof window.fetch !== 'function') {
+            return legacyLoadContent(page, offset, order);
+        }
+
+        return fetchAndRender(page, offset, order);
+    }
+
+    $('#m-content').on('click', '[data-tracking-report-page-link]', function (event) {
+        if (state.legacyMode || !config.enabled) {
+            return;
+        }
+
+        event.preventDefault();
+
+        var offset = $(this).data('offset');
+        var order = $(this).data('order') || '';
+        fetchAndRender(config.legacyPageUrl, offset, order);
+    });
+
+    window.loadContent = interceptedLoadContent;
+    window.Tracking202ReportCanary = {
+        isEnabled: function () {
+            return config.enabled && !state.legacyMode;
+        },
+        load: function (options) {
+            var requestOptions = options || {};
+
+            return fetchAndRender(
+                config.legacyPageUrl,
+                requestOptions.offset,
+                requestOptions.order || ''
+            );
+        }
+    };
+}(window, document, window.jQuery));

--- a/202-js/tracking-report.js
+++ b/202-js/tracking-report.js
@@ -439,6 +439,20 @@
 
     function interceptedLoadContent(page, offset, order) {
         if (state.legacyMode || !config.enabled || !matchesLegacyPage(page) || typeof window.fetch !== 'function') {
+            // We're taking the legacy transport. When JSON mode was on at render time,
+            // display_calendar() suppressed the legacy aff-campaign/text-ad/landing-page
+            // bootstrap on the expectation that the JSON response would supply those
+            // fragments — but on this path (most importantly when window.fetch is missing,
+            // e.g. an older embedded webview) that response is never fetched, so the saved
+            // dependent filters and ad preview would render blank. Hydrate them once here,
+            // the same way fetchAndRender()'s failure path does. Gated on firstLoadPending
+            // so legacy pagination cannot re-run the cascade, and the helper itself is a
+            // no-op unless jsonBootstrap applies, so the flag-off/publisher paths are safe.
+            if (state.firstLoadPending) {
+                state.firstLoadPending = false;
+                bootstrapLegacyDependentFilters();
+            }
+
             return legacyLoadContent(page, offset, order);
         }
 

--- a/tests/DataEngine/GroupedReportRegistryTest.php
+++ b/tests/DataEngine/GroupedReportRegistryTest.php
@@ -30,13 +30,26 @@ final class GroupedReportRegistryTest extends TestCase
         self::assertNull(GroupedReportRegistry::definition('nope'));
     }
 
-    public function testEveryReportHasAPaginationCountStrategy(): void
+    /**
+     * Pagination counts the report's own GROUP BY (DataEngine::countReportGroups), so a
+     * definition needs nothing extra to be countable — but the groupBy must be resolvable
+     * in that count's inner SELECT, which selects labelSelect and nothing else. A groupBy
+     * naming an alias is fine only if labelSelect actually defines that alias.
+     */
+    public function testEveryGroupByIsResolvableFromItsLabelSelect(): void
     {
         foreach (self::GROUPED_TYPES as $type) {
-            $definition = GroupedReportRegistry::definition($type);
+            $definition = GroupedReportRegistry::definition($type, 'inet6_ntoa');
+            $groupBy = $definition->groupBy;
+            $labelSelect = $definition->labelSelect;
+
+            $resolvable = str_contains($labelSelect, $groupBy)
+                || str_contains($labelSelect, '`' . $groupBy . '`');
+
             self::assertTrue(
-                $definition->countColumn !== null || $definition->usesRefererCount,
-                "Report $type must define a pagination count strategy"
+                $resolvable,
+                "Report $type groups by '$groupBy', which its labelSelect '$labelSelect' does not "
+                . 'provide — the pagination count would fail with an unknown column.'
             );
         }
     }
@@ -58,11 +71,11 @@ final class GroupedReportRegistryTest extends TestCase
         }
     }
 
-    public function testRefererReportUsesDomainGroupingCount(): void
+    public function testRefererReportGroupsByItsDomainAlias(): void
     {
         $referer = GroupedReportRegistry::definition('referer');
-        self::assertTrue($referer->usesRefererCount);
-        self::assertNull($referer->countColumn);
+        self::assertSame('referer_name', $referer->groupBy);
+        self::assertStringContainsString('site_domain_host as referer_name', $referer->labelSelect);
     }
 
     public function testIpReportEmbedsIpv6DecodeFunction(): void
@@ -74,27 +87,34 @@ final class GroupedReportRegistryTest extends TestCase
         self::assertStringContainsString('IFNULL((2i6.ip_address),2i.ip_address)', $withoutUdf->labelSelect);
     }
 
-    public function testCountColumnsAreDataengineForeignKeys(): void
+    /**
+     * Regression guard. Reports group by the joined *name*, so pagination must count that
+     * grouping. Counting DISTINCT foreign keys on 202_dataengine instead — which is what
+     * the removed $countColumn described — counts a different thing: two ids sharing a
+     * name, or several ids with no lookup row (all of which collapse into one NULL-name
+     * group), make the count exceed the rows the report returns.
+     */
+    public function testReportsGroupByTheJoinedNameNotTheForeignKey(): void
     {
         $expected = [
-            'keyword' => 'keyword_id',
-            'textad' => 'text_ad_id',
-            'ip' => 'ip_id',
-            'country' => 'country_id',
-            'region' => 'region_id',
-            'city' => 'city_id',
-            'isp' => 'isp_id',
-            'landingpage' => 'landing_page_id',
-            'device' => 'device_id',
-            'browser' => 'browser_id',
-            'platform' => 'platform_id',
+            'textad' => 'text_ad_name',
+            'country' => 'country_name',
+            'region' => 'region_name',
+            'city' => 'city_name',
+            'isp' => 'isp_name',
+            'landingpage' => 'landing_page_nickname',
+            'device' => 'device_name',
+            'browser' => 'browser_name',
+            'platform' => 'platform_name',
         ];
 
-        foreach ($expected as $type => $column) {
-            self::assertSame(
-                $column,
-                GroupedReportRegistry::definition($type)->countColumn,
-                "Unexpected count column for $type"
+        foreach ($expected as $type => $groupBy) {
+            $definition = GroupedReportRegistry::definition($type);
+            self::assertSame($groupBy, $definition->groupBy, "Unexpected grouping for $type");
+            self::assertStringNotContainsString(
+                '_id',
+                $definition->groupBy,
+                "Report $type must not group by a foreign key"
             );
         }
     }

--- a/tests/DataEngine/ReportIntegrationTest.php
+++ b/tests/DataEngine/ReportIntegrationTest.php
@@ -111,9 +111,14 @@ final class ReportIntegrationTest extends TestCase
     /**
      * Seed a deterministic fixture: three clicks for the sentinel user.
      * Totals: clicks=3, click_out=2, leads=2, income=30, cost=6.
-     * Lookup dimensions are intentionally left unseeded — the reports
-     * LEFT JOIN them, so every row collapses into one "[no X]" group plus
-     * the totals row, which is all these assertions need.
+     *
+     * Each click carries a *different* id for every lookup dimension, and none of those
+     * ids exist in the lookup tables. The reports LEFT JOIN those tables, so all three
+     * rows collapse into a single "[no X]" group — while there are three distinct
+     * foreign keys. That gap is deliberate: it is the shape that made the pagination
+     * count disagree with the rows returned (see
+     * testFoundRowsMatchesTheRowsActuallyReturned), and it is what real data looks like
+     * whenever 202_dataengine references a lookup row that was never written.
      */
     private static function seedFixture(): void
     {
@@ -131,13 +136,21 @@ final class ReportIntegrationTest extends TestCase
             [9900002, 1, 1, 1, '20.00000', '2.00000'],
             [9900003, 0, 0, 0, '0.00000',  '2.00000'],
         ];
-        foreach ($rows as [$clickId, $clickOut, $leads, $clickLead, $income, $cost]) {
+        // Dimension ids are unique per row and resolve to nothing.
+        $dimBase = 970000;
+        foreach ($rows as $i => [$clickId, $clickOut, $leads, $clickLead, $income, $cost]) {
+            $d = $dimBase + $i;
             $ok = self::$db->query(
                 "INSERT INTO 202_dataengine
                    (user_id, click_id, click_time, ppc_account_id, landing_page_id,
+                    keyword_id, text_ad_id, ip_id, country_id, region_id, city_id,
+                    isp_id, device_id, browser_id, platform_id, click_referer_site_url_id,
                     click_lead, clicks, click_out, leads, payout, income, cost)
                  VALUES
-                   ($uid, $clickId, $t, 0, 0, $clickLead, 1, $clickOut, $leads, 0.00, $income, $cost)"
+                   ($uid, $clickId, $t, 0, $d,
+                    $d, $d, $d, $d, $d, $d,
+                    $d, $d, $d, $d, $d,
+                    $clickLead, 1, $clickOut, $leads, 0.00, $income, $cost)"
             );
             if (!$ok) {
                 self::markTestSkipped('Could not seed 202_dataengine: ' . self::$db->error);
@@ -186,6 +199,59 @@ final class ReportIntegrationTest extends TestCase
 
         // foundRows (pagination count) must be reachable without error.
         self::assertIsInt($de->foundRows());
+    }
+
+    /**
+     * The pagination count must equal the number of rows the report actually returns.
+     *
+     * This is the regression guard for the count/rows mismatch. Reports GROUP BY the
+     * joined name (region_name, text_ad_name, …), but the count used to run a separate
+     * COUNT(DISTINCT <foreign key>) against 202_dataengine with none of the report's
+     * joins. The fixture seeds three distinct, unresolvable dimension ids per report, so
+     * the old count returned 3 where the report returns a single "[no X]" group — an
+     * inflated totalRows that advertised a trailing page rendering zero rows.
+     *
+     * The limit is well above the group count here, so every group is on page one and
+     * foundRows is directly comparable to the rows returned.
+     *
+     * @dataProvider groupedReportProvider
+     */
+    public function testFoundRowsMatchesTheRowsActuallyReturned(string $reportType): void
+    {
+        $de = new \DataEngine();
+        $data = $de->getReportData($reportType, self::$from, self::$to, false);
+
+        self::assertIsArray($data);
+        self::assertNotEmpty($data);
+
+        // The engine appends a trailing "Totals for report" row that is not a group.
+        $dataRows = count($data) - 1;
+
+        self::assertSame(
+            $dataRows,
+            $de->foundRows(),
+            "$reportType: pagination count ({$de->foundRows()}) must equal the $dataRows row(s) returned"
+        );
+    }
+
+    /**
+     * The three seeded clicks share no lookup rows, so each report must collapse them
+     * into exactly one group. Pins the fixture's intent, so a future edit that makes the
+     * ids resolvable cannot quietly neuter the guard above.
+     *
+     * @dataProvider groupedReportProvider
+     */
+    public function testUnresolvableDimensionIdsCollapseIntoASingleGroup(string $reportType): void
+    {
+        $de = new \DataEngine();
+        $data = $de->getReportData($reportType, self::$from, self::$to, false);
+
+        self::assertCount(
+            2,
+            $data,
+            "$reportType must return one group plus the totals row for three unresolvable ids"
+        );
+        self::assertSame(1, $de->foundRows(), "$reportType must count exactly one group");
     }
 
     public function testTimeBreakdownReportsExecute(): void

--- a/tests/Report/Json/FlatReportPaginationTest.php
+++ b/tests/Report/Json/FlatReportPaginationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Report\Json;
+
+use PHPUnit\Framework\TestCase;
+use Tracking202\Report\Json\FlatReportPayloadBuilder;
+
+/**
+ * Tests for the pagination block of the JSON report payload.
+ *
+ * The report SQL runs its LIMIT with the client's raw offset before this metadata is
+ * built, so the metadata must describe the page that was actually queried. An earlier
+ * version clamped the reported offset, which meant an out-of-range request returned an
+ * empty row set described as the last page.
+ */
+final class FlatReportPaginationTest extends TestCase
+{
+    public function testDescribesAMiddlePage(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(250, 50, 2, '');
+
+        self::assertSame(250, $p['totalRows']);
+        self::assertSame(50, $p['limit']);
+        self::assertSame(5, $p['pageCount']);
+        self::assertSame(2, $p['currentOffset']);
+        self::assertSame(3, $p['currentPageNumber']);
+        self::assertFalse($p['outOfRange']);
+        self::assertTrue($p['hasPreviousPage']);
+        self::assertSame(1, $p['previousOffset']);
+        self::assertTrue($p['hasNextPage']);
+        self::assertSame(3, $p['nextOffset']);
+    }
+
+    public function testFirstPageHasNoPrevious(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(250, 50, 0, '');
+
+        self::assertFalse($p['hasPreviousPage']);
+        self::assertSame(0, $p['previousOffset']);
+        self::assertTrue($p['hasNextPage']);
+    }
+
+    public function testLastPageHasNoNext(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(250, 50, 4, '');
+
+        self::assertSame(5, $p['pageCount']);
+        self::assertFalse($p['outOfRange']);
+        self::assertFalse($p['hasNextPage']);
+        self::assertSame(4, $p['nextOffset'], 'next is a no-op on the last page');
+        self::assertTrue($p['hasPreviousPage']);
+    }
+
+    /**
+     * The regression this class exists for: offset past the end must not be described as
+     * the last page. The rows are empty, and saying otherwise makes the client render an
+     * empty table labelled "page 5 of 5".
+     */
+    public function testOutOfRangeOffsetIsReportedHonestly(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(250, 50, 999, '');
+
+        self::assertSame(5, $p['pageCount']);
+        self::assertTrue($p['outOfRange']);
+        self::assertSame(999, $p['currentOffset'], 'must report the offset the query actually used');
+        self::assertFalse($p['hasNextPage']);
+    }
+
+    /**
+     * ...and the client must be able to get back to real data from there.
+     */
+    public function testOutOfRangeOffsetPointsPreviousAtTheLastRealPage(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(250, 50, 999, '');
+
+        self::assertTrue($p['hasPreviousPage']);
+        self::assertSame(4, $p['previousOffset'], 'previous should recover to the last page that has rows');
+    }
+
+    public function testEmptyReportIsASinglePage(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(0, 50, 0, '');
+
+        self::assertSame(0, $p['totalRows']);
+        self::assertSame(1, $p['pageCount']);
+        self::assertFalse($p['outOfRange']);
+        self::assertFalse($p['hasNextPage']);
+        self::assertFalse($p['hasPreviousPage']);
+    }
+
+    /**
+     * A missing/zero user_pref_limit must not divide by zero.
+     */
+    public function testZeroLimitFallsBackToASinglePage(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(120, 0, 0, '');
+
+        self::assertSame(120, $p['limit'], 'a zero limit degrades to one page holding every row');
+        self::assertSame(1, $p['pageCount']);
+        self::assertFalse($p['hasNextPage']);
+    }
+
+    public function testOrderTokenIsEchoedBackForPaginationLinks(): void
+    {
+        $p = FlatReportPayloadBuilder::paginationFor(250, 50, 1, 'sort_breakdown_epc desc');
+
+        self::assertSame('sort_breakdown_epc desc', $p['orderToken']);
+    }
+}

--- a/tests/Report/Json/ReportDispatchRequestTest.php
+++ b/tests/Report/Json/ReportDispatchRequestTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Report\Json;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Prosper202\DataEngine\SortOrder;
+use Tracking202\Report\Json\ReportDispatchRequest;
+
+/**
+ * Tests for the JSON report transport's request parser.
+ *
+ * This is the trust boundary for the dispatch endpoint: every field on the wire is
+ * attacker-controllable, and the parser is the only thing between it and the report
+ * query. It is pure and DB-free, so it is exercised directly here.
+ */
+final class ReportDispatchRequestTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private array $postBackup = [];
+
+    protected function setUp(): void
+    {
+        $this->postBackup = $_POST;
+    }
+
+    protected function tearDown(): void
+    {
+        $_POST = $this->postBackup;
+    }
+
+    public function testParsesAMinimalValidPayload(): void
+    {
+        $request = ReportDispatchRequest::fromArray(['reportType' => 'keyword']);
+
+        self::assertSame('keyword', $request->reportType);
+        self::assertSame(0, $request->offset);
+        self::assertSame('', $request->order);
+        self::assertTrue($request->includeDependentFilters, 'dependent filters are bootstrapped by default');
+    }
+
+    public function testParsesAFullyPopulatedPayload(): void
+    {
+        $request = ReportDispatchRequest::fromArray([
+            'reportType' => 'country',
+            'offset' => 40,
+            'order' => 'sort_breakdown_clicks desc',
+            'includeDependentFilters' => false,
+        ]);
+
+        self::assertSame('country', $request->reportType);
+        self::assertSame(40, $request->offset);
+        self::assertSame('sort_breakdown_clicks desc', $request->order);
+        self::assertFalse($request->includeDependentFilters);
+    }
+
+    /**
+     * Every report page wired to the JSON transport must be accepted by the parser,
+     * otherwise that page 422s at runtime with the flag on.
+     *
+     * @return list<array{string}>
+     */
+    public static function supportedReportTypeProvider(): array
+    {
+        return array_map(
+            static fn (string $type): array => [$type],
+            ['keyword', 'textad', 'referer', 'ip', 'country', 'region', 'city', 'isp', 'landingpage', 'device', 'browser', 'platform']
+        );
+    }
+
+    /**
+     * @dataProvider supportedReportTypeProvider
+     */
+    public function testAcceptsEverySupportedReportType(string $reportType): void
+    {
+        $request = ReportDispatchRequest::fromArray(['reportType' => $reportType]);
+
+        self::assertSame($reportType, $request->reportType);
+    }
+
+    public function testRejectsUnknownReportType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray(['reportType' => 'ltv']);
+    }
+
+    public function testRejectsMissingReportType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray(['offset' => 0]);
+    }
+
+    /**
+     * A typo'd or stale field must not be silently ignored (CLAUDE.md #4) — a client
+     * that thinks it disabled dependent filters should not get them anyway.
+     */
+    public function testRejectsUnknownFieldsRatherThanIgnoringThem(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray([
+            'reportType' => 'keyword',
+            'includeDependantFilters' => false,
+        ]);
+    }
+
+    public function testRejectsNegativeOffset(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray(['reportType' => 'keyword', 'offset' => -1]);
+    }
+
+    public function testAcceptsNumericStringOffset(): void
+    {
+        $request = ReportDispatchRequest::fromArray(['reportType' => 'keyword', 'offset' => '120']);
+
+        self::assertSame(120, $request->offset);
+    }
+
+    /**
+     * @return list<array{mixed}>
+     */
+    public static function invalidOffsetProvider(): array
+    {
+        return [['abc'], ['-5'], ['1.5'], [1.5], [null], [true], [[]], ['']];
+    }
+
+    /**
+     * @dataProvider invalidOffsetProvider
+     */
+    public function testRejectsNonIntegerOffset(mixed $offset): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray(['reportType' => 'keyword', 'offset' => $offset]);
+    }
+
+    public function testRejectsUnsupportedOrderToken(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray([
+            'reportType' => 'keyword',
+            'order' => 'clicks; DROP TABLE 202_clicks',
+        ]);
+    }
+
+    public function testRejectsNonStringOrder(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray(['reportType' => 'keyword', 'order' => 1]);
+    }
+
+    /**
+     * Booleans are not coerced: "false" (a truthy string) must not silently become true.
+     */
+    public function testRejectsNonBooleanIncludeDependentFilters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray([
+            'reportType' => 'keyword',
+            'includeDependentFilters' => 'false',
+        ]);
+    }
+
+    /**
+     * An omitted field takes its default, but an explicitly-null one is malformed input.
+     * Coalescing null to the default is the silent-fallback pattern the parser exists to
+     * prevent, so each nullable-looking field is pinned here.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function explicitlyNullFieldProvider(): array
+    {
+        return [
+            'offset' => ['offset'],
+            'order' => ['order'],
+            'includeDependentFilters' => ['includeDependentFilters'],
+        ];
+    }
+
+    /**
+     * @dataProvider explicitlyNullFieldProvider
+     */
+    public function testRejectsExplicitlyNullField(string $field): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(422);
+
+        ReportDispatchRequest::fromArray(['reportType' => 'keyword', $field => null]);
+    }
+
+    public function testOmittedFieldsStillTakeTheirDefaults(): void
+    {
+        $request = ReportDispatchRequest::fromArray(['reportType' => 'keyword']);
+
+        self::assertSame(0, $request->offset);
+        self::assertSame('', $request->order);
+        self::assertTrue($request->includeDependentFilters);
+    }
+
+    public function testApplyLegacyGlobalsPublishesOffsetAndOrder(): void
+    {
+        $_POST = ['stale' => 'value'];
+
+        $request = ReportDispatchRequest::fromArray([
+            'reportType' => 'keyword',
+            'offset' => 25,
+            'order' => 'sort_breakdown_epc asc',
+        ]);
+        $request->applyLegacyGlobals();
+
+        self::assertSame('25', $_POST['offset']);
+        self::assertSame('sort_breakdown_epc asc', $_POST['order']);
+        self::assertArrayNotHasKey('stale', $_POST, 'legacy globals must not leak in from the ambient request');
+    }
+
+    /**
+     * DataEngine::sortOrder() falls back to its default when $_POST['order'] is absent,
+     * so an empty token must be left unset rather than published as ''.
+     */
+    public function testApplyLegacyGlobalsOmitsEmptyOrder(): void
+    {
+        $request = ReportDispatchRequest::fromArray(['reportType' => 'keyword']);
+        $request->applyLegacyGlobals();
+
+        self::assertSame('0', $_POST['offset']);
+        self::assertArrayNotHasKey('order', $_POST);
+    }
+
+    /**
+     * Regression guard against a silent-divergence bug.
+     *
+     * The parser whitelists sort tokens, but DataEngine hands them to SortOrder, which
+     * whitelists them *again* and quietly falls back to "ORDER BY leads DESC" on a miss.
+     * A token accepted here but unknown to SortOrder would therefore validate, 200, and
+     * return data sorted by something other than what the user clicked — with no error.
+     * Pin the two whitelists together.
+     */
+    public function testEveryAcceptedOrderTokenIsHonoredBySortOrder(): void
+    {
+        $tokens = array_filter(ReportDispatchRequest::supportedOrderTokens());
+        self::assertNotEmpty($tokens);
+
+        foreach ($tokens as $token) {
+            self::assertSame(
+                $token,
+                SortOrder::canonicalKey($token),
+                sprintf('Sort token "%s" is accepted by the dispatcher but SortOrder would ignore it.', $token)
+            );
+        }
+    }
+}

--- a/tracking202/Data/StaticFilterOptionsProvider.php
+++ b/tracking202/Data/StaticFilterOptionsProvider.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tracking202\Data;
+
+use DB;
+use mysqli;
+
+final class StaticFilterOptionsProvider
+{
+    private const FILTERS = [
+        'country' => [
+            'query' => 'SELECT country_id AS option_value, country_name AS option_label FROM 202_locations_country GROUP BY country_name ORDER BY country_name ASC',
+        ],
+        'region' => [
+            'query' => 'SELECT region_id AS option_value, region_name AS option_label FROM 202_locations_region GROUP BY region_name ORDER BY region_name ASC',
+        ],
+        'isp' => [
+            'query' => 'SELECT isp_id AS option_value, isp_name AS option_label FROM 202_locations_isp GROUP BY isp_name ORDER BY isp_name ASC',
+        ],
+        'device' => [
+            'query' => 'SELECT type_id AS option_value, type_name AS option_label FROM 202_device_types ORDER BY type_name ASC',
+        ],
+        'browser' => [
+            'query' => 'SELECT browser_id AS option_value, browser_name AS option_label FROM 202_browsers GROUP BY browser_name ORDER BY browser_name ASC',
+        ],
+        'platform' => [
+            'query' => 'SELECT platform_id AS option_value, platform_name AS option_label FROM 202_platforms GROUP BY platform_name ORDER BY platform_name ASC',
+        ],
+    ];
+
+    /**
+     * @param array<string, string> $selectedValues
+     * @return array<string, array{enabled: bool, option_count: int, estimated_bytes: int, options_html: string}>
+     */
+    public static function build(array $selectedValues): array
+    {
+        $states = self::disabledStates();
+        if (!function_exists('tracking202StaticFilterSsrEnabled') || !tracking202StaticFilterSsrEnabled()) {
+            return $states;
+        }
+
+        $database = DB::getInstance();
+        $db = $database->getConnection();
+
+        $combinedBytes = 0;
+        foreach (self::FILTERS as $filterName => $config) {
+            $state = self::buildFilterState($db, $config['query'], $selectedValues[$filterName] ?? '');
+            $states[$filterName] = $state;
+
+            if ($state['enabled']) {
+                $combinedBytes += $state['estimated_bytes'];
+            }
+        }
+
+        if (function_exists('tracking202StaticFilterSsrMaxBytes') && $combinedBytes > tracking202StaticFilterSsrMaxBytes()) {
+            return self::disabledStates();
+        }
+
+        return $states;
+    }
+
+    /**
+     * @return array<string, array{enabled: bool, option_count: int, estimated_bytes: int, options_html: string}>
+     */
+    private static function disabledStates(): array
+    {
+        $states = [];
+        foreach (array_keys(self::FILTERS) as $filterName) {
+            $states[$filterName] = [
+                'enabled' => false,
+                'option_count' => 0,
+                'estimated_bytes' => 0,
+                'options_html' => '',
+            ];
+        }
+
+        return $states;
+    }
+
+    /**
+     * @return array{enabled: bool, option_count: int, estimated_bytes: int, options_html: string}
+     */
+    private static function buildFilterState(mysqli $db, string $query, string $selectedValue): array
+    {
+        $result = $db->query($query);
+        if (!$result) {
+            // Degrade rather than throw, unlike DependentFilterPayloadBuilder. A disabled
+            // static filter falls back to the legacy load_<name>_id() AJAX call, which
+            // fetches the same options — the user sees an identical dropdown, so there is
+            // no data loss or wrong number to report. Still logged: a persistently failing
+            // query here would silently cost every page an extra round-trip forever.
+            error_log('tracking202 static filter SSR: query failed, falling back to AJAX: ' . $db->error);
+
+            return [
+                'enabled' => false,
+                'option_count' => 0,
+                'estimated_bytes' => 0,
+                'options_html' => '',
+            ];
+        }
+
+        $optionCount = 0;
+        $optionsHtml = '';
+        while ($row = $result->fetch_assoc()) {
+            $optionCount++;
+            $rawValue = (string) ($row['option_value'] ?? '');
+            $value = htmlentities($rawValue, ENT_QUOTES, 'UTF-8');
+            $label = htmlentities((string) ($row['option_label'] ?? ''), ENT_QUOTES, 'UTF-8');
+            $selected = ($selectedValue !== '' && $selectedValue === $rawValue) ? 'selected=""' : '';
+            $optionsHtml .= sprintf('<option %s value="%s">%s</option>', $selected, $value, $label);
+        }
+
+        $enabled = !function_exists('tracking202StaticFilterSsrMaxOptions')
+            || $optionCount <= tracking202StaticFilterSsrMaxOptions();
+
+        return [
+            'enabled' => $enabled,
+            'option_count' => $optionCount,
+            'estimated_bytes' => strlen($optionsHtml),
+            'options_html' => $enabled ? $optionsHtml : '',
+        ];
+    }
+}

--- a/tracking202/Report/Json/DependentFilterPayloadBuilder.php
+++ b/tracking202/Report/Json/DependentFilterPayloadBuilder.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tracking202\Report\Json;
+
+/**
+ * Builds the first-pass dependent filter payload for flat report canaries.
+ *
+ * The current UI expects server-rendered select markup with inline change handlers,
+ * so this adapter keeps those fragments server-owned while transport moves to JSON.
+ */
+final class DependentFilterPayloadBuilder
+{
+    /**
+     * @param array<string, mixed> $userPreferences
+     * @return array<string, mixed>
+     */
+    public static function build(ReportDispatchRequest $request, array $userPreferences): array
+    {
+        if (!$request->includeDependentFilters) {
+            return [
+                'requested' => false,
+                'included' => false,
+                'reason' => 'not_requested',
+            ];
+        }
+
+        if (!empty($_SESSION['publisher'])) {
+            return [
+                'requested' => true,
+                'included' => false,
+                'reason' => 'publisher_sections_hidden',
+            ];
+        }
+
+        $preferences = self::normalizePreferences($userPreferences);
+
+        return [
+            'requested' => true,
+            'included' => true,
+            'fragments' => [
+                'affCampaign' => [
+                    'targetId' => 'aff_campaign_id_div',
+                    'html' => self::renderAffiliateCampaignSelect(
+                        $preferences['affNetworkId'],
+                        $preferences['affCampaignId']
+                    ),
+                ],
+                'textAd' => [
+                    'targetId' => 'text_ad_id_div',
+                    'html' => self::renderTextAdSelect(
+                        $preferences['affCampaignId'],
+                        $preferences['textAdId']
+                    ),
+                ],
+                'landingPage' => [
+                    'targetId' => 'landing_page_div',
+                    'html' => self::renderLandingPageSelect(
+                        $preferences['affCampaignId'],
+                        $preferences['landingPageId'],
+                        $preferences['methodOfPromotion']
+                    ),
+                ],
+                'adPreview' => [
+                    'targetId' => 'ad_preview_div',
+                    'html' => self::renderAdPreview($preferences['textAdId']),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $userPreferences
+     * @return array{affNetworkId: int, affCampaignId: int, textAdId: int, landingPageId: int, methodOfPromotion: string}
+     */
+    private static function normalizePreferences(array $userPreferences): array
+    {
+        $methodOfPromotion = trim((string) ($userPreferences['user_pref_method_of_promotion'] ?? ''));
+        if ($methodOfPromotion === 'landingpage') {
+            $methodOfPromotion = 'landingpages';
+        }
+
+        return [
+            'affNetworkId' => self::normalizeId($userPreferences['user_pref_aff_network_id'] ?? 0),
+            'affCampaignId' => self::normalizeId($userPreferences['user_pref_aff_campaign_id'] ?? 0),
+            'textAdId' => self::normalizeId($userPreferences['user_pref_text_ad_id'] ?? 0),
+            'landingPageId' => self::normalizeId($userPreferences['user_pref_landing_page_id'] ?? 0),
+            'methodOfPromotion' => $methodOfPromotion,
+        ];
+    }
+
+    private static function normalizeId(mixed $value): int
+    {
+        if (is_int($value)) {
+            return max($value, 0);
+        }
+
+        $stringValue = trim((string) $value);
+        if ($stringValue === '' || preg_match('/^\d+$/', $stringValue) !== 1) {
+            return 0;
+        }
+
+        return (int) $stringValue;
+    }
+
+    private static function renderAffiliateCampaignSelect(int $affNetworkId, int $selectedAffCampaignId): string
+    {
+        if ($selectedAffCampaignId <= 0) {
+            return '';
+        }
+
+        $db = \DB::getInstance()->getConnection();
+        $userId = $db->real_escape_string((string) ($_SESSION['user_id'] ?? 0));
+        $escapedAffNetworkId = $db->real_escape_string((string) $affNetworkId);
+
+        $sql = "SELECT * 
+                FROM `202_aff_campaigns`
+                WHERE `user_id`='" . $userId . "'
+                AND `aff_network_id`='" . $escapedAffNetworkId . "'
+                AND `aff_campaign_deleted`='0'
+                ORDER BY `aff_campaign_name` ASC";
+        $result = $db->query($sql);
+        if ($result === false) {
+            error_log('tracking202 dependent filter: failed to load affiliate campaign options: ' . $db->error);
+            throw new \RuntimeException('Unable to load affiliate campaign options.');
+        }
+
+        if ($result->num_rows === 0) {
+            return self::renderDisabledSelect('aff_campaign_id');
+        }
+
+        $options = ['<option value="0"> -- </option>'];
+        while ($row = $result->fetch_assoc()) {
+            $campaignId = self::escapeAttribute((string) ($row['aff_campaign_id'] ?? ''));
+            $campaignName = self::escapeHtml((string) ($row['aff_campaign_name'] ?? ''));
+            $campaignPayout = self::escapeHtml((string) ($row['aff_campaign_payout'] ?? ''));
+            $selected = ((string) $selectedAffCampaignId === (string) ($row['aff_campaign_id'] ?? ''))
+                ? ' selected=""'
+                : '';
+
+            $options[] = sprintf(
+                '<option%s value="%s">%s &middot; &#36;%s</option>',
+                $selected,
+                $campaignId,
+                $campaignName,
+                $campaignPayout
+            );
+        }
+
+        return '<select class="form-control input-sm" name="aff_campaign_id" id="aff_campaign_id" onchange="load_text_ad_id(this.value); if($(\'#landing_page_style_type\')){load_landing_page($(\'#aff_campaign_id option:selected\').val(), 0, $(\'input:radio[name=landing_page_type]:checked\').val()?$(\'input:radio[name=landing_page_type]:checked\').val():\'landingpage\');} if($(\'#unsecure_pixel\').length != 0) { change_pixel_data();}">'
+            . implode('', $options)
+            . '</select>';
+    }
+
+    private static function renderTextAdSelect(int $affCampaignId, int $selectedTextAdId): string
+    {
+        if ($selectedTextAdId <= 0) {
+            return '';
+        }
+
+        $db = \DB::getInstance()->getConnection();
+        $userId = $db->real_escape_string((string) ($_SESSION['user_id'] ?? 0));
+        $escapedAffCampaignId = $db->real_escape_string((string) $affCampaignId);
+
+        $sql = "SELECT *
+                FROM `202_text_ads`
+                WHERE `user_id`='" . $userId . "'
+                AND `aff_campaign_id`='" . $escapedAffCampaignId . "'
+                AND `text_ad_deleted`='0'
+                ORDER BY `aff_campaign_id`, `text_ad_name` ASC";
+        $result = $db->query($sql);
+        if ($result === false) {
+            error_log('tracking202 dependent filter: failed to load text ad options: ' . $db->error);
+            throw new \RuntimeException('Unable to load text ad options.');
+        }
+
+        if ($result->num_rows === 0) {
+            return self::renderDisabledSelect('text_ad_id', '--');
+        }
+
+        $options = ['<option value="0"> -- </option>'];
+        while ($row = $result->fetch_assoc()) {
+            $textAdId = self::escapeAttribute((string) ($row['text_ad_id'] ?? ''));
+            $textAdName = self::escapeHtml((string) ($row['text_ad_name'] ?? ''));
+            $selected = ((string) $selectedTextAdId === (string) ($row['text_ad_id'] ?? ''))
+                ? ' selected=""'
+                : '';
+
+            $options[] = sprintf('<option%s value="%s">%s</option>', $selected, $textAdId, $textAdName);
+        }
+
+        return '<select class="form-control input-sm" id="text_ad_id" name="text_ad_id" onchange="load_ad_preview(this.value);">'
+            . implode('', $options)
+            . '</select>';
+    }
+
+    private static function renderLandingPageSelect(int $affCampaignId, int $selectedLandingPageId, string $type): string
+    {
+        if ($selectedLandingPageId <= 0) {
+            return '';
+        }
+
+        if ($type !== 'landingpage' && $type !== 'landingpages' && $type !== 'advlandingpage') {
+            return self::renderDisabledSelect('landing_page_id');
+        }
+
+        $db = \DB::getInstance()->getConnection();
+        $userId = $db->real_escape_string((string) ($_SESSION['user_id'] ?? 0));
+        $escapedAffCampaignId = $db->real_escape_string((string) $affCampaignId);
+        $eq = $affCampaignId === 0 ? '>=' : '=';
+
+        if ($type === 'landingpage') {
+            $sql = "SELECT *
+                    FROM `202_landing_pages` AS 2lp
+                    JOIN 202_aff_campaigns USING(aff_campaign_id)
+                    JOIN 202_aff_networks USING(aff_network_id)
+                    WHERE 2lp.user_id='" . $userId . "'
+                    AND 2lp.aff_campaign_id" . $eq . "'" . $escapedAffCampaignId . "'
+                    AND `landing_page_deleted`='0'
+                    AND aff_campaign_deleted='0'
+                    AND `aff_network_deleted`='0'
+                    ORDER BY `aff_campaign_id`, `landing_page_nickname` ASC";
+        } elseif ($type === 'advlandingpage') {
+            $sql = "SELECT *
+                    FROM `202_landing_pages`
+                    WHERE `user_id`='" . $userId . "'
+                    AND `landing_page_type`='1'
+                    AND `landing_page_deleted`='0'
+                    ORDER BY `landing_page_nickname` ASC";
+        } else {
+            $sql = "(SELECT landing_page_id, landing_page_nickname
+                    FROM `202_landing_pages` AS 2lp
+                    JOIN 202_aff_campaigns USING(aff_campaign_id)
+                    JOIN 202_aff_networks USING(aff_network_id)
+                    WHERE 2lp.user_id='" . $userId . "'
+                    AND 2lp.aff_campaign_id" . $eq . "'" . $escapedAffCampaignId . "'
+                    AND `landing_page_deleted`='0'
+                    AND aff_campaign_deleted='0'
+                    AND `aff_network_deleted`='0'
+                    ORDER BY `aff_campaign_id`, `landing_page_nickname` ASC)
+                    UNION
+                    (SELECT landing_page_id, landing_page_nickname
+                    FROM `202_landing_pages`
+                    WHERE `user_id`='" . $userId . "'
+                    AND `landing_page_type`='1'
+                    AND `landing_page_deleted`='0'
+                    ORDER BY `landing_page_nickname` ASC)";
+        }
+
+        $result = $db->query($sql);
+        if ($result === false) {
+            error_log('tracking202 dependent filter: failed to load landing page options: ' . $db->error);
+            throw new \RuntimeException('Unable to load landing page options.');
+        }
+
+        $hiddenInput = '<input id="landing_page_style_type" type="hidden" name="landing_page_style_type" value="' . self::escapeAttribute($type) . '"/>';
+        if ($result->num_rows === 0) {
+            return $hiddenInput . self::renderBaseSelect('landing_page_id', ['<option value="0"> -- </option>']);
+        }
+
+        $options = ['<option value="0"> -- </option>'];
+        while ($row = $result->fetch_assoc()) {
+            $landingPageId = self::escapeAttribute((string) ($row['landing_page_id'] ?? ''));
+            $landingPageNickname = self::escapeHtml((string) ($row['landing_page_nickname'] ?? ''));
+            $selected = ((string) $selectedLandingPageId === (string) ($row['landing_page_id'] ?? ''))
+                ? ' selected=""'
+                : '';
+
+            $options[] = sprintf('<option%s value="%s">%s</option>', $selected, $landingPageId, $landingPageNickname);
+        }
+
+        $onChange = $type === 'advlandingpage'
+            ? 'load_adv_text_ad_id(this.value);'
+            : 'load_text_ad_id($(\'#aff_campaign_id\').val());';
+
+        return $hiddenInput
+            . '<select class="form-control input-sm" name="landing_page_id" id="landing_page_id" onchange="' . self::escapeAttribute($onChange) . '">'
+            . implode('', $options)
+            . '</select>';
+    }
+
+    private static function renderAdPreview(int $textAdId): string
+    {
+        if ($textAdId <= 0) {
+            return '';
+        }
+
+        $db = \DB::getInstance()->getConnection();
+        $userId = $db->real_escape_string((string) ($_SESSION['user_id'] ?? 0));
+        $escapedTextAdId = $db->real_escape_string((string) $textAdId);
+
+        $sql = "SELECT *
+                FROM `202_text_ads`
+                WHERE `text_ad_id`='" . $escapedTextAdId . "'
+                AND `user_id`='" . $userId . "'";
+        $result = $db->query($sql);
+        if ($result === false) {
+            error_log('tracking202 dependent filter: failed to load text ad preview: ' . $db->error);
+            throw new \RuntimeException('Unable to load text ad preview.');
+        }
+
+        if ($result->num_rows === 0) {
+            return '<div class="panel panel-default" style="opacity:0.5; border-color: #3498db; margin-bottom:0px; width: 220px"><div class="panel-body" style="width: 220px"><span id="ad-preview-headline">aLuxury Cruise to Mars</span><br/><span id="ad-preview-body">Visit the Red Planet in style. Low-gravity fun for everyone!</span><br/><span id="ad-preview-url">www.example.com</span></div></div>';
+        }
+
+        $row = $result->fetch_assoc() ?: [];
+        $headline = self::escapeHtml((string) ($row['text_ad_headline'] ?? ''));
+        $description = self::escapeHtml((string) ($row['text_ad_description'] ?? ''));
+        $displayUrl = self::escapeHtml((string) ($row['text_ad_display_url'] ?? ''));
+
+        return '<div class="panel panel-default" style="border-color: #3498db; margin-bottom:0px; width:220px"><div class="panel-body" style="width: 220px"><span id="ad-preview-headline">' . $headline . '</span><br/><span id="ad-preview-body">' . $description . '</span><br/><span id="ad-preview-url">' . $displayUrl . '</span></div></div>';
+    }
+
+    private static function renderDisabledSelect(string $selectId, string $placeholder = ' -- '): string
+    {
+        return self::renderBaseSelect(
+            $selectId,
+            ['<option value="0">' . self::escapeHtml($placeholder) . '</option>'],
+            true
+        );
+    }
+
+    /**
+     * @param list<string> $options
+     */
+    private static function renderBaseSelect(string $selectId, array $options, bool $disabled = false): string
+    {
+        $disabledAttribute = $disabled ? ' disabled=""' : '';
+
+        return '<select class="form-control input-sm" name="' . self::escapeAttribute($selectId) . '" id="' . self::escapeAttribute($selectId) . '"' . $disabledAttribute . '>'
+            . implode('', $options)
+            . '</select>';
+    }
+
+    private static function escapeHtml(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+
+    private static function escapeAttribute(string $value): string
+    {
+        return htmlentities($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/tracking202/Report/Json/FlatReportPayloadBuilder.php
+++ b/tracking202/Report/Json/FlatReportPayloadBuilder.php
@@ -1,0 +1,447 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tracking202\Report\Json;
+
+use UserPrefs;
+
+final class FlatReportPayloadBuilder
+{
+    /**
+     * @var array<string, array{featureLabel: string, downloadPath: string}>
+     */
+    private const REPORTS = [
+        'keyword' => [
+            'featureLabel' => 'Keyword',
+            'downloadPath' => 'tracking202/analyze/keywords_download.php',
+        ],
+        'textad' => [
+            'featureLabel' => 'Text ad',
+            'downloadPath' => 'tracking202/analyze/text_ads_download.php',
+        ],
+        'referer' => [
+            'featureLabel' => 'Referer',
+            'downloadPath' => 'tracking202/analyze/referers_download.php',
+        ],
+        'ip' => [
+            'featureLabel' => 'IP',
+            'downloadPath' => 'tracking202/analyze/ips_download.php',
+        ],
+        'country' => [
+            'featureLabel' => 'Country',
+            'downloadPath' => 'tracking202/analyze/countries_download.php',
+        ],
+        'region' => [
+            'featureLabel' => 'Region',
+            'downloadPath' => 'tracking202/analyze/regions_download.php',
+        ],
+        'city' => [
+            'featureLabel' => 'City',
+            'downloadPath' => 'tracking202/analyze/cities_download.php',
+        ],
+        'isp' => [
+            'featureLabel' => 'ISP/Carrier',
+            'downloadPath' => 'tracking202/analyze/isps_download.php',
+        ],
+        'landingpage' => [
+            'featureLabel' => 'Landing Page',
+            'downloadPath' => 'tracking202/analyze/landing_pages_download.php',
+        ],
+        'device' => [
+            'featureLabel' => 'Device',
+            'downloadPath' => 'tracking202/analyze/device_download.php',
+        ],
+        'browser' => [
+            'featureLabel' => 'Browser',
+            'downloadPath' => 'tracking202/analyze/browser_download.php',
+        ],
+        'platform' => [
+            'featureLabel' => 'Platform',
+            'downloadPath' => 'tracking202/analyze/platform_download.php',
+        ],
+    ];
+
+    /**
+     * @var list<array{id: string, label: string, type: string, colspan?: int}>
+     */
+    private const COLUMNS = [
+        ['id' => 'feature', 'label' => 'Feature', 'type' => 'feature', 'colspan' => 4],
+        ['id' => 'clicks', 'label' => 'Clicks', 'type' => 'metric'],
+        ['id' => 'clickOut', 'label' => 'Click Throughs', 'type' => 'metric'],
+        ['id' => 'ctr', 'label' => 'CTR', 'type' => 'metric'],
+        ['id' => 'leads', 'label' => 'Leads', 'type' => 'metric'],
+        ['id' => 'avgSu', 'label' => 'Avg S/U', 'type' => 'metric'],
+        ['id' => 'avgPayout', 'label' => 'Avg Payout', 'type' => 'metric'],
+        ['id' => 'avgEpc', 'label' => 'Avg EPC', 'type' => 'metric'],
+        ['id' => 'avgCpc', 'label' => 'Avg CPC', 'type' => 'metric'],
+        ['id' => 'income', 'label' => 'Income', 'type' => 'metric'],
+        ['id' => 'cost', 'label' => 'Cost', 'type' => 'metric'],
+        ['id' => 'net', 'label' => 'Net', 'type' => 'metric'],
+        ['id' => 'roi', 'label' => 'ROI', 'type' => 'metric'],
+    ];
+
+    /**
+     * @param array<int, array<string, mixed>> $reportData
+     * @param array<string, mixed> $userPreferences
+     * @return array<string, mixed>
+     */
+    public static function build(
+        string $reportType,
+        array $reportData,
+        int $foundRows,
+        ReportDispatchRequest $request,
+        array $userPreferences = []
+    ): array {
+        $definition = self::REPORTS[$reportType] ?? null;
+        if ($definition === null) {
+            throw new \InvalidArgumentException('Unsupported flat report type "' . $reportType . '".');
+        }
+
+        $totalsRow = null;
+        if ($reportData !== []) {
+            $totalsRow = array_pop($reportData);
+        }
+
+        $campaignDataRestricted = self::campaignDataRestricted();
+
+        return [
+            'family' => 'flat',
+            'type' => $reportType,
+            'featureLabel' => $definition['featureLabel'],
+            'download' => [
+                'label' => 'Download to excel',
+                'url' => get_absolute_url() . $definition['downloadPath'],
+            ],
+            'columns' => self::columnsFor($definition['featureLabel']),
+            'rows' => self::buildRows($reportType, $reportData, $campaignDataRestricted),
+            'totals' => self::buildTotals($totalsRow, $campaignDataRestricted),
+            'pagination' => self::buildPagination($foundRows, $request->offset, $request->order),
+            'access' => [
+                'publisher' => !empty($_SESSION['publisher']),
+                'campaignDataRestricted' => $campaignDataRestricted,
+            ],
+            'dependentFilters' => DependentFilterPayloadBuilder::build($request, $userPreferences),
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $reportData
+     * @return list<array<string, mixed>>
+     */
+    private static function buildRows(string $reportType, array $reportData, bool $campaignDataRestricted): array
+    {
+        $rows = [];
+
+        foreach ($reportData as $row) {
+            $rows[] = [
+                'kind' => 'row',
+                'feature' => self::buildFeaturePayload($reportType, $row),
+                'metrics' => self::buildMetricPayload($row, $campaignDataRestricted, false),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed>|null $row
+     * @return array<string, mixed>
+     */
+    private static function buildTotals(?array $row, bool $campaignDataRestricted): array
+    {
+        if ($row === null) {
+            return [
+                'kind' => 'totals',
+                'feature' => [
+                    'text' => 'Totals for report',
+                    'title' => 'Totals for report',
+                    'variant' => 'totals',
+                ],
+                'metrics' => self::buildMetricPayload([], $campaignDataRestricted, true),
+            ];
+        }
+
+        return [
+            'kind' => 'totals',
+            'feature' => [
+                'text' => 'Totals for report',
+                'title' => 'Totals for report',
+                'variant' => 'totals',
+            ],
+            'metrics' => self::buildMetricPayload($row, $campaignDataRestricted, true),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function columnsFor(string $featureLabel): array
+    {
+        $columns = self::COLUMNS;
+        $columns[0]['label'] = $featureLabel;
+
+        return $columns;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private static function buildFeaturePayload(string $reportType, array $row): array
+    {
+        switch ($reportType) {
+            case 'keyword':
+                $keyword = (string) ($row['keyword'] ?? '[no keyword]');
+
+                return [
+                    'text' => $keyword,
+                    'title' => $keyword,
+                    'variant' => 'truncated_text',
+                    'maxWidthPx' => 250,
+                ];
+            case 'textad':
+                return [
+                    'text' => (string) ($row['text_ad_name'] ?? 'Unknown'),
+                    'title' => (string) ($row['text_ad_name'] ?? 'Unknown'),
+                    'variant' => 'plain_text',
+                ];
+            case 'referer':
+                $referer = (string) ($row['referer_name'] ?? 'Unknown');
+
+                return [
+                    'text' => $referer,
+                    'title' => $referer,
+                    'variant' => 'truncated_text',
+                    'maxWidthPx' => 250,
+                ];
+            case 'ip':
+                return [
+                    'text' => (string) ($row['ip_address'] ?? 'Unknown'),
+                    'title' => (string) ($row['ip_address'] ?? 'Unknown'),
+                    'variant' => 'plain_text',
+                ];
+            case 'country':
+                return self::buildFlaggedLocationPayload(
+                    (string) ($row['country_name'] ?? 'Unknown'),
+                    (string) ($row['country_code'] ?? 'unknown')
+                );
+            case 'region':
+                return self::buildFlaggedLocationPayload(
+                    (string) ($row['region_name'] ?? 'Unknown'),
+                    (string) ($row['country_code'] ?? 'unknown')
+                );
+            case 'city':
+                return self::buildFlaggedLocationPayload(
+                    (string) ($row['city_name'] ?? 'Unknown'),
+                    (string) ($row['country_code'] ?? 'unknown')
+                );
+            case 'isp':
+                return [
+                    'text' => (string) ($row['isp_name'] ?? 'Unknown'),
+                    'title' => (string) ($row['isp_name'] ?? 'Unknown'),
+                    'variant' => 'plain_text',
+                ];
+            case 'landingpage':
+                $landingPage = (string) ($row['landing_page_nickname'] ?? 'Unknown');
+
+                return [
+                    'text' => $landingPage,
+                    'title' => $landingPage,
+                    'variant' => 'truncated_text',
+                    'maxWidthPx' => 240,
+                ];
+            case 'device':
+                return [
+                    'text' => (string) ($row['device_name'] ?? 'Unknown'),
+                    'title' => (string) ($row['device_name'] ?? 'Unknown'),
+                    'variant' => 'plain_text',
+                ];
+            case 'browser':
+                return [
+                    'text' => (string) ($row['browser_name'] ?? 'Unknown'),
+                    'title' => (string) ($row['browser_name'] ?? 'Unknown'),
+                    'variant' => 'plain_text',
+                ];
+            case 'platform':
+                return [
+                    'text' => (string) ($row['platform_name'] ?? 'Unknown'),
+                    'title' => (string) ($row['platform_name'] ?? 'Unknown'),
+                    'variant' => 'plain_text',
+                ];
+        }
+
+        return [
+            'text' => '',
+            'title' => '',
+            'variant' => 'plain_text',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, array<string, mixed>>
+     */
+    private static function buildMetricPayload(array $row, bool $campaignDataRestricted, bool $totals): array
+    {
+        $prefix = $totals ? 'total_' : '';
+        $clicks = self::metricCell((string) ($row[$prefix . 'clicks'] ?? '0'));
+        $clickOut = self::metricCell((string) ($row[$prefix . 'click_out'] ?? '0'));
+        $ctr = self::metricCell((string) ($row[$prefix . 'ctr'] ?? '0%'));
+        $leads = self::metricCell((string) ($row[$prefix . 'leads'] ?? '0'));
+        $avgSu = self::metricCell((string) ($row[$prefix . 'su_ratio'] ?? '0%'));
+        $avgPayout = self::metricCell((string) ($row[$prefix . 'payout'] ?? '$0.00'));
+        $avgEpc = self::metricCell((string) ($row[$prefix . 'epc'] ?? '$0.00'));
+        $avgCpc = self::metricCell((string) ($row[$prefix . 'cpc'] ?? '$0.00'));
+        $income = self::metricCell((string) ($row[$prefix . 'income'] ?? '$0.00'), 'info');
+        $cost = self::metricCell(
+            self::wrapCost((string) ($row[$prefix . 'cost'] ?? '$0.00')),
+            'info'
+        );
+        $net = self::metricCell(
+            (string) ($row[$prefix . 'net'] ?? '$0.00'),
+            self::toneFromDisplay((string) ($row[$prefix . 'net'] ?? '$0.00'))
+        );
+        $roi = self::metricCell(
+            (string) ($row[$prefix . 'roi'] ?? '0%'),
+            self::toneFromDisplay((string) ($row[$prefix . 'roi'] ?? '0%'))
+        );
+
+        if ($campaignDataRestricted) {
+            $clicks = self::metricCell('?');
+            $clickOut = self::metricCell('?');
+            $leads = self::metricCell('?');
+            $income = self::metricCell('?', 'info');
+            $cost = self::metricCell('?', 'info');
+            $net = self::metricCell('?', 'default');
+        }
+
+        return [
+            'clicks' => $clicks,
+            'clickOut' => $clickOut,
+            'ctr' => $ctr,
+            'leads' => $leads,
+            'avgSu' => $avgSu,
+            'avgPayout' => $avgPayout,
+            'avgEpc' => $avgEpc,
+            'avgCpc' => $avgCpc,
+            'income' => $income,
+            'cost' => $cost,
+            'net' => $net,
+            'roi' => $roi,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function buildPagination(int $foundRows, int $offset, string $order): array
+    {
+        $limit = 0;
+        if (isset($_SESSION['user_id'])) {
+            new UserPrefs();
+            $limit = (int) UserPrefs::getPref('user_pref_limit');
+        }
+
+        return self::paginationFor($foundRows, $limit, $offset, $order);
+    }
+
+    /**
+     * The pure pagination math, split from the preference lookup above so it can be
+     * exercised without a database or session.
+     *
+     * @return array<string, mixed>
+     */
+    public static function paginationFor(int $foundRows, int $limit, int $offset, string $order): array
+    {
+        if ($limit <= 0) {
+            $limit = max($foundRows, 1);
+        }
+
+        $pageCount = max((int) ceil($foundRows / $limit), 1);
+        $maxOffset = max($pageCount - 1, 0);
+
+        // Report the offset the query actually ran with, not a clamped one. The LIMIT has
+        // already executed by the time we get here, so an offset past the end returned zero
+        // rows; clamping only the metadata would describe those empty rows as the last page.
+        // Flag it instead, and point previousOffset at the last real page so the client can
+        // always get back to data.
+        $outOfRange = $offset > $maxOffset;
+
+        return [
+            'serverPaginated' => true,
+            'totalRows' => $foundRows,
+            'limit' => $limit,
+            'currentOffset' => $offset,
+            'currentPageNumber' => $offset + 1,
+            'pageCount' => $pageCount,
+            'outOfRange' => $outOfRange,
+            'hasPreviousPage' => $offset > 0,
+            'previousOffset' => $outOfRange ? $maxOffset : max($offset - 1, 0),
+            'hasNextPage' => $offset < $maxOffset,
+            'nextOffset' => $offset < $maxOffset ? $offset + 1 : $offset,
+            'orderToken' => $order,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function buildFlaggedLocationPayload(string $name, string $countryCode): array
+    {
+        $normalizedCountryCode = strtolower(trim($countryCode)) ?: 'unknown';
+
+        return [
+            'text' => $name . ' (' . strtoupper($normalizedCountryCode) . ')',
+            'title' => $name . ' (' . strtoupper($normalizedCountryCode) . ')',
+            'variant' => 'flagged_location',
+            'flagUrl' => get_absolute_url() . '202-img/flags/' . $normalizedCountryCode . '.png',
+            'flagCode' => strtoupper($normalizedCountryCode),
+        ];
+    }
+
+    private static function campaignDataRestricted(): bool
+    {
+        global $userObj;
+
+        return (bool) (
+            $userObj
+            && !$userObj->hasPermission('access_to_campaign_data')
+            && empty($_SESSION['publisher'])
+        );
+    }
+
+    /**
+     * @return array{display: string, tone: string}
+     */
+    private static function metricCell(string $display, string $tone = 'default'): array
+    {
+        return [
+            'display' => $display,
+            'tone' => $tone,
+        ];
+    }
+
+    private static function wrapCost(string $display): string
+    {
+        return '(' . $display . ')';
+    }
+
+    private static function toneFromDisplay(string $display): string
+    {
+        $normalized = trim($display);
+        if ($normalized === '' || $normalized === '?') {
+            return 'default';
+        }
+
+        $negative = str_starts_with($normalized, '(') || str_starts_with($normalized, '-');
+        $numeric = preg_replace('/[^0-9.]/', '', $normalized);
+        $value = (float) ($numeric !== '' ? $numeric : '0');
+
+        if ($value === 0.0) {
+            return 'default';
+        }
+
+        return $negative ? 'important' : 'primary';
+    }
+}

--- a/tracking202/Report/Json/ReportDispatchRequest.php
+++ b/tracking202/Report/Json/ReportDispatchRequest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tracking202\Report\Json;
+
+use InvalidArgumentException;
+use JsonException;
+
+final class ReportDispatchRequest
+{
+    /**
+     * Keep the JSON dispatcher limited to the flat report family for now.
+     *
+     * @var list<string>
+     */
+    private const SUPPORTED_REPORT_TYPES = [
+        'keyword',
+        'textad',
+        'referer',
+        'ip',
+        'country',
+        'region',
+        'city',
+        'isp',
+        'landingpage',
+        'device',
+        'browser',
+        'platform',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_KEYS = [
+        'reportType',
+        'offset',
+        'order',
+        'includeDependentFilters',
+    ];
+
+    /**
+     * The legacy flat reports all route through the same sort token family.
+     *
+     * @var list<string>
+     */
+    private const SUPPORTED_ORDER_TOKENS = [
+        '',
+        'sort_breakdown_clicks asc',
+        'sort_breakdown_clicks desc',
+        'sort_breakdown_click_throughs asc',
+        'sort_breakdown_click_throughs desc',
+        'sort_breakdown_ctr asc',
+        'sort_breakdown_ctr desc',
+        'sort_breakdown_leads asc',
+        'sort_breakdown_leads desc',
+        'sort_breakdown_su_ratio asc',
+        'sort_breakdown_su_ratio desc',
+        'sort_breakdown_payout asc',
+        'sort_breakdown_payout desc',
+        'sort_breakdown_epc asc',
+        'sort_breakdown_epc desc',
+        'sort_breakdown_cpc asc',
+        'sort_breakdown_cpc desc',
+        'sort_breakdown_income asc',
+        'sort_breakdown_income desc',
+        'sort_breakdown_cost asc',
+        'sort_breakdown_cost desc',
+        'sort_breakdown_net asc',
+        'sort_breakdown_net desc',
+        'sort_breakdown_roi asc',
+        'sort_breakdown_roi desc',
+    ];
+
+    public function __construct(
+        public readonly string $reportType,
+        public readonly int $offset,
+        public readonly string $order,
+        public readonly bool $includeDependentFilters
+    ) {
+    }
+
+    public static function fromGlobals(): self
+    {
+        $method = strtoupper((string) ($_SERVER['REQUEST_METHOD'] ?? ''));
+        if ($method !== 'POST') {
+            throw new InvalidArgumentException('Only POST is supported for report dispatch.', 405);
+        }
+
+        $contentType = strtolower(trim((string) ($_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '')));
+        if (!str_starts_with($contentType, 'application/json')) {
+            throw new InvalidArgumentException('Content-Type must be application/json.', 415);
+        }
+
+        $rawBody = file_get_contents('php://input');
+        if (!is_string($rawBody) || trim($rawBody) === '') {
+            throw new InvalidArgumentException('Request body must contain a JSON object.', 400);
+        }
+
+        try {
+            $payload = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidArgumentException('Request body contains invalid JSON.', 400, $e);
+        }
+
+        if (!is_array($payload) || array_is_list($payload)) {
+            throw new InvalidArgumentException('Request body must decode to a JSON object.', 400);
+        }
+
+        return self::fromArray($payload);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $unknownKeys = array_diff(array_keys($payload), self::ALLOWED_KEYS);
+        if ($unknownKeys !== []) {
+            sort($unknownKeys);
+            throw new InvalidArgumentException(
+                'Unsupported request field(s): ' . implode(', ', $unknownKeys) . '.',
+                422
+            );
+        }
+
+        $reportType = trim((string) ($payload['reportType'] ?? ''));
+        if ($reportType === '') {
+            throw new InvalidArgumentException('reportType is required.', 422);
+        }
+
+        if (!in_array($reportType, self::SUPPORTED_REPORT_TYPES, true)) {
+            throw new InvalidArgumentException(
+                'Unsupported reportType "' . $reportType . '".',
+                422
+            );
+        }
+
+        // array_key_exists, not ??: an omitted field takes the default, but a field the
+        // client explicitly sent as null is malformed input and must be rejected rather
+        // than silently coalesced (CLAUDE.md #4).
+        $offset = array_key_exists('offset', $payload)
+            ? self::parseOffset($payload['offset'])
+            : 0;
+        $order = array_key_exists('order', $payload)
+            ? self::parseOrder($payload['order'])
+            : '';
+        $includeDependentFilters = array_key_exists('includeDependentFilters', $payload)
+            ? self::parseBoolean($payload['includeDependentFilters'], 'includeDependentFilters')
+            : true;
+
+        return new self($reportType, $offset, $order, $includeDependentFilters);
+    }
+
+    /**
+     * Adapt the new JSON transport onto the current report-generation seam.
+     */
+    public function applyLegacyGlobals(): void
+    {
+        $_POST = [];
+        $_POST['offset'] = (string) $this->offset;
+
+        if ($this->order !== '') {
+            $_POST['order'] = $this->order;
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function supportedOrderTokens(): array
+    {
+        return self::SUPPORTED_ORDER_TOKENS;
+    }
+
+    private static function parseOffset(mixed $value): int
+    {
+        if (is_int($value)) {
+            if ($value < 0) {
+                throw new InvalidArgumentException('offset must be greater than or equal to 0.', 422);
+            }
+
+            return $value;
+        }
+
+        if (is_string($value) && preg_match('/^\d+$/', $value) === 1) {
+            return (int) $value;
+        }
+
+        throw new InvalidArgumentException('offset must be a non-negative integer.', 422);
+    }
+
+    private static function parseOrder(mixed $value): string
+    {
+        if (!is_string($value)) {
+            throw new InvalidArgumentException('order must be a string.', 422);
+        }
+
+        $order = trim($value);
+        if (!in_array($order, self::SUPPORTED_ORDER_TOKENS, true)) {
+            throw new InvalidArgumentException('order is not a supported sort token.', 422);
+        }
+
+        return $order;
+    }
+
+    private static function parseBoolean(mixed $value, string $fieldName): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        throw new InvalidArgumentException($fieldName . ' must be a boolean.', 422);
+    }
+}

--- a/tracking202/ajax/report_dispatch.php
+++ b/tracking202/ajax/report_dispatch.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use Tracking202\Report\Json\FlatReportPayloadBuilder;
+use Tracking202\Report\Json\ReportDispatchRequest;
+
+include_once(substr(__DIR__, 0, -17) . '/202-config/connect.php');
+include_once(substr(__DIR__, 0, -17) . '/202-config/class-dataengine.php');
+
+if (!function_exists('tracking202ReportDispatchRespondJson')) {
+    /**
+     * @param array<string, mixed> $payload
+     */
+    function tracking202ReportDispatchRespondJson(int $status, array $payload): never
+    {
+        http_response_code($status);
+        header('Content-Type: application/json; charset=utf-8');
+
+        try {
+            echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            http_response_code(500);
+            echo '{"ok":false,"error":{"message":"Response encoding failed.","status":500}}';
+        }
+
+        exit;
+    }
+}
+
+if (!tracking202JsonArchitectureEnabled()) {
+    tracking202ReportDispatchRespondJson(404, [
+        'ok' => false,
+        'error' => [
+            'message' => 'Tracking JSON architecture mode is disabled.',
+            'status' => 404,
+        ],
+    ]);
+}
+
+if (!AUTH::logged_in()) {
+    tracking202ReportDispatchRespondJson(401, [
+        'ok' => false,
+        'error' => [
+            'message' => 'Authentication is required.',
+            'status' => 401,
+        ],
+    ]);
+}
+
+AUTH::require_user();
+AUTH::set_timezone($_SESSION['user_timezone']);
+
+try {
+    $request = ReportDispatchRequest::fromGlobals();
+    $request->applyLegacyGlobals();
+
+    $time = grab_timeframe();
+    $from = $db->real_escape_string((string) $time['from']);
+    $to = $db->real_escape_string((string) $time['to']);
+
+    $userId = $db->real_escape_string((string) $_SESSION['user_id']);
+    $userSql = "SELECT
+                    user_cpc_or_cpv,
+                    user_pref_aff_network_id,
+                    user_pref_aff_campaign_id,
+                    user_pref_text_ad_id,
+                    user_pref_method_of_promotion,
+                    user_pref_landing_page_id
+                FROM 202_users_pref
+                WHERE user_id=" . $userId;
+    $userResult = _mysqli_query($userSql);
+    if (!$userResult instanceof mysqli_result) {
+        // No silent fallback: swallowing this would default $cpv to false and cost the
+        // entire report as CPC for a CPV user — wrong numbers rather than an error.
+        // The Throwable handler below turns this into a clean JSON 500.
+        throw new RuntimeException('Failed to read user pricing preferences.');
+    }
+
+    $userRow = $userResult->fetch_assoc() ?? [];
+    $cpv = (($userRow['user_cpc_or_cpv'] ?? '') === 'cpv');
+
+    $dataEngine = new DataEngine();
+    $reportData = $dataEngine->getReportData($request->reportType, $from, $to, $cpv);
+
+    if (!is_array($reportData)) {
+        tracking202ReportDispatchRespondJson(500, [
+            'ok' => false,
+            'error' => [
+                'message' => 'Report data could not be generated.',
+                'status' => 500,
+            ],
+        ]);
+    }
+
+    tracking202ReportDispatchRespondJson(200, [
+        'ok' => true,
+        'transportVersion' => 1,
+        'generatedAt' => gmdate(DATE_ATOM),
+        'request' => [
+            'reportType' => $request->reportType,
+            'offset' => $request->offset,
+            'order' => $request->order,
+            'includeDependentFilters' => $request->includeDependentFilters,
+        ],
+        'report' => FlatReportPayloadBuilder::build(
+            $request->reportType,
+            $reportData,
+            (int) $dataEngine->foundRows(),
+            $request,
+            $userRow
+        ),
+        'supportedOrderTokens' => ReportDispatchRequest::supportedOrderTokens(),
+    ]);
+} catch (InvalidArgumentException $e) {
+    $status = (int) $e->getCode();
+    if ($status < 400 || $status > 499) {
+        $status = 400;
+    }
+
+    tracking202ReportDispatchRespondJson($status, [
+        'ok' => false,
+        'error' => [
+            'message' => $e->getMessage(),
+            'status' => $status,
+        ],
+    ]);
+} catch (Throwable $e) {
+    error_log('tracking202 report dispatch failed: ' . $e->getMessage());
+
+    tracking202ReportDispatchRespondJson(500, [
+        'ok' => false,
+        'error' => [
+            'message' => 'Unexpected server error while generating report data.',
+            'status' => 500,
+        ],
+    ]);
+}

--- a/tracking202/analyze/browsers.php
+++ b/tracking202/analyze/browsers.php
@@ -7,6 +7,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_browsers.php';
+$reportCanary = tracking202_report_canary_config('browser', $reportSortUrl);
+
 //show the template
 template_top('Analyze Browsers'); ?>
 <div class="row" style="margin-bottom: 15px;">
@@ -15,10 +18,14 @@ template_top('Analyze Browsers'); ?>
 	</div>
 </div>                                      
 
-<?php display_calendar(get_absolute_url().'tracking202/ajax/sort_browsers.php', true, true, true, true, true, true); ?> 
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
     
 <script type="text/javascript">
-   loadContent('<?php echo get_absolute_url();?>tracking202/ajax/sort_browsers.php',null);
+   loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php  template_bottom();

--- a/tracking202/analyze/cities.php
+++ b/tracking202/analyze/cities.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_cities.php';
+$reportCanary = tracking202_report_canary_config('city', $reportSortUrl);
+
 //show the template
 template_top('Analyze Incoming Cities'); ?>
 
@@ -17,10 +20,14 @@ template_top('Analyze Incoming Cities'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_cities.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_cities.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom();

--- a/tracking202/analyze/countries.php
+++ b/tracking202/analyze/countries.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_countries.php';
+$reportCanary = tracking202_report_canary_config('country', $reportSortUrl);
+
 //show the template
 template_top('Analyze Incoming Countries'); ?>
 
@@ -17,10 +20,14 @@ template_top('Analyze Incoming Countries'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_countries.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_countries.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom(); ?>

--- a/tracking202/analyze/devices.php
+++ b/tracking202/analyze/devices.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_devices.php';
+$reportCanary = tracking202_report_canary_config('device', $reportSortUrl);
+
 //show the template
 template_top('Analyze Devices'); ?>
 <div class="row" style="margin-bottom: 15px;">
@@ -16,10 +19,14 @@ template_top('Analyze Devices'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_devices.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_devices.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom();

--- a/tracking202/analyze/ips.php
+++ b/tracking202/analyze/ips.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_ips.php';
+$reportCanary = tracking202_report_canary_config('ip', $reportSortUrl);
+
 //show the template
 template_top('Analyze Incoming IP Addresses'); ?>
 
@@ -17,10 +20,14 @@ template_top('Analyze Incoming IP Addresses'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_ips.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_ips.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom();

--- a/tracking202/analyze/isp.php
+++ b/tracking202/analyze/isp.php
@@ -7,6 +7,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_isp.php';
+$reportCanary = tracking202_report_canary_config('isp', $reportSortUrl);
+
 //show the template
 template_top('Analyze Incoming ISP/Carrier'); ?>
 
@@ -16,10 +19,14 @@ template_top('Analyze Incoming ISP/Carrier'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url().'tracking202/ajax/sort_isp.php', true, true, true, true, true, true); ?> 
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
     
 <script type="text/javascript">
-   loadContent('<?php echo get_absolute_url();?>tracking202/ajax/sort_isp.php',null);
+   loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php  template_bottom();

--- a/tracking202/analyze/keywords.php
+++ b/tracking202/analyze/keywords.php
@@ -7,6 +7,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_keywords.php';
+$reportCanary = tracking202_report_canary_config('keyword', $reportSortUrl);
+
 //show the template
 template_top('Analyze Your Keywords'); ?>
 
@@ -16,10 +19,14 @@ template_top('Analyze Your Keywords'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url().'tracking202/ajax/sort_keywords.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-   loadContent('<?php echo get_absolute_url();?>tracking202/ajax/sort_keywords.php',null);
+   loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php  template_bottom();

--- a/tracking202/analyze/landing_pages.php
+++ b/tracking202/analyze/landing_pages.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_landing_pages.php';
+$reportCanary = tracking202_report_canary_config('landingpage', $reportSortUrl);
+
 //show the template
 template_top('Analyze Landing Pages'); ?>
 <div class="row" style="margin-bottom: 15px;">
@@ -16,10 +19,14 @@ template_top('Analyze Landing Pages'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_landing_pages.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_landing_pages.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom();

--- a/tracking202/analyze/platforms.php
+++ b/tracking202/analyze/platforms.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_platforms.php';
+$reportCanary = tracking202_report_canary_config('platform', $reportSortUrl);
+
 //show the template
 template_top('Analyze Platforms'); ?>
 <div class="row" style="margin-bottom: 15px;">
@@ -16,10 +19,14 @@ template_top('Analyze Platforms'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_platforms.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_platforms.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom();

--- a/tracking202/analyze/referers.php
+++ b/tracking202/analyze/referers.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_referers.php';
+$reportCanary = tracking202_report_canary_config('referer', $reportSortUrl);
+
 //show the template
 template_top('Analyze Incoming Referers'); ?>
 
@@ -17,10 +20,14 @@ template_top('Analyze Incoming Referers'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_referers.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_referers.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom();

--- a/tracking202/analyze/regions.php
+++ b/tracking202/analyze/regions.php
@@ -8,6 +8,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_regions.php';
+$reportCanary = tracking202_report_canary_config('region', $reportSortUrl);
+
 //show the template
 template_top('Analyze Incoming Regions'); ?>
 
@@ -17,10 +20,14 @@ template_top('Analyze Incoming Regions'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url() . 'tracking202/ajax/sort_regions.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-	loadContent('<?php echo get_absolute_url(); ?>tracking202/ajax/sort_regions.php', null);
+	loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php template_bottom(); ?>

--- a/tracking202/analyze/text_ads.php
+++ b/tracking202/analyze/text_ads.php
@@ -7,6 +7,9 @@ AUTH::require_user();
 //set the timezone for the user, for entering their dates.
 AUTH::set_timezone($_SESSION['user_timezone']);
 
+$reportSortUrl = get_absolute_url() . 'tracking202/ajax/sort_text_ads.php';
+$reportCanary = tracking202_report_canary_config('textad', $reportSortUrl);
+
 //show the template
 template_top('Analyze Your Text Advertisements'); ?>
 
@@ -16,10 +19,14 @@ template_top('Analyze Your Text Advertisements'); ?>
 	</div>
 </div>
 
-<?php display_calendar(get_absolute_url().'tracking202/ajax/sort_text_ads.php', true, true, true, true, true, true); ?>
+<?php display_calendar($reportSortUrl, true, true, true, true, true, true, true, false, [
+	'json_bootstrap_dependent_filters' => $reportCanary['dependentFilters']['jsonBootstrap'],
+]); ?>
+
+<?php tracking202_render_report_canary($reportCanary); ?>
 
 <script type="text/javascript">
-   loadContent('<?php echo get_absolute_url();?>tracking202/ajax/sort_text_ads.php',null);
+   loadContent('<?php echo $reportSortUrl; ?>', null);
 </script>
 
 <?php  template_bottom();


### PR DESCRIPTION
Two commits. The first ports a stranded feature onto current master; the second fixes a pre-existing `DataEngine` bug found while verifying it.

## 1. JSON report transport (`6e233f1a`)

Replaces the HTML-blob transport for the **12 flat Analyze reports** with a JSON one. `tracking202/ajax/report_dispatch.php` returns columns/rows/totals/pagination as data and `202-js/tracking-report.js` renders client-side. The four dependent-filter AJAX round-trips (aff campaign, text ad, landing page, ad preview) fold into that same response, and the six bounded filter dropdowns are rendered server-side instead of fetched — removing six more.

**Gated behind `TRACKING202_JSON_ARCHITECTURE_ENABLED`, default `false`.** Any transport or parse error trips the client back to the legacy path for that page load. `202-config-sample.php` documents how to enable it (the `define()` must follow `declare(strict_types=1)` or PHP fatals on load).

### Provenance

Salvaged from the abandoned `codex/tracking-json-merge-ready` branch. That branch could not be merged: it had gone stale against master (63 conflicts, including `modify/delete` on the Slim v2 API and other files master has since deleted), and it still carried the pre-decomposition `class-dataengine.php`. Its other 52 commits already shipped via #91, so only this work was salvageable — it is re-applied here on current master rather than merged.

### Fixes carried over the port

- **Server-side sorting was inert.** `DataEngine::sortOrder()` clobbered the posted token, so every report silently fell back to `ORDER BY leads DESC`. Master's `SortOrder::orderByClause()` already fixed that, so the seam works as designed here. A test pins the dispatcher's token whitelist to `SortOrder`'s so they cannot drift apart.
- **Static-filter SSR no longer honours `?tracking_json_mode`.** It runs six `GROUP BY` queries per page, and any logged-in user could previously turn that on from the query string. It now reads the deploy-time constant only.
- The inline canary config is emitted with `JSON_HEX_TAG`/`AMP`/`APOS`/`QUOT` and `JSON_THROW_ON_ERROR`. It was unchecked, so an encode failure emitted `window.x = ;` and killed the whole inline script.
- A failed user-prefs read no longer defaults `$cpv` to `false`, which silently costed a CPV user's entire report as CPC.
- The request parser rejected malformed input everywhere except explicit nulls, which `??` coalesced to defaults. `offset`/`order`/`includeDependentFilters` now reject `null`.
- Pagination reported a *clamped* offset, so an out-of-range request described an empty row set as the last page. It now reports the offset the query actually ran with, flags `outOfRange`, and points `previousOffset` at the last real page.
- Dependent-filter query failures logged `$db->error` instead of putting it in the exception message.

## 2. Pagination count fix (`4542fb6f`) — pre-existing, not from the port

Grouped reports `GROUP BY` the joined name (`region_name`, `text_ad_name`, `keyword`, …), but the pagination count ran a separate `COUNT(DISTINCT <foreign key>)` against `202_dataengine` with **none of the report's joins**. Those count different things: two ids sharing a name, or several ids whose lookup row was never written (they all `LEFT JOIN` to `NULL` and collapse into one `[no X]` group), make the count exceed the rows actually returned.

Inflated `totalRows` on region (13 vs 12), city (13 vs 12), isp (2 vs 1), textad (6 vs 5) and keyword (159 vs 158). Keyword is the clearest symptom: it advertised 159 rows while paging out 150 + 8 = 158. An overcount that crosses a page boundary advertises a trailing page that renders empty.

The count now counts the report's own `GROUP BY` over the report's own joins, with both queries building their `FROM/JOIN/WHERE` from one shared method so they cannot drift apart again. This generalises what the `referer` report already did — it was the only one counting its real grouping, and the only one that was correct. `countColumn` / `usesRefererCount` described the old, wrong count and are removed rather than left to invite it back.

**The legacy HTML reports share `DataEngine`, so they are fixed by the same change.**

Cost is a wash — the count already scanned `202_dataengine`, and the added lookup join is a PK hit on a small table. Measured on the real table: **9.06ms before vs 9.16ms after**.

## Verification

Exercised end-to-end against a real install (container on the worktree, real MySQL, logged-in session), not just linted:

- All 12 report types return rows **at parity with the legacy endpoint** — same values, same totals (5,497 clicks matched).
- Sorting works (`clicks asc` → 1, `clicks desc` → 289); previously inert.
- The six static-filter round-trips are gone; the three dependent-filter ones are suppressed under the flag and hydrated from the JSON response.
- With the flag off (the default), the page stays on the legacy path and the endpoint returns 404.
- Error paths return JSON `401`/`405`/`415`/`422`, not HTML — the endpoint does a JSON-friendly 401 pre-check before `AUTH::require_user()`, which would otherwise `die(include 202-access-denied.php)` into a JSON response.
- After the count fix, all 12 reports agree on rows vs `totalRows`, and keyword's paging arithmetic closes exactly.

The pagination-count regression test was checked against the *old* code: it fails on 11 of 12 reports, and `referer` correctly passes. The previous fixture left every dimension id at `0`, so the broken count happened to agree — that is why this went unnoticed. It now seeds distinct, unresolvable ids, which is what real data looks like.

**Tests:** 1174 (up from 1105 on master). The 4 failures are pre-existing `DlIntegrationTest` environment failures, identical on master — no regressions.