### PR TITLE
Add rolling-origin conformal prediction bounds and ensemble forecasting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,15 @@ To ensure code quality and functionality:
    composer install
    ```
 
+## Go CLI (`go-cli/`)
+
+The `p202` Go CLI is the intended interface for agents operating a Prosper202 instance.
+
+* **Using it as an agent**: read `docs/cli-agent.md` (JSON output shapes, the error envelope and its `hint` field, exit codes, workflows, tool-use schema hints). Always pass `--json`.
+* **Forecasting**: `documentation/cli/11-forecasting.md` explains `p202 forecast` end to end with real outputs (bands, ensemble, coherent metrics, seasonality, level shifts, transient masking).
+* **Changing the CLI**: follow the error contract in `CLAUDE.md` ("Go CLI errors must be agent-actionable"): categorized validation errors, `%w` wrapping, a hint on every error that leaves a choice, centralized printing, and tests on exit code and hint. Keep `documentation/cli/10-go-cli.md` ("Errors") and `docs/cli-agent.md` in sync with any change to that contract.
+* **Validation**: `cd go-cli && go vet ./... && go test ./...` (the forecast package's acceptance suites take ~20s; `-short` skips them).
+
 ## Agent Interaction Guidelines
 
 * **Context Exploration**: Review relevant files in `202-*` directories and configuration files before making changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,46 @@ DELETE/204 responses return empty arrays. Rendering an empty array produces no o
 ### 7. bind_param type string mismatches
 When building `bind_param($types, ...)` with many parameters, count types against values one-by-one. Integer timestamps bound as 's' work due to MySQL coercion but indicate sloppy code and can cause subtle issues with strict modes.
 
+## Go CLI errors must be agent-actionable (`go-cli/`)
+
+The CLI is built for AI agents as much as humans. An agent reads a failure
+once and must know what to do next without guessing, so every error path in
+`go-cli/cmd/` follows this contract (plumbing lives in `cmd/cli_errors.go`,
+`cmd/root.go`, and `internal/api/client.go`):
+
+1. **Categorize input errors.** Bad flags, missing values, unsupported
+   names: return `validationError(...)`, never a bare `fmt.Errorf`. The
+   category prints as `Error [validation]:` and sets exit code 1. API
+   failures already carry `auth`/`network`/`server`/`validation` from
+   `api.APIError`/`api.RequestError`.
+2. **Wrap with `%w`, never `%v`.** Exit codes and hints are resolved with
+   `errors.As` through the wrap chain; `fmt.Errorf("fetching: %v", err)`
+   would turn a 401 (exit 2) into a generic exit 1.
+3. **Attach a next step whenever the message alone leaves a choice.**
+   `validationError(...).WithHint("...")` for new errors, `withHint(err,
+   "...")` for wrapped ones. A good hint names the command that produces
+   the right value (`p202 tracker list`), the flag to change, or the
+   ordering to follow. Lists of valid values belong in the message itself.
+   Errors without a specific hint fall back to `Run <command> --help`.
+4. **Add class-wide hints in `api.HintFor`,** not per call site, when a
+   whole failure class has one remedy (401 key check, 404 use `list`, 409
+   update instead of create, 429 back off, 5xx `p202 system health`).
+5. **Never print errors yourself.** Return them; `Execute` prints the
+   `Error [category]: ... / Hint: ...` lines, or under `--json`/`--ndjson`
+   a single `{"error": {category, message, hint, exit_code, command,
+   http_status, field_errors}}` envelope on stderr. Stdout stays empty on
+   failure so scripts never mistake an error for data.
+6. **Test the contract, not just the message.** For a new error path
+   assert `exitCodeForError(err)` and, when a hint was added,
+   `hintFor(err)` (see `cmd/cli_errors_test.go` and the forecast hint
+   tests for the pattern).
+
+When adding a command, run it once with a wrong flag and once against a
+dead URL under `--json` and read the envelopes as an agent would: if either
+leaves you unsure what to do next, the error needs a hint. The user-facing
+contract is documented in `documentation/cli/10-go-cli.md` under "Errors";
+keep it in sync.
+
 ## Review discipline
 - Review every file individually. Batch scanning causes context overload and misses real bugs.
 - Read the file first, then think about what each line does, especially error paths.

--- a/README.md
+++ b/README.md
@@ -320,27 +320,82 @@ bin/p202 rotator:create --name "My Rotator"
 
 ### Go CLI (`go-cli/`)
 
-Cross-platform Go CLI with `--json` output for scripting and agent consumption.
-Failures are categorized with distinct exit codes and carry a recovery hint;
-under `--json` they arrive as a structured envelope on stderr (see
-[Errors](documentation/cli/10-go-cli.md#errors)).
+A single static binary for humans and AI agents. Every command has a table
+view for people and `--json` / `--csv` / `--ndjson` for scripts. Full
+reference: [Go CLI (p202)](documentation/cli/10-go-cli.md).
+
+**1. Set up once**
 
 ```bash
-cd go-cli
-make build
-
+cd go-cli && make build
 ./p202 config set-url https://your-server
 ./p202 config set-key <api-key>
-./p202 campaign list --json
-./p202 sync all
-./p202 forecast --all-metrics --horizon 14 --json
+./p202 config test            # verifies URL + key against the instance
 ```
 
-The CLI includes a dependency-free forecasting engine: calibrated prediction
-bands from rolling backtests, an accuracy-weighted ensemble, coherent
-clicks/leads/income/cost/net forecasts, seasonal profiles, level-shift
-handling, and masking of transient outages and spikes. See the
-[Forecasting Guide](documentation/cli/11-forecasting.md) for worked examples.
+**2. Use it**
+
+```bash
+./p202 campaign list --json                 # any entity: list / get / create / update / delete
+./p202 report summary --period last7
+./p202 forecast --metric revenue --horizon 7
+./p202 sync all --from prod --to staging    # replicate between instances
+```
+
+**3. Built for agents**
+
+Agents need to know, from a failure alone, what to do next. So:
+
+- **Exit codes mean something:** `1` bad input, `2` auth, `3` network,
+  `4` server error, `5` partial failure, and they hold through error
+  wrapping.
+- **Every error carries a recovery hint.** In human mode:
+
+  ```text
+  Error [auth]: fetching historical data: API error (401): invalid api key
+  Hint: Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong.
+  ```
+
+- **Under `--json` the error is a structured envelope on stderr** (stdout
+  stays empty), so nothing has to be parsed from prose:
+
+  ```json
+  {"error":{"category":"auth","message":"fetching historical data: API error (401): invalid api key","hint":"Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong.","exit_code":2,"command":"p202 forecast","http_status":401}}
+  ```
+
+  Details and the hint sources: [Errors](documentation/cli/10-go-cli.md#errors).
+
+**4. Forecasting**
+
+`p202 forecast` projects any metric forward from its history, locally, with
+no extra dependencies. Ask for one metric or all core metrics at once:
+
+```bash
+./p202 forecast --metric clicks --horizon 3 --json
+```
+
+```json
+{
+  "data": [
+    { "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 329.14, "upper_bound": 635.98, "p50": 557.68 }
+  ],
+  "meta": {
+    "method": "ensemble", "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 },
+    "bounds": "p05-p95 (90%)", "anomalies_masked": ["2026-07-25", "2026-07-26"], "rmse": 95.67
+  }
+}
+```
+
+What the output is telling you: an ensemble of three methods produced the
+point forecast; the band is the empirical 90% range from rolling backtests
+(not a normal-distribution guess); two days were recognised as a tracking
+outage and excluded from fitting; and the model's typical error on this
+series has been about 96 clicks. Beyond that, the engine keeps
+`leads = clicks × conv_rate` and `net = income − cost` exact across
+`--all-metrics`, applies weekday/hourly profiles only when the data really
+repeats, and fits the new level after a detected shift. Each of these is
+walked through with real output in the
+[Forecasting Guide](documentation/cli/11-forecasting.md).
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,9 @@ bin/p202 rotator:create --name "My Rotator"
 ### Go CLI (`go-cli/`)
 
 Cross-platform Go CLI with `--json` output for scripting and agent consumption.
+Failures are categorized with distinct exit codes and carry a recovery hint;
+under `--json` they arrive as a structured envelope on stderr (see
+[Errors](documentation/cli/10-go-cli.md#errors)).
 
 ```bash
 cd go-cli

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Since 2007, Prosper202 has helped marketers take control of their tracking with 
 - **Deep Linking** — Boost conversion rates by deep linking directly into apps, reducing friction for users.
 - **Team Access** — Full role-based authentication with no limit on users and no per-seat costs.
 - **API & CLI Tools** — Full REST API and CLI tools designed for both human developers and AI agents. Automate campaign management, pull reports, and integrate with your existing tools. CLI-first design works seamlessly with AI coding agents like Claude Code, Codex, and OpenClaw.
+- **Forecasting** — `p202 forecast` projects any metric forward with calibrated bands, coherent multi-metric output, seasonality, and anomaly handling ([guide](documentation/cli/11-forecasting.md))
 
 ## Requirements
 
@@ -329,7 +330,14 @@ make build
 ./p202 config set-key <api-key>
 ./p202 campaign list --json
 ./p202 sync all
+./p202 forecast --all-metrics --horizon 14 --json
 ```
+
+The CLI includes a dependency-free forecasting engine: calibrated prediction
+bands from rolling backtests, an accuracy-weighted ensemble, coherent
+clicks/leads/income/cost/net forecasts, seasonal profiles, level-shift
+handling, and masking of transient outages and spikes. See the
+[Forecasting Guide](documentation/cli/11-forecasting.md) for worked examples.
 
 ## Development Setup
 

--- a/docs/cli-agent.md
+++ b/docs/cli-agent.md
@@ -8,6 +8,7 @@ This document describes how to use the `p202` CLI from an AI agent, automation s
 2. **Always use `--force` on deletes** -- Interactive confirmation prompts will hang a non-interactive process.
 3. **Never rely on table column order** -- Use `--json` and parse the response fields by name.
 4. **Do not rely on interactive password prompts** -- In non-interactive runs, pass the password explicitly: `--user_pass "thepassword"`.
+5. **On failure, read the hint** -- Every error carries a category, exit code, and (almost always) a `hint` naming the next action. Follow it instead of guessing at flags. See [Error handling](#error-handling).
 
 ## Setup
 
@@ -83,28 +84,44 @@ Void operations print a plain-text success message to stdout. There is no JSON b
 
 ### Error
 
-Errors are printed to stderr and the process exits with code 1. The error message contains the API's error text or the HTTP status code.
+On failure nothing is written to stdout. With `--json` (or `--ndjson`) stderr carries exactly one JSON envelope:
+
+```json
+{"error":{"category":"auth","message":"fetching historical data: API error (401): invalid api key","hint":"Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong.","exit_code":2,"command":"p202 forecast","http_status":401}}
+```
+
+| Field | Present | Use it for |
+|-------|---------|------------|
+| `category` | always | Branching: `validation`, `auth`, `network`, `server`, `partial_failure` |
+| `message` | always | What failed (includes the API's own text when there is one) |
+| `hint` | when there is a next step | **Do this before retrying.** It names the command that produces the right value, the flag to change, or the order to follow |
+| `exit_code` | always | Same value the process exits with |
+| `command` | always | The command that ran, e.g. `p202 rotator create` |
+| `http_status` | API errors | The server's status code |
+| `field_errors` | 422 responses | `{field: message}` from the server; fix these fields and retry |
+
+Without `--json` the same information is two text lines: `Error [category]: message` and, when available, `Hint: ...`.
 
 ## Error handling
 
-| Exit code | Category | Meaning |
-|-----------|----------|---------|
-| 0 | | Success |
-| 1 | validation | Bad input, missing flags, invalid arguments |
-| 2 | auth | Authentication or authorization failure (401/403) |
-| 3 | network | Connection timeout, DNS failure, unreachable server |
-| 4 | server | API returned a 5xx error |
-| 5 | partial_failure | Bulk operation completed with some failures |
+| Exit code | Category | Meaning | Typical hint |
+|-----------|----------|---------|--------------|
+| 0 | | Success | |
+| 1 | validation | Bad input, missing flags, invalid arguments, or a 4xx other than auth | Lists valid values, or `Run <command> --help` |
+| 2 | auth | Authentication or authorization failure (401/403) | Check the key with `p202 config get` / `p202 config set-key` |
+| 3 | network | Connection timeout, DNS failure, unreachable server | Check the URL; `p202 config test` |
+| 4 | server | API returned a 5xx error | Retry after a wait; `p202 system health` |
+| 5 | partial_failure | Bulk operation completed with some failures | stderr lists the failed items |
 
-When parsing errors programmatically, check the exit code first. If non-zero, the stderr output contains the error description in the format `Error [category]: message`.
+Decision procedure for an agent:
 
-The API may return structured errors with field-level detail:
+1. Exit code 0: parse stdout as JSON.
+2. Otherwise read the envelope on stderr. If `hint` is present, it is the intended next action: follow it, then retry. Do not guess at flags.
+3. `category: auth` and `network` are environment problems, not input problems; do not vary the command, fix the configuration the hint names.
+4. `category: server`: safe to retry read-only commands (list, get, report, forecast) after a short wait; do not retry creates blindly (see Idempotency).
+5. `field_errors`: change exactly those fields.
 
-```
-Error [validation]: Validation failed
-  aff_campaign_name: required
-  aff_campaign_url: required
-```
+Exit codes are stable across error wrapping: a 401 surfaced as "fetching historical data: API error (401)" still exits 2.
 
 For bulk operations (`--ids`), exit code 5 indicates partial failure. The stdout summary shows `Deleted N of M <entity>.` and stderr lists individual failures.
 
@@ -202,6 +219,20 @@ p202 rotator rule-create "$ROTATOR_ID" \
 ```
 
 JSON fields (`--criteria_json`, `--redirects_json`, `--weighting_config`) are validated locally before the API call. Malformed JSON produces an immediate error.
+
+### Forecast next week and flag today as normal or anomalous
+
+```bash
+# 1. Forecast the metric; note lower_bound/upper_bound per date.
+p202 forecast --metric clicks --horizon 7 --json
+# 2. Today's actual, same filters.
+p202 report timeseries --interval day --period today --json
+# 3. Compare: today's total_clicks outside [lower_bound, upper_bound] for today's date
+#    means the day is outside the 90% band. If meta.anomalies_masked lists recent
+#    dates, the model already treated them as an outage/spike.
+```
+
+Use `--all-metrics` when you need clicks, leads, income, cost, and net that agree with each other (budget or revenue projections).
 
 ### Check system health
 
@@ -375,6 +406,36 @@ p202 report daypart    [-s sort_col] [--sort_dir ASC|DESC] [-p period] [filters.
 p202 report weekpart   [-s sort_col] [--sort_dir ASC|DESC] [-p period] [filters...] [--json]
 ```
 
+### Forecasting
+
+```
+p202 forecast --metric M   [-n horizon] [-i hour|day|week|month] [--history P]
+                           [--method auto|ensemble|linear|sma|wma|holtwinters]
+                           [--confidence 0.5|0.8|0.9] [--seasonal] [--seasonal-monthly]
+                           [--events] [--event-tag T1,T2] [--no-level-shift]
+                           [--no-anomaly-mask] [--anomaly-sigma N] [--anomaly-cycles N]
+                           [filters...] [--json]
+p202 forecast --all-metrics [-n horizon] [-i interval] [--history P] [filters...] [--json]
+```
+
+Metrics: `clicks`, `leads` (alias `conversions`), `revenue` (alias `income`), `cost`, `profit` (alias `net`), `epc`, `avg_cpc`, `conv_rate`, `roi`, `cpa`. `--all-metrics` returns clicks, leads, income, cost, and net in one row per date with the identities `leads = clicks × conv_rate` and `net = income − cost` holding exactly.
+
+Output rows carry the point forecast, `lower_bound`/`upper_bound` (the band `--confidence` selects; the meta's `bounds` names it), and the remaining quantile columns `p05`…`p95`. Read the meta before trusting a forecast:
+
+| Meta key | Meaning |
+|----------|---------|
+| `method`, `weights` | Method used; ensemble member shares |
+| `bounds`, `bounds_source` | Which quantile pair the band is; `conformal` (backtested) vs `gaussian` (history too short) |
+| `mae`, `rmse` | The forecaster's typical error on this series (rolling backtest) |
+| `data_points_used` | Points actually fitted after masking and level-shift truncation |
+| `anomalies_masked` | Dates excluded as transients (outage/spike) |
+| `level_shift_at` | First period of a detected new regime |
+| `composition`, `composition_fallback` | For derived metrics: `derived` (composed from drivers) or `direct`, and why |
+| `seasonal_applied`, `seasonal_profiles` | Whether a requested seasonal profile actually applied |
+| `buckets_rejected` | Response rows the parser could not use |
+
+Anomaly check for alerting: an observed value below `lower_bound` (or above `upper_bound`) of the band forecast for that date is outside the band's nominal coverage (90% at the default confidence). Full guide with worked examples: `documentation/cli/11-forecasting.md`.
+
 Report filter flags (all optional): `--aff_campaign_id`, `--ppc_account_id`, `--aff_network_id`, `--ppc_network_id`, `--landing_page_id`, `--country_id`.
 
 `dashboard` defaults `period=today` if omitted.
@@ -526,6 +587,7 @@ For tighter control, define separate tools per operation category:
 - `p202_update` -- Update a resource
 - `p202_delete` -- Delete a resource (always include --force)
 - `p202_report` -- Generate reports
+- `p202_forecast` -- Forecast a metric or all core metrics (read-only)
 - `p202_system` -- System diagnostics
 
 ### System prompt snippet
@@ -543,6 +605,8 @@ Rules:
 - Pagination: check pagination.total vs offset+limit to determine if more pages exist
 - The health endpoint (p202 system health) does not require authentication
 - All other endpoints require a valid API key configured via p202 config set-key
+- On a non-zero exit, read the JSON error envelope on stderr and follow its "hint" before retrying; category auth/network means fix configuration, not the command
+- p202 forecast is read-only and safe to retry; check meta.bounds_source, anomalies_masked, and level_shift_at before acting on a forecast
 ```
 
 ## Idempotency and safety
@@ -555,5 +619,6 @@ Rules:
 | delete | Yes | First call deletes, subsequent calls return 404 |
 | config set-url/set-key | Yes | Overwrites stored value |
 | report | Yes | None (read-only) |
+| forecast | Yes | None (read-only; deterministic for the same history) |
 
 For agents that may retry on failure: list, get, update, delete, and report commands are safe to retry. Create commands are not -- a retry may produce duplicates.

--- a/docs/cli-agent.md
+++ b/docs/cli-agent.md
@@ -411,7 +411,7 @@ p202 report weekpart   [-s sort_col] [--sort_dir ASC|DESC] [-p period] [filters.
 ```
 p202 forecast --metric M   [-n horizon] [-i hour|day|week|month] [--history P]
                            [--method auto|ensemble|linear|sma|wma|holtwinters]
-                           [--confidence 0.5|0.8|0.9] [--seasonal] [--seasonal-monthly]
+                           [--confidence 0.0-1.0] [--seasonal] [--seasonal-monthly]
                            [--events] [--event-tag T1,T2] [--no-level-shift]
                            [--no-anomaly-mask] [--anomaly-sigma N] [--anomaly-cycles N]
                            [filters...] [--json]
@@ -420,7 +420,7 @@ p202 forecast --all-metrics [-n horizon] [-i interval] [--history P] [filters...
 
 Metrics: `clicks`, `leads` (alias `conversions`), `revenue` (alias `income`), `cost`, `profit` (alias `net`), `epc`, `avg_cpc`, `conv_rate`, `roi`, `cpa`. `--all-metrics` returns clicks, leads, income, cost, and net in one row per date with the identities `leads = clicks × conv_rate` and `net = income − cost` holding exactly.
 
-Output rows carry the point forecast, `lower_bound`/`upper_bound` (the band `--confidence` selects; the meta's `bounds` names it), and the remaining quantile columns `p05`…`p95`. Read the meta before trusting a forecast:
+Output rows carry the point forecast, `lower_bound`/`upper_bound` (the band `--confidence` selects; the meta's `bounds` names it), and the remaining quantile columns `p05`…`p95`. `--confidence` takes any level (default 0.95) and snaps to the nearest emitted band: below 0.65 → p25–p75 (50%), below 0.85 → p10–p90 (80%), otherwise p05–p95 (90%); read `bounds` for the one delivered. Read the meta before trusting a forecast:
 
 | Meta key | Meaning |
 |----------|---------|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -551,6 +551,34 @@ p202 report weekpart --sort roi --sort_dir DESC --country_id 223
 | `-s, --sort`    | day_of_week  | Sort by: day_of_week, total_clicks, total_click_throughs, total_leads, total_income, total_cost, total_net, epc, avg_cpc, conv_rate, roi, cpa |
 | `--sort_dir`    | ASC          | Sort direction: ASC or DESC |
 
+## Forecasting
+
+`p202 forecast` projects any tracked metric forward from its history, entirely on the client, with calibrated prediction bands. Full guide with worked examples: [documentation/cli/11-forecasting.md](../documentation/cli/11-forecasting.md).
+
+```bash
+p202 forecast --metric revenue --horizon 7
+p202 forecast --metric clicks --interval hour --horizon 24
+p202 forecast --all-metrics --horizon 14 --json
+p202 forecast --metric profit --seasonal --events
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--metric`, `-m` | required unless `--all-metrics` | clicks, leads/conversions, revenue/income, cost, profit/net, epc, avg_cpc, conv_rate, roi, cpa |
+| `--all-metrics` | off | Clicks, leads, income, cost, net together, kept consistent (`net = income − cost`, `leads = clicks × conv_rate`) |
+| `--horizon`, `-n` | 7 | Periods to forecast (max 365) |
+| `--interval`, `-i` | day | hour, day, week, month |
+| `--history` | last90 (last30 hourly) | Training window |
+| `--method` | auto | auto/ensemble, linear, sma, wma, holtwinters |
+| `--confidence` | 0.95 | Band selection: <0.65 → p25–p75 (50%), <0.85 → p10–p90 (80%), else p05–p95 (90%) |
+| `--seasonal` | off | Weekday profile (plus hour-of-day for hourly), applied only when the data repeats at that lag |
+| `--seasonal-monthly` | off | Day-of-month profile (day interval, non-negative metrics) |
+| `--events`, `--event-tag` | off | Fold in stored forecast events (day interval) |
+| `--no-level-shift` | off | Do not fit only the newest regime after a detected level shift |
+| `--no-anomaly-mask`, `--anomaly-sigma`, `--anomaly-cycles` | off / 5 / 4 | Transient (outage/spike) masking controls |
+
+Each row carries the point forecast, `lower_bound`/`upper_bound`, and quantile columns; the meta reports the method and ensemble `weights`, `bounds`/`bounds_source`, rolling `mae`/`rmse`, `data_points_used`, `anomalies_masked`, `level_shift_at`, `composition`, and `seasonal_applied`. Forecasts are read-only and deterministic for the same history.
+
 ## Rotators
 
 ### List/get/create/update/delete rotators
@@ -874,7 +902,20 @@ p202 report daypart --period last30 --csv
 | 4    | server   | API returned a 5xx error |
 | 5    | partial_failure | Bulk operation completed with some failures |
 
-Error messages are printed to stderr in the format `Error [category]: message` when a category is available. Scripts can use the exit code to differentiate failure types without parsing error text.
+Errors go to stderr; stdout stays empty on failure. In human mode:
+
+```
+Error [auth]: fetching historical data: API error (401): invalid api key
+Hint: Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong.
+```
+
+With `--json` or `--ndjson` the same failure is one JSON envelope:
+
+```json
+{"error":{"category":"auth","message":"...","hint":"...","exit_code":2,"command":"p202 forecast","http_status":401}}
+```
+
+`field_errors` is added for 422 responses. Exit codes hold through error wrapping, and nearly every error carries a `hint` naming the next step (the command that yields the right value, the flag to change, or the order to follow); validation errors without a specific hint point at `<command> --help`. See the agent guide's [Error handling](cli-agent.md#error-handling) for the decision procedure.
 
 ## Telemetry
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -571,7 +571,7 @@ p202 forecast --metric profit --seasonal --events
 | `--history` | last90 (last30 hourly) | Training window |
 | `--method` | auto | auto/ensemble, linear, sma, wma, holtwinters |
 | `--confidence` | 0.95 | Band selection: <0.65 → p25–p75 (50%), <0.85 → p10–p90 (80%), else p05–p95 (90%) |
-| `--seasonal` | off | Weekday profile (plus hour-of-day for hourly), applied only when the data repeats at that lag |
+| `--seasonal` | off | Weekday profile learned from the fetched history (plus hour-of-day for hourly), applied only when the data repeats at that lag |
 | `--seasonal-monthly` | off | Day-of-month profile (day interval, non-negative metrics) |
 | `--events`, `--event-tag` | off | Fold in stored forecast events (day interval) |
 | `--no-level-shift` | off | Do not fit only the newest regime after a detected level shift |

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -51,6 +51,7 @@
 ### CLI Reference
 
 - [Go CLI (p202)](cli/10-go-cli.md) — cross-platform binary with multi-profile, sync, and diff
+- [Forecasting Guide](cli/11-forecasting.md) — how `p202 forecast` works, with worked examples: bands, ensemble, coherent metrics, seasonality, level shifts, transient masking
 
 A separate PHP/Symfony Console CLI also ships at `bin/p202` (run `php bin/p202 list` to see its commands); it does not yet have a dedicated reference page here.
 

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -164,6 +164,17 @@ p202 forecast --metric clicks --history last90 --method linear
 p202 forecast --metric profit --horizon 14 --method auto --seasonal
 ```
 
+Prediction bounds come from rolling-origin conformal prediction: the model is
+re-fit at up to 50 cut points stepping back from the end of the history, and
+held-out errors are bucketed by horizon step. `lower_bound`/`upper_bound` are
+the empirical P10/P90 of those errors (an 80% interval; `--confidence` below
+0.65 switches to P25/P75, a 50% interval), so bounds are asymmetric when the
+errors are. Each prediction also carries `p25`/`p50`/`p75` columns (`p50` is
+the bias-corrected median path). Reported `mae`/`rmse` are averages across
+all rolling cut points. Metrics that cannot go negative (clicks, leads, cost,
+income, rates) have bounds clipped at zero; very short histories (fewer than
+~9 points) fall back to symmetric Gaussian bounds without quantile columns.
+
 With `--seasonal`, predictions are modulated by day-of-week weights derived from
 weekpart report data (requires `--interval day` or `hour`). Event-aware
 forecasting (`--events`, `--event-tag`) folds in stored [forecast

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -166,7 +166,25 @@ clearly trail the best, and reports each member's share in the output meta
 p202 forecast --metric revenue --horizon 7
 p202 forecast --metric clicks --history last90 --method linear
 p202 forecast --metric profit --horizon 14 --method auto --seasonal
+p202 forecast --all-metrics --horizon 7
 ```
+
+Derived metrics (leads, income, cost, net) requested on their own are
+forecast by ratio decomposition: clicks and the linking rates (conversion
+rate, average CPC, average payout) are forecast as drivers and the totals
+composed from them, so `leads = clicks × conv_rate`, `income = leads ×
+avg_payout`, and `net = income − cost` hold exactly across the output. The
+meta reports `composition: derived`, or `direct` when a driver is defined on
+too few days (under ~70% of buckets) and the metric's own series is forecast
+instead. `--all-metrics` forecasts clicks, leads, income, cost, and net
+together this way in one table (one row per date with `<metric>`,
+`<metric>_lower`, `<metric>_upper` columns); it cannot be combined with
+`--metric`, `--seasonal`, or `--events`, and `--seasonal`/`--events` on a
+single derived metric keep the direct path since those layers operate on the
+metric's own series. Composed band endpoints combine conservatively
+(worst-case dependence between factors), so derived bands can over-cover
+slightly; derived rows carry no `mae`/`rmse` since rolling errors are only
+measured for directly fitted series.
 
 Prediction bounds come from rolling-origin conformal prediction: the model is
 re-fit at up to 50 cut points stepping back from the end of the history, and

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -207,7 +207,48 @@ p202 config get-default report.period
 p202 config unset-default report.period
 ```
 
-## Exit Codes
+## Errors
+
+Every failure is reported on **stderr** with a category, the message, and,
+whenever there is a concrete next step, a recovery hint. Stdout stays empty
+on failure, so a script never confuses an error for data. Exit codes follow
+the category (table below) and survive wrapping: "fetching historical data:
+API error (401)" still exits 2.
+
+Human mode:
+
+```text
+Error [auth]: fetching historical data: API error (401): invalid api key
+Hint: Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong.
+```
+
+With `--json` or `--ndjson` the same failure is a single JSON envelope, so
+an agent reads structured fields instead of parsing prose:
+
+```json
+{"error":{"category":"auth","message":"fetching historical data: API error (401): invalid api key","hint":"Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong.","exit_code":2,"command":"p202 forecast","http_status":401}}
+```
+
+| Field | Always | Meaning |
+| --- | --- | --- |
+| `category` | yes | `validation`, `auth`, `network`, `server`, or `partial_failure` |
+| `message` | yes | What failed |
+| `exit_code` | yes | The process exit code (table below) |
+| `command` | yes | The command that ran, e.g. `p202 rotator create` |
+| `hint` | when known | The recovery step to take next |
+| `http_status` | API errors | The server's status code |
+| `field_errors` | 422 responses | Per-field messages from the server |
+
+Hints come from three sources, in order of precedence: a hint attached by
+the command itself (for example, the metrics the response *did* contain
+when the requested one is missing, or the dependency order to sync first
+when a foreign key cannot be resolved); a generic hint for the failure
+class (401/403 key check, 404 use `list` for ids, 409 update instead of
+create, 429 back off, 5xx retry then `p202 system health`, network check the
+URL and `p202 config test`); and for any remaining validation error, a
+pointer to `<command> --help`.
+
+### Exit Codes
 
 | Code | Meaning |
 | ---- | ------- |

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -155,8 +155,12 @@ Aliases: `--group-by lp` -> `landing_page`, `--sort conversions` -> `total_leads
 ## Forecasting
 
 Project any tracked metric forward from historical time-series data. Supports
-linear regression, simple and weighted moving averages, Holt-Winters
-exponential smoothing, and automatic method selection via backtesting.
+linear regression, simple and weighted moving averages, damped-trend
+Holt-Winters exponential smoothing, and an ensemble — the default (`--method
+auto` is an alias for `ensemble`) — that averages the methods weighted by
+their recency-discounted rolling-backtest accuracy, drops members that
+clearly trail the best, and reports each member's share in the output meta
+(`weights`).
 
 ```bash
 p202 forecast --metric revenue --horizon 7

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -154,96 +154,40 @@ Aliases: `--group-by lp` -> `landing_page`, `--sort conversions` -> `total_leads
 
 ## Forecasting
 
-Project any tracked metric forward from historical time-series data. Supports
-linear regression, simple and weighted moving averages, damped-trend
-Holt-Winters exponential smoothing, and an ensemble — the default (`--method
-auto` is an alias for `ensemble`) — that averages the methods weighted by
-their recency-discounted rolling-backtest accuracy, drops members that
-clearly trail the best, and reports each member's share in the output meta
-(`weights`).
+Project any tracked metric forward from historical time-series data, with
+calibrated prediction bands, an accuracy-weighted ensemble of methods,
+coherent multi-metric output, seasonal profiles, level-shift handling, and
+transient (outage/spike) masking. The full guide with worked examples is
+[Forecasting Guide](11-forecasting.md).
 
 ```bash
 p202 forecast --metric revenue --horizon 7
 p202 forecast --metric clicks --history last90 --method linear
-p202 forecast --metric profit --horizon 14 --method auto --seasonal
-p202 forecast --all-metrics --horizon 7
+p202 forecast --metric profit --horizon 14 --seasonal --events
+p202 forecast --all-metrics --horizon 7 --json
 ```
 
-Derived metrics (leads, income, cost, net) requested on their own are
-forecast by ratio decomposition: clicks and the linking rates (conversion
-rate, average CPC, average payout) are forecast as drivers and the totals
-composed from them, so `leads = clicks × conv_rate`, `income = leads ×
-avg_payout`, and `net = income − cost` hold exactly across the output. The
-meta reports `composition: derived`, or `direct` when a driver is defined on
-too few days (under ~70% of buckets) and the metric's own series is forecast
-instead. `--all-metrics` forecasts clicks, leads, income, cost, and net
-together this way in one table (one row per date with `<metric>`,
-`<metric>_lower`, `<metric>_upper` columns); it cannot be combined with
-`--metric`, `--seasonal`, `--seasonal-monthly`, `--events`, or
-`--event-tag`, and those flags on a single derived metric keep the direct
-path since the layers operate on the metric's own series. When composition
-is impossible (companion metrics missing from the response, or a driver
-too sparse to forecast), the direct path serves the forecast with
-`composition: direct` and a `composition_fallback` reason in the meta.
-Composed band endpoints combine conservatively (worst-case dependence
-between factors), so derived bands can over-cover slightly, and
-`bounds_source` reads `mixed` when the composed operands' bounds came from
-different methods; derived rows carry no `mae`/`rmse` since rolling errors
-are only measured for directly fitted series.
+Key behaviors, each detailed in the guide:
 
-Prediction bounds come from rolling-origin conformal prediction: the model is
-re-fit at up to 50 cut points stepping back from the end of the history, and
-held-out errors are bucketed by horizon step. `lower_bound`/`upper_bound` are
-the empirical quantile pair nearest `--confidence`: P25/P75 for levels under
-0.65 (a 50% band), P10/P90 under 0.85 (80%), and P05/P95 otherwise (90% —
-the widest band the residual pool supports, so the default 0.95 and 0.99
-both get it). The meta's `bounds` names the pair in use, and bounds are
-asymmetric when the errors are. Each prediction also carries the remaining
-quantile columns (`p05`…`p95`; `p50` is the bias-corrected median path).
-Reported `mae`/`rmse` are averages across all rolling cut points. Metrics
-that cannot go negative (clicks, leads, cost, income, rates) have bounds
-clipped at zero. Conformal bounds need at least 8 held-out residuals, which
-takes roughly 12 points at a 4+ step horizon and 16 at `--horizon 1`;
-shorter histories fall back to symmetric Gaussian bounds (which do honor the
-exact confidence level) without quantile columns — the meta's
-`bounds_source` says which applied.
-
-With `--seasonal`, predictions are modulated by day-of-week weights derived
-from weekpart report data (requires `--interval day` or `hour`); hourly
-forecasts also get an hour-of-day profile learned from the series, and
-`--seasonal-monthly` (day interval, non-negative metrics only) adds
-day-of-month weights for monthly budget/payout resets. Profile multipliers
-are shrunk toward 1.0 when a slot has few samples, and weekday/hourly
-profiles only apply when the series actually shows structure at that lag
-(detrended autocorrelation ≥ 0.3; a history too short to measure the lag
-applies the profile as supplied) — the meta's `seasonal_applied` and
-`seasonal_profiles` report the outcome. Count metrics (clicks,
-click-throughs, leads) are fitted on log1p scale and inverted on output, so
-multiplicative growth extrapolates correctly. When a level shift is detected
-(offer paused, traffic source added), the model fits the new regime —
-truncating or re-leveling pre-shift history — and reports the boundary in
-the meta as `level_shift_at`; `data_points_used` then counts the points
-actually fitted. A transient burst (a two-day tracking outage, an untagged
-promo spike) is not a shift: short outlier runs that are abnormal *for this
-series at that point of its cycle* (compared with the same weekday or hour
-in the surrounding weeks, so a business closed on Sundays or a low-volume
-tracker is never affected) and at least halved or doubled relative to that
-reference are masked from fitting and listed in the meta
-as `anomalies_masked`, keeping the bands at the healthy level so the
-alerting layer still flags the outage. Runs of five or more points are a
-regime change and go to the shift detector instead. `--no-anomaly-mask`
-fits every point as data, `--anomaly-sigma` (default 5) and
-`--anomaly-cycles` (default 4) tune how far a point must deviate and how
-many surrounding weeks supply its reference, and `--no-level-shift` fits
-the full history as-is if the detector misreads a known transient; tagging known outages and
-promos as events remains the explicit override for both. Event-aware forecasting (`--events`,
-`--event-tag`) folds in stored [forecast
-events](../api/18-forecast-events.md) and requires `--interval day`:
-
-```bash
-p202 forecast --metric revenue --events --horizon 14
-p202 forecast --metric clicks --events --event-tag us-holidays
-```
+- **Bands** (`lower_bound`/`upper_bound`, plus `p05`…`p95` columns) come from
+  rolling-origin conformal prediction; `--confidence` snaps to a 50%, 80%,
+  or 90% band and the meta's `bounds` names the one in use. Histories under
+  ~12 points fall back to Gaussian bands (`bounds_source`).
+- **`--method auto`** is an ensemble weighted by recent rolling accuracy;
+  the meta's `weights` shows each member's share.
+- **Derived metrics** (leads, income, cost, net, or `--all-metrics`) are
+  composed from driver forecasts so `net = income − cost` and
+  `leads = clicks × conv_rate` hold exactly (`composition` in meta).
+- **`--seasonal`** applies shrunk weekday (and hourly) profiles only when
+  the series repeats at that lag (`seasonal_applied`); `--seasonal-monthly`
+  adds a day-of-month profile for non-negative metrics.
+- **Level shifts** are detected and the new regime fitted
+  (`level_shift_at`; `--no-level-shift` to disable). **Transients** such as a
+  two-day tracking outage are masked from fitting and listed in
+  `anomalies_masked` (`--no-anomaly-mask`, `--anomaly-sigma`,
+  `--anomaly-cycles`).
+- **`--events` / `--event-tag`** fold in stored
+  [forecast events](../api/18-forecast-events.md) (day interval only).
 
 ## Bulk Operations
 

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -231,8 +231,10 @@ tracker is never affected) are masked from fitting and listed in the meta
 as `anomalies_masked`, keeping the bands at the healthy level so the
 alerting layer still flags the outage. Runs of five or more points are a
 regime change and go to the shift detector instead. `--no-anomaly-mask`
-fits every point as data, and `--no-level-shift` fits the full history
-as-is if the detector misreads a known transient; tagging known outages and
+fits every point as data, `--anomaly-sigma` (default 5) and
+`--anomaly-cycles` (default 4) tune how far a point must deviate and how
+many surrounding weeks supply its reference, and `--no-level-shift` fits
+the full history as-is if the detector misreads a known transient; tagging known outages and
 promos as events remains the explicit override for both. Event-aware forecasting (`--events`,
 `--event-tag`) folds in stored [forecast
 events](../api/18-forecast-events.md) and requires `--interval day`:

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -210,8 +210,10 @@ p202 config unset-default report.period
 ## Errors
 
 Every failure is reported on **stderr** with a category, the message, and,
-whenever there is a concrete next step, a recovery hint. Stdout stays empty
-on failure, so a script never confuses an error for data. Exit codes follow
+whenever there is a concrete next step, a recovery hint, including failures
+the CLI raises before running the command (a wrong argument count, an
+unknown subcommand). Stdout stays empty on failure, so a script never
+confuses an error for data. Exit codes follow
 the category (table below) and survive wrapping: "fetching historical data:
 API error (401)" still exits 2.
 

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -197,9 +197,20 @@ all rolling cut points. Metrics that cannot go negative (clicks, leads, cost,
 income, rates) have bounds clipped at zero; very short histories (fewer than
 ~9 points) fall back to symmetric Gaussian bounds without quantile columns.
 
-With `--seasonal`, predictions are modulated by day-of-week weights derived from
-weekpart report data (requires `--interval day` or `hour`). Event-aware
-forecasting (`--events`, `--event-tag`) folds in stored [forecast
+With `--seasonal`, predictions are modulated by day-of-week weights derived
+from weekpart report data (requires `--interval day` or `hour`); hourly
+forecasts also get an hour-of-day profile learned from the series, and
+`--seasonal-monthly` (day interval) adds day-of-month weights for monthly
+budget/payout resets. Profile multipliers are shrunk toward 1.0 when a slot
+has few samples, and weekday/hourly profiles only apply when the series
+actually shows structure at that lag (detrended autocorrelation ≥ 0.3) —
+the meta's `seasonal_applied` reports the outcome. Count metrics (clicks,
+click-throughs, leads) are fitted on log1p scale and inverted on output, so
+multiplicative growth extrapolates correctly. When a level shift is detected
+(offer paused, traffic source added), the model fits the new regime —
+truncating or re-leveling pre-shift history — and reports the boundary in
+the meta as `level_shift_at`. Event-aware forecasting (`--events`,
+`--event-tag`) folds in stored [forecast
 events](../api/18-forecast-events.md) and requires `--interval day`:
 
 ```bash

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -223,10 +223,17 @@ multiplicative growth extrapolates correctly. When a level shift is detected
 (offer paused, traffic source added), the model fits the new regime —
 truncating or re-leveling pre-shift history — and reports the boundary in
 the meta as `level_shift_at`; `data_points_used` then counts the points
-actually fitted. A transient burst at the end of the history (a two-day
-tracking outage, a promo spike) is not treated as a shift; if the detector
-still misreads a known transient, `--no-level-shift` fits the full history
-as-is. Event-aware forecasting (`--events`,
+actually fitted. A transient burst (a two-day tracking outage, an untagged
+promo spike) is not a shift: short outlier runs that are abnormal *for this
+series at that point of its cycle* (compared with the same weekday or hour
+in the surrounding weeks, so a business closed on Sundays or a low-volume
+tracker is never affected) are masked from fitting and listed in the meta
+as `anomalies_masked`, keeping the bands at the healthy level so the
+alerting layer still flags the outage. Runs of five or more points are a
+regime change and go to the shift detector instead. `--no-anomaly-mask`
+fits every point as data, and `--no-level-shift` fits the full history
+as-is if the detector misreads a known transient; tagging known outages and
+promos as events remains the explicit override for both. Event-aware forecasting (`--events`,
 `--event-tag`) folds in stored [forecast
 events](../api/18-forecast-events.md) and requires `--interval day`:
 

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -227,7 +227,8 @@ actually fitted. A transient burst (a two-day tracking outage, an untagged
 promo spike) is not a shift: short outlier runs that are abnormal *for this
 series at that point of its cycle* (compared with the same weekday or hour
 in the surrounding weeks, so a business closed on Sundays or a low-volume
-tracker is never affected) are masked from fitting and listed in the meta
+tracker is never affected) and at least halved or doubled relative to that
+reference are masked from fitting and listed in the meta
 as `anomalies_masked`, keeping the bands at the healthy level so the
 alerting layer still flags the outage. Runs of five or more points are a
 regime change and go to the shift detector instead. `--no-anomaly-mask`

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -239,14 +239,16 @@ an agent reads structured fields instead of parsing prose:
 | `http_status` | API errors | The server's status code |
 | `field_errors` | 422 responses | Per-field messages from the server |
 
-Hints come from three sources, in order of precedence: a hint attached by
-the command itself (for example, the metrics the response *did* contain
-when the requested one is missing, or the dependency order to sync first
-when a foreign key cannot be resolved); a generic hint for the failure
-class (401/403 key check, 404 use `list` for ids, 409 update instead of
-create, 429 back off, 5xx retry then `p202 system health`, network check the
-URL and `p202 config test`); and for any remaining validation error, a
-pointer to `<command> --help`.
+Lists of valid values (supported entities, the metrics a response did
+contain) sit in the message itself, so they are visible even when the hint
+is ignored; the hint carries the next action. Hints come from three sources,
+in order of precedence: a hint attached by the command itself (for example,
+which flag to change when the requested metric is missing, or the dependency
+order to sync first when a foreign key cannot be resolved); a generic hint
+for the failure class (401/403 key check, 404 use `list` for ids, 409 update
+instead of create, 429 back off, 5xx retry then `p202 system health`,
+network check the URL and `p202 config test`); and for any remaining
+validation error, a pointer to `<command> --help`.
 
 ### Exit Codes
 

--- a/documentation/cli/10-go-cli.md
+++ b/documentation/cli/10-go-cli.md
@@ -179,37 +179,54 @@ too few days (under ~70% of buckets) and the metric's own series is forecast
 instead. `--all-metrics` forecasts clicks, leads, income, cost, and net
 together this way in one table (one row per date with `<metric>`,
 `<metric>_lower`, `<metric>_upper` columns); it cannot be combined with
-`--metric`, `--seasonal`, or `--events`, and `--seasonal`/`--events` on a
-single derived metric keep the direct path since those layers operate on the
-metric's own series. Composed band endpoints combine conservatively
-(worst-case dependence between factors), so derived bands can over-cover
-slightly; derived rows carry no `mae`/`rmse` since rolling errors are only
-measured for directly fitted series.
+`--metric`, `--seasonal`, `--seasonal-monthly`, `--events`, or
+`--event-tag`, and those flags on a single derived metric keep the direct
+path since the layers operate on the metric's own series. When composition
+is impossible (companion metrics missing from the response, or a driver
+too sparse to forecast), the direct path serves the forecast with
+`composition: direct` and a `composition_fallback` reason in the meta.
+Composed band endpoints combine conservatively (worst-case dependence
+between factors), so derived bands can over-cover slightly, and
+`bounds_source` reads `mixed` when the composed operands' bounds came from
+different methods; derived rows carry no `mae`/`rmse` since rolling errors
+are only measured for directly fitted series.
 
 Prediction bounds come from rolling-origin conformal prediction: the model is
 re-fit at up to 50 cut points stepping back from the end of the history, and
 held-out errors are bucketed by horizon step. `lower_bound`/`upper_bound` are
-the empirical P10/P90 of those errors (an 80% interval; `--confidence` below
-0.65 switches to P25/P75, a 50% interval), so bounds are asymmetric when the
-errors are. Each prediction also carries `p25`/`p50`/`p75` columns (`p50` is
-the bias-corrected median path). Reported `mae`/`rmse` are averages across
-all rolling cut points. Metrics that cannot go negative (clicks, leads, cost,
-income, rates) have bounds clipped at zero; very short histories (fewer than
-~9 points) fall back to symmetric Gaussian bounds without quantile columns.
+the empirical quantile pair nearest `--confidence`: P25/P75 for levels under
+0.65 (a 50% band), P10/P90 under 0.85 (80%), and P05/P95 otherwise (90% —
+the widest band the residual pool supports, so the default 0.95 and 0.99
+both get it). The meta's `bounds` names the pair in use, and bounds are
+asymmetric when the errors are. Each prediction also carries the remaining
+quantile columns (`p05`…`p95`; `p50` is the bias-corrected median path).
+Reported `mae`/`rmse` are averages across all rolling cut points. Metrics
+that cannot go negative (clicks, leads, cost, income, rates) have bounds
+clipped at zero. Conformal bounds need at least 8 held-out residuals, which
+takes roughly 12 points at a 4+ step horizon and 16 at `--horizon 1`;
+shorter histories fall back to symmetric Gaussian bounds (which do honor the
+exact confidence level) without quantile columns — the meta's
+`bounds_source` says which applied.
 
 With `--seasonal`, predictions are modulated by day-of-week weights derived
 from weekpart report data (requires `--interval day` or `hour`); hourly
 forecasts also get an hour-of-day profile learned from the series, and
-`--seasonal-monthly` (day interval) adds day-of-month weights for monthly
-budget/payout resets. Profile multipliers are shrunk toward 1.0 when a slot
-has few samples, and weekday/hourly profiles only apply when the series
-actually shows structure at that lag (detrended autocorrelation ≥ 0.3) —
-the meta's `seasonal_applied` reports the outcome. Count metrics (clicks,
+`--seasonal-monthly` (day interval, non-negative metrics only) adds
+day-of-month weights for monthly budget/payout resets. Profile multipliers
+are shrunk toward 1.0 when a slot has few samples, and weekday/hourly
+profiles only apply when the series actually shows structure at that lag
+(detrended autocorrelation ≥ 0.3; a history too short to measure the lag
+applies the profile as supplied) — the meta's `seasonal_applied` and
+`seasonal_profiles` report the outcome. Count metrics (clicks,
 click-throughs, leads) are fitted on log1p scale and inverted on output, so
 multiplicative growth extrapolates correctly. When a level shift is detected
 (offer paused, traffic source added), the model fits the new regime —
 truncating or re-leveling pre-shift history — and reports the boundary in
-the meta as `level_shift_at`. Event-aware forecasting (`--events`,
+the meta as `level_shift_at`; `data_points_used` then counts the points
+actually fitted. A transient burst at the end of the history (a two-day
+tracking outage, a promo spike) is not treated as a shift; if the detector
+still misreads a known transient, `--no-level-shift` fits the full history
+as-is. Event-aware forecasting (`--events`,
 `--event-tag`) folds in stored [forecast
 events](../api/18-forecast-events.md) and requires `--interval day`:
 

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -40,8 +40,8 @@ metric, `Run` does the following, in this order:
 | 3. Transient masking | Short outlier runs that are abnormal *for this series at that point of its week* are removed from fitting. Section 7. | `anomalies_masked` |
 | 4. Level-shift handling | If the series changed level (offer paused, new source), the model fits the new regime. Section 6. | `level_shift_at`, `data_points_used` |
 | 5. Fit | The chosen method, or the ensemble of all of them. Section 3. | `method`, `weights` |
-| 6. Bounds | Rolling-origin backtest residuals become empirical prediction bands. Section 4. | `lower_bound`, `upper_bound`, `p05`…`p95`, `bounds`, `bounds_source`, `mae`, `rmse` |
-| 7. Seasonal profiles | Weekday / hourly / day-of-month multipliers, if requested and supported by the data. Section 8. | `seasonal_applied`, `seasonal_profiles` |
+| 6. Seasonal profiles | Weekday / hourly / day-of-month multipliers, if requested and supported by the data, applied inside the fit and inside every backtest fold. Section 8. | `seasonal_applied`, `seasonal_profiles` |
+| 7. Bounds | Rolling-origin backtest residuals of the forecaster as emitted (profiles included) become empirical prediction bands. Section 4. | `lower_bound`, `upper_bound`, `p05`…`p95`, `bounds`, `bounds_source`, `mae`, `rmse` |
 | 8. Events | Calendar events scale the affected days. Section 9. | `events_in_horizon` |
 | 9. Clip | Metrics that cannot go negative are floored at zero. | |
 
@@ -75,7 +75,7 @@ shapes the weights that predict it.
 "meta": {
   "method": "ensemble",
   "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 },
-  "mae": 84.85, "rmse": 95.67, ...
+  "mae": 84.58, "rmse": 96.17, ...
 }
 ```
 
@@ -123,21 +123,21 @@ row:
 {
   "date": "2026-07-31",
   "total_clicks": 497.94,
-  "lower_bound": 329.14, "upper_bound": 635.98,
-  "p10": 355.86, "p25": 402.65, "p50": 557.68, "p75": 590.94, "p90": 633.31
+  "lower_bound": 318.64, "upper_bound": 640.12,
+  "p10": 355.99, "p25": 402.73, "p50": 554.77, "p75": 587.52, "p90": 626.25
 }
 ```
 
 and with `--confidence 0.5`:
 
 ```json
-{ "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 402.65, "upper_bound": 590.94, "p50": 557.68 }
+{ "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 402.73, "upper_bound": 587.52, "p50": 554.77 }
 ```
 
 Reading it:
 
 - `total_clicks` (497.94) is the point forecast: the ensemble's value.
-- `p50` (557.68) is the **bias-corrected median**: the point forecast plus
+- `p50` (554.77) is the **bias-corrected median**: the point forecast plus
   the median of the model's recent errors. When it sits far from the point
   forecast, as here, the model has been systematically off in that
   direction lately. In this example the series has a strong weekday pattern
@@ -204,17 +204,21 @@ p202 forecast --all-metrics --horizon 3 --json
   "data": [
     {
       "date": "2026-07-31",
-      "total_clicks": 497.94, "total_clicks_lower": 329.14, "total_clicks_upper": 635.98,
-      "total_leads":   39.72, "total_leads_lower":   26.11, "total_leads_upper":   52.91,
-      "total_cost":   212.28, "total_cost_lower":   140.25, "total_cost_upper":   273.93,
-      "total_income": 382.93, "total_income_lower": 228.15, "total_income_upper": 512.24,
-      "total_net":    170.65, "total_net_lower":    85.44, "total_net_upper":    263.3
+      "total_clicks": 497.94, "total_clicks_lower": 318.64, "total_clicks_upper": 640.12,
+      "total_leads":   39.72, "total_leads_lower":   25.03, "total_leads_upper":   52.92,
+      "total_cost":   212.28, "total_cost_lower":   139.95, "total_cost_upper":   273.95,
+      "total_income": 382.93, "total_income_lower": 223.68, "total_income_upper": 512.31,
+      "total_net":    170.65, "total_net_lower":    83.6,  "total_net_upper":    263.25
     }
   ],
   "meta": {
     "composition": {
       "total_clicks": "direct", "total_leads": "derived", "total_cost": "derived",
       "total_income": "derived", "total_net": "derived"
+    },
+    "bounds": {
+      "total_clicks": "p05-p95 (90%)", "total_leads": "p05-p95 (90%)", "total_cost": "p05-p95 (90%)",
+      "total_income": "p05-p95 (90%)", "total_net": "p05-p95 (90%)"
     },
     "bounds_source": {
       "total_clicks": "conformal", "total_leads": "conformal", "total_cost": "conformal",
@@ -245,9 +249,10 @@ observed derived value, and turns those residuals into the derived metric's
 own empirical quantiles, band, `mae`, and `rmse`. `total_net_lower` above is
 therefore a calibrated 90% floor for net in its own right (the worst-corner
 pairing of the income and cost bands would have put it below −100), and
-`bounds_source` reports `conformal` per metric.
+`bounds` and `bounds_source` name each metric's band and how it was made,
+so a consumer of the payload never needs to know the invocation.
 
-Measured on the rolling suite, composed p05–p95 bands now cover 87–96% of
+Measured on the rolling suite, composed p05–p95 bands now cover 88–97% of
 held-out values against the 90% nominal, matching direct forecasts of the
 same metrics; the worst-corner pairing covered 94–100%, too wide to be a
 useful alerting threshold.
@@ -270,7 +275,7 @@ composition automatically and returns just that metric:
 ```json
 "meta": {
   "metric": "total_leads", "composition": "derived",
-  "bounds": "p05-p95 (90%)", "bounds_source": "conformal", "mae": 6.97, "rmse": 8.22,
+  "bounds": "p05-p95 (90%)", "bounds_source": "conformal", "mae": 7.01, "rmse": 8.31,
   "anomalies_masked": ["2026-07-25", "2026-07-26"], ...
 }
 ```
@@ -321,7 +326,7 @@ about a shift before the data could reveal it.
 ~1,900/day twenty days before the end:
 
 ```json
-"data": [ { "date": "2026-08-30", "total_income": 1915.71, "lower_bound": 1862.58, "upper_bound": 2043.2, "p50": 1905.15 } ],
+"data": [ { "date": "2026-08-30", "total_income": 1915.71, "lower_bound": 1845.49, "upper_bound": 2043.2, "p50": 1904.14 } ],
 "meta": {
   "level_shift_at": "2026-08-10",
   "data_points_used": 20,
@@ -369,15 +374,15 @@ That definition is what makes it safe across very different funnels:
 2026-07-25/26. Default run:
 
 ```json
-"data": [ { "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 329.14, "upper_bound": 635.98 } ],
-"meta": { "anomalies_masked": ["2026-07-25", "2026-07-26"], "data_points_used": 58, "rmse": 95.67, ... }
+"data": [ { "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 318.64, "upper_bound": 640.12 } ],
+"meta": { "anomalies_masked": ["2026-07-25", "2026-07-26"], "data_points_used": 58, "rmse": 96.17, ... }
 ```
 
 The same run with `--no-anomaly-mask`:
 
 ```json
-"data": [ { "date": "2026-07-31", "total_clicks": 206.22, "lower_bound": 0, "upper_bound": 652.42 } ],
-"meta": { "data_points_used": 60, "rmse": 160.09, ... }
+"data": [ { "date": "2026-07-31", "total_clicks": 206.22, "lower_bound": 1.64, "upper_bound": 817.87 } ],
+"meta": { "data_points_used": 60, "rmse": 174.81, ... }
 ```
 
 Reading it: with the outage treated as data, the forecast collapses to 206
@@ -421,23 +426,29 @@ the mean), then two safeguards apply:
    ignored, and `seasonal_applied: false` says so. A history too short to
    measure the lag (under 8 points or 4 weekly pairs) applies the profile
    as supplied.
+3. **Calibration.** The profile is applied inside the model, in the
+   deployed fit and in every backtest fold, so `mae`/`rmse` and the bands
+   describe the seasonally adjusted forecast you receive, not the flat one
+   it was built from.
 
 **Worked example.** The clicks series with `--seasonal --horizon 7`:
 
 ```json
 "data": [
-  { "date": "2026-07-31", "total_clicks": 498.08 },   // Friday
-  { "date": "2026-08-01", "total_clicks": 398.5 },    // Saturday
-  { "date": "2026-08-02", "total_clicks": 415.15 },   // Sunday
-  { "date": "2026-08-03", "total_clicks": 532.73 },   // Monday
-  { "date": "2026-08-04", "total_clicks": 567.29 }    // Tuesday
+  { "date": "2026-07-31", "total_clicks": 497.93 },   // Friday
+  { "date": "2026-08-01", "total_clicks": 398.39 },   // Saturday
+  { "date": "2026-08-02", "total_clicks": 415.03 },   // Sunday
+  { "date": "2026-08-03", "total_clicks": 532.57 },   // Monday
+  { "date": "2026-08-04", "total_clicks": 567.12 }    // Tuesday
 ],
-"meta": { "seasonal": true, "seasonal_applied": true, "seasonal_profiles": ["weekday"], "rmse": 90.96, ... }
+"meta": { "seasonal": true, "seasonal_applied": true, "seasonal_profiles": ["weekday"], "rmse": 38.36, ... }
 ```
 
 Compare with the unseasonal run's flat 498/day: the weekend now dips and the
 week's peak lands on Tuesday, matching the history, and the rolling error
-falls from 95.67 to 90.96.
+falls from 96.17 to 38.36: the flat ensemble was missing the weekly swing
+by ~96 clicks a day, and the adjusted forecaster, measured as such, is
+within ~38.
 
 ### Hourly profile (`--seasonal` with `--interval hour`)
 

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -46,7 +46,8 @@ metric, `Run` does the following, in this order:
 | 9. Clip | Metrics that cannot go negative are floored at zero. | |
 
 `--all-metrics` and derived metrics run this pipeline once per *driver*
-series and then compose the totals (section 5).
+series, compose the totals, and backtest each composition for its own
+bands and errors (section 5).
 
 ---
 
@@ -201,10 +202,10 @@ p202 forecast --all-metrics --horizon 3 --json
     {
       "date": "2026-07-31",
       "total_clicks": 497.94, "total_clicks_lower": 329.14, "total_clicks_upper": 635.98,
-      "total_leads":   39.72, "total_leads_lower":   22.43, "total_leads_upper":   58.95,
-      "total_cost":   212.28, "total_cost_lower":   114.77, "total_cost_upper":   309.5,
-      "total_income": 382.93, "total_income_lower": 197.42, "total_income_upper": 626.7,
-      "total_net":    170.65, "total_net_lower":   -112.08, "total_net_upper":    511.93
+      "total_leads":   39.72, "total_leads_lower":   26.11, "total_leads_upper":   52.91,
+      "total_cost":   212.28, "total_cost_lower":   140.25, "total_cost_upper":   273.93,
+      "total_income": 382.93, "total_income_lower": 228.15, "total_income_upper": 512.24,
+      "total_net":    170.65, "total_net_lower":    85.44, "total_net_upper":    263.3
     }
   ],
   "meta": {
@@ -212,18 +213,51 @@ p202 forecast --all-metrics --horizon 3 --json
       "total_clicks": "direct", "total_leads": "derived", "total_cost": "derived",
       "total_income": "derived", "total_net": "derived"
     },
-    "anomalies_masked": { "total_clicks": ["2026-07-25", "2026-07-26"] },
+    "bounds_source": {
+      "total_clicks": "conformal", "total_leads": "conformal", "total_cost": "conformal",
+      "total_income": "conformal", "total_net": "conformal"
+    },
+    "anomalies_masked": {
+      "total_clicks": ["2026-07-25", "2026-07-26"], "total_leads": ["2026-07-25", "2026-07-26"],
+      "total_cost": ["2026-07-25", "2026-07-26"], "total_income": ["2026-07-25", "2026-07-26"],
+      "total_net": ["2026-07-25", "2026-07-26"]
+    },
     "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 }, ...
   }
 }
 ```
 
 Check the identities yourself: 382.93 − 212.28 = 170.65 = `total_net`, and
-39.72 ÷ 497.94 = 0.0798, the forecast conversion rate. Composed band
-endpoints combine conservatively (lower × lower, upper × upper for products;
-`income_lower − cost_upper` for net), which is why `total_net_lower` is
-negative here even though the point forecast is comfortably positive:
-it is the pessimistic corner of both operand bands at once.
+39.72 ÷ 497.94 = 0.0798, the forecast conversion rate.
+
+### Bands on derived metrics are backtested too
+
+Multiplying or subtracting the drivers' band endpoints would not give a band
+of known coverage (two 90% bands jointly cover as little as 80%, and pairing
+their worst corners over-covers instead). So the engine backtests the
+composition itself: at every rolling cut where both drivers made a
+prediction for the same date, it composes those predictions the same way
+(`clicks × conv_rate`, `income − cost`), takes the error against the
+observed derived value, and turns those residuals into the derived metric's
+own empirical quantiles, band, `mae`, and `rmse`. `total_net_lower` above is
+therefore a calibrated 90% floor for net in its own right (the worst-corner
+pairing of the income and cost bands would have put it below −100), and
+`bounds_source` reports `conformal` per metric.
+
+Measured on the rolling suite, composed p05–p95 bands now cover 87–96% of
+held-out values against the 90% nominal, matching direct forecasts of the
+same metrics; the worst-corner pairing covered 94–100%, too wide to be a
+useful alerting threshold.
+
+When a history is too short to pair at least 8 rolling predictions, the
+worst-corner pairing is kept and labelled `"bounds_source": "composed"`
+with `"bounds": "p05-p95 (composed from operand bands, not calibrated)"`;
+treat such a band as valid but wide.
+
+The masked anomalies of every driver are inherited by the metrics built
+from them, which is why the clicks outage above is listed under all five
+metrics: an agent reading only `total_net` still learns which observations
+were excluded.
 
 ### A single derived metric
 
@@ -231,11 +265,16 @@ it is the pessimistic corner of both operand bands at once.
 composition automatically and returns just that metric:
 
 ```json
-"meta": { "metric": "total_leads", "composition": "derived", ... }
+"meta": {
+  "metric": "total_leads", "composition": "derived",
+  "bounds": "p05-p95 (90%)", "bounds_source": "conformal", "mae": 6.97, "rmse": 8.22,
+  "anomalies_masked": ["2026-07-25", "2026-07-26"], ...
+}
 ```
 
-Derived rows carry no `mae`/`rmse`: rolling errors are measured only for
-directly fitted series.
+`mae`/`rmse` are the composed forecast's own rolling errors (leads here,
+not clicks or the conversion rate), and `anomalies_masked` carries the
+drivers' masked dates, as described above.
 
 ### When composition is not possible
 
@@ -440,8 +479,8 @@ mask catch what you did not.
 | Key | Meaning |
 | --- | --- |
 | `method`, `weights` | Method used; ensemble member shares (sum to 1) |
-| `mae`, `rmse` | Rolling-backtest errors on the metric's scale (absent for derived metrics) |
-| `bounds`, `bounds_source` | Band in use (`p05-p95 (90%)` …); `conformal`, `gaussian`, or `mixed` (composed metrics whose operands differ) |
+| `mae`, `rmse` | Rolling-backtest errors on the metric's scale (for derived metrics, of the composed forecast) |
+| `bounds`, `bounds_source` | Band in use (`p05-p95 (90%)` …); `conformal` (rolling residuals, for derived metrics of the composition itself), `gaussian` (short history), or `composed` (derived metric with too few paired rolling predictions: worst-corner pairing of the drivers' bands, not calibrated). Per metric under `--all-metrics` |
 | `data_points_used` | Points actually fitted (after masking and level-shift truncation) |
 | `buckets_rejected` | Response rows the parser could not use |
 | `anomalies_masked` | Dates removed as transients (per metric under `--all-metrics`) |

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -64,7 +64,10 @@ bands and errors (section 5).
 The ensemble weights each member by how well it has *recently* forecast this
 series in a rolling backtest (inverse squared error, older cuts discounted
 0.85 per point of age), and drops any member that trails the best by more
-than 15%. Weights are reported so you can see who contributed.
+than 15%. Weights are reported so you can see who contributed. Bands and
+`mae`/`rmse` are measured out of sample: each backtest fold's ensemble uses
+weights derived only from the folds before it, so a fold's own error never
+shapes the weights that predict it.
 
 **Worked example.** Sixty days of clicks with a weekly pattern:
 
@@ -308,8 +311,11 @@ transient burst, and then:
 - if the post-shift segment is long enough to model alone (14 daily points,
   48 hourly), fits only that segment;
 - otherwise re-levels older history to the new regime so its shape still
-  helps without dragging the level. Re-leveling is applied per backtest
-  fold, so bands never see the points they are holding out.
+  helps without dragging the level.
+
+Detection and handling run again inside every backtest fold on that fold's
+own history, so bands never see the points they hold out and never know
+about a shift before the data could reveal it.
 
 **Worked example.** Ninety days of revenue at ~1,200/day that jumped to
 ~1,900/day twenty days before the end:

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -43,7 +43,7 @@ metric, `Run` does the following, in this order:
 | 6. Seasonal profiles | Weekday / hourly / day-of-month multipliers, if requested and supported by the data, applied inside the fit and inside every backtest fold. Section 8. | `seasonal_applied`, `seasonal_profiles` |
 | 7. Bounds | Rolling-origin backtest residuals of the forecaster as emitted (profiles included) become empirical prediction bands. Section 4. | `lower_bound`, `upper_bound`, `p05`…`p95`, `bounds`, `bounds_source`, `mae`, `rmse` |
 | 8. Events | Calendar events scale the affected days. Section 9. | `events_in_horizon` |
-| 9. Clip | Metrics that cannot go negative are floored at zero. | |
+| 9. Clip | Metrics that cannot go negative are floored at zero: point forecasts inside the fit and every backtest fold (so errors and bands describe the clipped forecast you receive), bands and quantiles at output. | |
 
 `--all-metrics` and derived metrics run this pipeline once per *driver*
 series, compose the totals, and backtest each composition for its own

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -479,7 +479,7 @@ under `--json` it arrives as a structured envelope on stderr (see
 response did not contain:
 
 ```json
-{"error":{"category":"validation","message":"no valid data points found for metric \"epc\"","hint":"The response carried values for total_clicks but not \"epc\". Pick one of those with --metric, or widen --history.","exit_code":1,"command":"p202 forecast"}}
+{"error":{"category":"validation","message":"no valid data points found for metric \"epc\" (response carried: total_clicks)","hint":"Pick one of the metrics the response carried with --metric, or widen --history.","exit_code":1,"command":"p202 forecast"}}
 ```
 
 The symptoms below are the ones that produce *successful* runs whose output

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -498,7 +498,7 @@ mask catch what you did not.
 | `method`, `weights` | Method used; ensemble member shares (sum to 1) |
 | `mae`, `rmse` | Rolling-backtest errors on the metric's scale (for derived metrics, of the composed forecast) |
 | `bounds`, `bounds_source` | Band in use (`p05-p95 (90%)` …); `conformal` (rolling residuals, for derived metrics of the composition itself), `gaussian` (short history), or `composed` (derived metric with too few paired rolling predictions: worst-corner pairing of the drivers' bands, not calibrated). Per metric under `--all-metrics` |
-| `data_points_used` | Points actually fitted (after masking and level-shift truncation) |
+| `data_points_used` | Points actually fitted (after masking and level-shift truncation); for a derived metric, the fewest any of its drivers was fitted on |
 | `buckets_rejected` | Response rows the parser could not use |
 | `anomalies_masked` | Dates removed as transients (per metric under `--all-metrics`) |
 | `level_shift_at` (`level_shifts`) | First period of the new regime |

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -232,6 +232,8 @@ p202 forecast --all-metrics --horizon 3 --json
     "data_points_used": {
       "total_clicks": 58, "total_leads": 58, "total_cost": 58, "total_income": 58, "total_net": 58
     },
+    "mae":  { "total_clicks": 84.58, "total_leads": 7.01, "total_cost": 38.39, "total_income": 65.16, "total_net": 39.22 },
+    "rmse": { "total_clicks": 96.17, "total_leads": 8.31, "total_cost": 44.3, "total_income": 77.75, "total_net": 49.06 },
     "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 }, ...
   }
 }
@@ -504,7 +506,7 @@ mask catch what you did not.
 | Key | Meaning |
 | --- | --- |
 | `method`, `weights` | Method used; ensemble member shares (sum to 1) |
-| `mae`, `rmse` | Rolling-backtest errors on the metric's scale (for derived metrics, of the composed forecast) |
+| `mae`, `rmse` | Rolling-backtest errors on the metric's scale (for derived metrics, of the composed forecast); per metric under `--all-metrics` |
 | `bounds`, `bounds_source` | Band in use (`p05-p95 (90%)` …); `conformal` (rolling residuals, for derived metrics of the composition itself), `gaussian` (short history), or `composed` (derived metric with too few paired rolling predictions: worst-corner pairing of the drivers' bands, not calibrated). Per metric under `--all-metrics` |
 | `data_points_used` | Points actually fitted (after masking and level-shift truncation); for a derived metric, the fewest any of its drivers was fitted on |
 | `buckets_rejected` | Response rows the parser could not use |

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -37,7 +37,7 @@ metric, `Run` does the following, in this order:
 | --- | --- | --- |
 | 1. Parse | Reads every bucket from the API response. Buckets with an unparseable time or a non-numeric value are dropped and counted. | `buckets_rejected` in meta |
 | 2. Log transform | Count metrics (clicks, click-throughs, leads) are fitted on `log1p` scale and inverted on output, so 3%-a-day growth is a straight line, not a curve. | (silent; trends are reported on the original scale) |
-| 3. Transient masking | Short outlier runs that are abnormal *for this series at that point of its week* are removed from fitting. Section 7. | `anomalies_masked` |
+| 3. Transient masking | Short outlier runs that are abnormal *for this series at that point of its week* are removed from fitting, decided afresh inside every backtest fold from that fold's own history. Section 7. | `anomalies_masked` |
 | 4. Level-shift handling | If the series changed level (offer paused, new source), the model fits the new regime. Section 6. | `level_shift_at`, `data_points_used` |
 | 5. Fit | The chosen method, or the ensemble of all of them. Section 3. | `method`, `weights` |
 | 6. Seasonal profiles | Weekday / hourly / day-of-month multipliers, if requested and supported by the data, applied inside the fit and inside every backtest fold. Section 8. | `seasonal_applied`, `seasonal_profiles` |
@@ -364,6 +364,14 @@ units of this series' own noise, and the point must also be at least halved
 or doubled relative to that reference. Only runs shorter than five points
 are masked; a longer run is a regime change and goes to the level-shift
 detector instead. Masking applies to non-negative metrics only.
+
+Like level shifts and seasonal profiles, masking is decided per training
+view: the deployed fit masks from the full history, and each backtest fold
+re-runs the detector on its own prefix, so no fold trains on data edited
+with knowledge of what came after it. The dates reported in
+`anomalies_masked` come from the full history; they are never scored as
+held-out actuals, because the bands describe normal days and the alerting
+layer judges an outage or spike against them separately.
 
 That definition is what makes it safe across very different funnels:
 

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -1,0 +1,550 @@
+# Forecasting Guide (`p202 forecast`)
+
+`p202 forecast` projects any tracked metric forward from its history and
+returns, for every future period, a point forecast, a prediction band, and
+the metadata you need to trust (or distrust) it. This guide explains how
+the engine works, walks through real outputs, and shows how to read every
+field. It applies to any funnel tracked in Prosper202: paid media, lead
+generation, e-commerce, SaaS trials, newsletters.
+
+The short reference lives in [Go CLI (p202)](10-go-cli.md#forecasting); the
+event calendar it can consume is documented under
+[Forecast Events](../api/18-forecast-events.md).
+
+---
+
+## 1. Quick start
+
+```bash
+p202 forecast --metric revenue --horizon 7            # next 7 days of income
+p202 forecast --metric clicks --interval hour --horizon 24
+p202 forecast --all-metrics --horizon 14 --json       # clicks, leads, income, cost, net together
+p202 forecast --metric profit --seasonal --events     # weekday profile + calendar events
+```
+
+Every run fetches `reports/timeseries` for the chosen `--history` window
+(default `last90`), fits the models locally, and renders a table (or `--json`
+/ `--csv`). No model runs on the server.
+
+---
+
+## 2. What happens to your data, in order
+
+Understanding the pipeline makes every output field predictable. For one
+metric, `Run` does the following, in this order:
+
+| Step | What it does | Where you see it |
+| --- | --- | --- |
+| 1. Parse | Reads every bucket from the API response. Buckets with an unparseable time or a non-numeric value are dropped and counted. | `buckets_rejected` in meta |
+| 2. Log transform | Count metrics (clicks, click-throughs, leads) are fitted on `log1p` scale and inverted on output, so 3%-a-day growth is a straight line, not a curve. | (silent; trends are reported on the original scale) |
+| 3. Transient masking | Short outlier runs that are abnormal *for this series at that point of its week* are removed from fitting. Section 7. | `anomalies_masked` |
+| 4. Level-shift handling | If the series changed level (offer paused, new source), the model fits the new regime. Section 6. | `level_shift_at`, `data_points_used` |
+| 5. Fit | The chosen method, or the ensemble of all of them. Section 3. | `method`, `weights` |
+| 6. Bounds | Rolling-origin backtest residuals become empirical prediction bands. Section 4. | `lower_bound`, `upper_bound`, `p05`…`p95`, `bounds`, `bounds_source`, `mae`, `rmse` |
+| 7. Seasonal profiles | Weekday / hourly / day-of-month multipliers, if requested and supported by the data. Section 8. | `seasonal_applied`, `seasonal_profiles` |
+| 8. Events | Calendar events scale the affected days. Section 9. | `events_in_horizon` |
+| 9. Clip | Metrics that cannot go negative are floored at zero. | |
+
+`--all-metrics` and derived metrics run this pipeline once per *driver*
+series and then compose the totals (section 5).
+
+---
+
+## 3. Methods and the ensemble
+
+| `--method` | Model | Good for |
+| --- | --- | --- |
+| `linear` | Least-squares line through the history | Steady trends |
+| `sma` | Mean of the last window (`--window`, default ~¼ of history, 3–30) | Stable levels |
+| `wma` | Same window, recent points weighted more | Levels that drift |
+| `holtwinters` | Damped-trend exponential smoothing (level + trend, trend fades with horizon) | Trends that may flatten |
+| `ensemble` (default; `auto` is an alias) | Weighted average of the above | Everything else |
+
+The ensemble weights each member by how well it has *recently* forecast this
+series in a rolling backtest (inverse squared error, older cuts discounted
+0.85 per point of age), and drops any member that trails the best by more
+than 15%. Weights are reported so you can see who contributed.
+
+**Worked example.** Sixty days of clicks with a weekly pattern:
+
+```json
+"meta": {
+  "method": "ensemble",
+  "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 },
+  "mae": 84.85, "rmse": 95.67, ...
+}
+```
+
+Reading it: three members shared the forecast almost equally; Holt-Winters is
+absent because its recent rolling error was more than 15% worse than the
+best member, so it was dropped rather than diluting the mix. `mae`/`rmse`
+are the ensemble's average errors across all rolling cuts, on the metric's
+own scale, so they answer "how far off has this forecaster typically been
+on this series".
+
+The ensemble is deterministic: the same input always gives the same weights
+and numbers.
+
+---
+
+## 4. Prediction bands and how to read them
+
+Bands are **conformal**: the model is re-fit at up to 50 cut points stepping
+back through the history, each time forecasting the points it has not seen,
+and the errors are collected per horizon step. The band around a forecast is
+the empirical spread of those errors, with the finite-sample rank correction
+that makes the nominal coverage hold on future data. No normality or symmetry
+is assumed, so bands are asymmetric when the errors are.
+
+### Which quantiles you get
+
+Every conformal prediction carries seven quantiles. `--confidence` picks the
+pair shown as `lower_bound`/`upper_bound`; the others are still emitted as
+columns:
+
+| `--confidence` | Band | Nominal coverage | Meta `bounds` |
+| --- | --- | --- | --- |
+| below 0.65 | p25 – p75 | 50% | `p25-p75 (50%)` |
+| 0.65 – 0.85 | p10 – p90 | 80% | `p10-p90 (80%)` |
+| 0.85 and above (default 0.95, and 0.99) | p05 – p95 | 90% | `p05-p95 (90%)` |
+
+The 90% band is the widest a 50-cut residual pool supports honestly, which
+is why 0.95 and 0.99 both map to it; the meta always says which band is in
+use so a requested level is never mistaken for the delivered one.
+
+**Worked example.** Same clicks series, default confidence, first forecast
+row:
+
+```json
+{
+  "date": "2026-07-31",
+  "total_clicks": 497.94,
+  "lower_bound": 329.14, "upper_bound": 635.98,
+  "p10": 355.86, "p25": 402.65, "p50": 557.68, "p75": 590.94, "p90": 633.31
+}
+```
+
+and with `--confidence 0.5`:
+
+```json
+{ "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 402.65, "upper_bound": 590.94, "p50": 557.68 }
+```
+
+Reading it:
+
+- `total_clicks` (497.94) is the point forecast: the ensemble's value.
+- `p50` (557.68) is the **bias-corrected median**: the point forecast plus
+  the median of the model's recent errors. When it sits far from the point
+  forecast, as here, the model has been systematically off in that
+  direction lately. In this example the series has a strong weekday pattern
+  and no seasonal profile was requested, so the ensemble's flat level has
+  been under-predicting weekdays; `p50` is telling you that. Running with
+  `--seasonal` (section 8) closes most of that gap.
+- The 90% band is `[329, 636]`; the 50% band is `[403, 591]`. Nine days in
+  ten the actual should fall inside the wide band, one day in two inside
+  the narrow one, *provided the series keeps behaving as it has*.
+- Bands never narrow with horizon: each step's offsets are at least as wide
+  as the previous step's.
+
+### When you get Gaussian bands instead
+
+Conformal bands need at least 8 held-out residuals, which takes about 12
+points at a horizon of 4 or more and 16 at `--horizon 1`. Shorter histories
+fall back to symmetric bands from a single holdout, which do honor the exact
+confidence level but carry no quantile columns:
+
+```json
+"meta": { "bounds_source": "gaussian", "data_points_used": 8, "method": "linear", ... }
+```
+
+Look at `bounds_source` before comparing bands across runs of different
+lengths.
+
+### Bands as an alerting primitive
+
+Because the bands are empirical and per-step, "today's observed value fell
+below `lower_bound`" is a calibrated anomaly signal: at the 90% band it
+happens about 5% of the time by chance. Section 7 explains why transient
+masking matters for this use.
+
+---
+
+## 5. Coherent multi-metric forecasts
+
+Forecasting income and cost independently can produce a pair of paths whose
+implied ROI nothing supports. Derived metrics are therefore forecast by
+**ratio decomposition**: the engine forecasts the drivers and composes the
+totals from them, so these identities hold exactly in every output row:
+
+```
+leads  = clicks × conv_rate
+cost   = clicks × avg_cpc
+income = leads  × avg_payout
+net    = income − cost
+```
+
+The rates are derived per bucket from the totals in the same response
+(`conv_rate` here means leads ÷ clicks, not the API's click-through-based
+rate), which is what makes the identities hold against the data you supplied.
+Rates are far more stationary than totals, which is where the accuracy comes
+from.
+
+### `--all-metrics`
+
+```bash
+p202 forecast --all-metrics --horizon 3 --json
+```
+
+```json
+{
+  "data": [
+    {
+      "date": "2026-07-31",
+      "total_clicks": 497.94, "total_clicks_lower": 329.14, "total_clicks_upper": 635.98,
+      "total_leads":   39.72, "total_leads_lower":   22.43, "total_leads_upper":   58.95,
+      "total_cost":   212.28, "total_cost_lower":   114.77, "total_cost_upper":   309.5,
+      "total_income": 382.93, "total_income_lower": 197.42, "total_income_upper": 626.7,
+      "total_net":    170.65, "total_net_lower":   -112.08, "total_net_upper":    511.93
+    }
+  ],
+  "meta": {
+    "composition": {
+      "total_clicks": "direct", "total_leads": "derived", "total_cost": "derived",
+      "total_income": "derived", "total_net": "derived"
+    },
+    "anomalies_masked": { "total_clicks": ["2026-07-25", "2026-07-26"] },
+    "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 }, ...
+  }
+}
+```
+
+Check the identities yourself: 382.93 − 212.28 = 170.65 = `total_net`, and
+39.72 ÷ 497.94 = 0.0798, the forecast conversion rate. Composed band
+endpoints combine conservatively (lower × lower, upper × upper for products;
+`income_lower − cost_upper` for net), which is why `total_net_lower` is
+negative here even though the point forecast is comfortably positive:
+it is the pessimistic corner of both operand bands at once.
+
+### A single derived metric
+
+`--metric leads`, `income`, `cost`, or `net` on its own uses the same
+composition automatically and returns just that metric:
+
+```json
+"meta": { "metric": "total_leads", "composition": "derived", ... }
+```
+
+Derived rows carry no `mae`/`rmse`: rolling errors are measured only for
+directly fitted series.
+
+### When composition is not possible
+
+If a driver is defined on too few buckets (conversion rate needs clicks > 0
+on at least 70% of days) the affected metric is forecast directly and
+labeled `"composition": "direct"`. If the response lacks the companion
+metrics altogether, the direct path serves the forecast and says why:
+
+```json
+"meta": {
+  "composition": "direct",
+  "composition_fallback": "coherent forecast needs at least 3 data points for total_clicks, got 0", ...
+}
+```
+
+`--seasonal`, `--seasonal-monthly`, `--events`, and `--event-tag` always use
+the direct path for a single metric (those layers operate on the metric's
+own series) and cannot be combined with `--all-metrics`.
+
+---
+
+## 6. Level shifts
+
+A paused offer, a new traffic source, or a cap change moves a series to a
+new level. Fitting all history equally would then land the forecast between
+the old and new levels. The engine detects the strongest level change
+(a CUSUM statistic on one-step residuals, immune to steady trends), checks
+that the post-shift segment is a consistent new regime rather than a
+transient burst, and then:
+
+- if the post-shift segment is long enough to model alone (14 daily points,
+  48 hourly), fits only that segment;
+- otherwise re-levels older history to the new regime so its shape still
+  helps without dragging the level. Re-leveling is applied per backtest
+  fold, so bands never see the points they are holding out.
+
+**Worked example.** Ninety days of revenue at ~1,200/day that jumped to
+~1,900/day twenty days before the end:
+
+```json
+"data": [ { "date": "2026-08-30", "total_income": 1915.71, "lower_bound": 1862.58, "upper_bound": 2043.2, "p50": 1905.15 } ],
+"meta": {
+  "level_shift_at": "2026-08-10",
+  "data_points_used": 20,
+  "weights": { "sma": 0.516, "wma": 0.484 }, ...
+}
+```
+
+Reading it: the shift was placed on 2026-08-10, the 20 post-shift points
+were long enough to fit alone (`data_points_used` counts what was actually
+fitted, not the 90 supplied), and the forecast sits at the new level with
+a band of ±5%. Without shift handling the forecast would have been near
+1,350 with a band wide enough to be useless.
+
+`--no-level-shift` fits the full history as-is if the detector misreads a
+known change. Series shorter than 20 points are never checked.
+
+---
+
+## 7. Transient masking (outages and spikes)
+
+A two-day tracking outage or an untagged promo spike is not information
+about next week, but fitting it (on log scale, fitting a zero) drags the
+forecast and collapses the band exactly when you most need a healthy
+baseline. Short outlier runs are therefore **masked** before fitting.
+
+The test is "abnormal for this series at this point of its cycle": each
+point is compared with the same weekday (daily data) or the same hour
+(hourly) in the four surrounding cycles, the deviation is measured in robust
+units of this series' own noise, and the point must also be at least halved
+or doubled relative to that reference. Only runs shorter than five points
+are masked; a longer run is a regime change and goes to the level-shift
+detector instead. Masking applies to non-negative metrics only.
+
+That definition is what makes it safe across very different funnels:
+
+| Series | Result |
+| --- | --- |
+| 500 clicks/day, two zero days from a broken postback | Both days masked |
+| A store closed every Sunday (0 on Sundays) | Nothing masked: zero is normal for a Sunday here |
+| A low-volume tracker averaging 3/day with frequent zeros | Nothing masked: zeros are within its spread |
+| A campaign paused for six days | Nothing masked: handled as a level shift |
+| A 15% dip on one Monday | Nothing masked: below the halved-or-doubled floor |
+
+**Worked example.** The clicks series above has a two-day outage on
+2026-07-25/26. Default run:
+
+```json
+"data": [ { "date": "2026-07-31", "total_clicks": 497.94, "lower_bound": 329.14, "upper_bound": 635.98 } ],
+"meta": { "anomalies_masked": ["2026-07-25", "2026-07-26"], "data_points_used": 58, "rmse": 95.67, ... }
+```
+
+The same run with `--no-anomaly-mask`:
+
+```json
+"data": [ { "date": "2026-07-31", "total_clicks": 206.22, "lower_bound": 0, "upper_bound": 652.42 } ],
+"meta": { "data_points_used": 60, "rmse": 160.09, ... }
+```
+
+Reading it: with the outage treated as data, the forecast collapses to 206
+(the log-scale fit is pulled hard by two zeros), the band runs from 0 to
+652, and the rolling error jumps from 96 to 160. With masking, the forecast
+stays at the established level, predictions still start after the outage,
+and the two days are listed so nobody is surprised.
+
+For the alerting use, note what this buys: the band stays at the healthy
+level, so an outage keeps tripping "observed below `lower_bound`" for as
+long as it lasts, instead of the model quietly adapting to the broken state.
+
+Knobs, for installs where the defaults prove too eager or too lax:
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--no-anomaly-mask` | off | Fit every point as data |
+| `--anomaly-sigma` | 5 | Deviation threshold in robust sigmas; lower masks more |
+| `--anomaly-cycles` | 4 | Weeks (or days, hourly) on each side supplying the reference |
+
+Tagging known outages and promos as [forecast events](../api/18-forecast-events.md)
+remains the explicit override: event days are removed from training before
+any of this runs.
+
+---
+
+## 8. Seasonality
+
+### Weekday profile (`--seasonal`, day or hour interval)
+
+Weights come from the `reports/weekpart` endpoint (each weekday's total over
+the mean), then two safeguards apply:
+
+1. **Shrinkage.** Each multiplier is pulled toward 1.0 by `n / (n + 4)`,
+   where `n` is that weekday's sample count in the fetched history. Two
+   Mondays showing 1.9× become 1.3×; thirteen Mondays keep 1.69×. Thin
+   histories cannot produce extreme weights.
+2. **Gating.** The profile is applied only if the history, after removing
+   its trend, actually repeats week over week (lag-7 autocorrelation of at
+   least 0.3). Weights built from a series with no weekly structure are
+   ignored, and `seasonal_applied: false` says so. A history too short to
+   measure the lag (under 8 points or 4 weekly pairs) applies the profile
+   as supplied.
+
+**Worked example.** The clicks series with `--seasonal --horizon 7`:
+
+```json
+"data": [
+  { "date": "2026-07-31", "total_clicks": 498.08 },   // Friday
+  { "date": "2026-08-01", "total_clicks": 398.5 },    // Saturday
+  { "date": "2026-08-02", "total_clicks": 415.15 },   // Sunday
+  { "date": "2026-08-03", "total_clicks": 532.73 },   // Monday
+  { "date": "2026-08-04", "total_clicks": 567.29 }    // Tuesday
+],
+"meta": { "seasonal": true, "seasonal_applied": true, "seasonal_profiles": ["weekday"], "rmse": 90.96, ... }
+```
+
+Compare with the unseasonal run's flat 498/day: the weekend now dips and the
+week's peak lands on Tuesday, matching the history, and the rolling error
+falls from 95.67 to 90.96.
+
+### Hourly profile (`--seasonal` with `--interval hour`)
+
+Hourly forecasts additionally get an hour-of-day profile learned from the
+fetched series itself, with the same shrinkage and a lag-24h gate. Signed
+metrics (net, ROI) get no hourly profile.
+
+### Day-of-month profile (`--seasonal-monthly`, day interval)
+
+For budgets and payouts that reset monthly. Learned from the series, same
+shrinkage, no gate (it is an explicit opt-in), non-negative metrics only.
+
+---
+
+## 9. Events
+
+`--events` (all stored events) or `--event-tag promos,us-holidays` folds in
+the [forecast event calendar](../api/18-forecast-events.md): past
+occurrences are removed from training, their impact on lead/core/lag days is
+learned from history (blended with any `expected_impact_pct` hint), and
+future occurrences in the horizon scale the affected predictions and their
+bands. Requires `--interval day`. Events named in `events_unquantified` were
+seen but had neither history nor a hint, so they did not move the numbers.
+
+Events and transient masking are complementary: tag what you know, let the
+mask catch what you did not.
+
+---
+
+## 10. Output reference
+
+### Row columns
+
+| Column | Meaning |
+| --- | --- |
+| `date` | Period start (`YYYY-MM-DD`, `YYYY-MM-DD HH:MM` hourly, `YYYY-MM` monthly, `... (wk)` weekly) |
+| `<metric>` | Point forecast |
+| `lower_bound`, `upper_bound` | The band selected by `--confidence` |
+| `p05` … `p95` | Remaining quantiles (conformal runs only); `p50` is the bias-corrected median |
+| `trend` | First row only: per-period trend as a percent of the history's mean |
+| `<metric>_lower`, `<metric>_upper` | `--all-metrics` only, per metric |
+
+### Meta keys
+
+| Key | Meaning |
+| --- | --- |
+| `method`, `weights` | Method used; ensemble member shares (sum to 1) |
+| `mae`, `rmse` | Rolling-backtest errors on the metric's scale (absent for derived metrics) |
+| `bounds`, `bounds_source` | Band in use (`p05-p95 (90%)` …); `conformal`, `gaussian`, or `mixed` (composed metrics whose operands differ) |
+| `data_points_used` | Points actually fitted (after masking and level-shift truncation) |
+| `buckets_rejected` | Response rows the parser could not use |
+| `anomalies_masked` | Dates removed as transients (per metric under `--all-metrics`) |
+| `level_shift_at` (`level_shifts`) | First period of the new regime |
+| `composition`, `composition_fallback` | `derived` / `direct`, and why direct if composition was intended |
+| `seasonal`, `seasonal_applied`, `seasonal_profiles` | Requested; actually applied; which profiles |
+| `events_active`, `events_in_horizon`, `events_unquantified` | Event layer status |
+| `trend_per_period`, `trend_pct` | Trend in metric units and as a percent of the history's mean |
+
+### Flags
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--metric`, `-m` | required unless `--all-metrics` | Aliases: clicks, leads/conversions, revenue/income, cost, profit/net |
+| `--all-metrics` | off | Coherent clicks/leads/income/cost/net; excludes `--metric`, seasonal and event flags |
+| `--horizon`, `-n` | 7 | Up to 365 |
+| `--interval`, `-i` | day | hour, day, week, month |
+| `--history` (`--period`, `--days`) | last90 (last30 hourly) | Hourly is limited to today/yesterday/last7/last30 |
+| `--method` | auto | auto, ensemble, linear, sma, wma, holtwinters |
+| `--window` | auto | SMA/WMA window |
+| `--confidence` | 0.95 | Snaps to 50/80/90% bands (section 4) |
+| `--seasonal`, `--seasonal-monthly` | off | Section 8 |
+| `--events`, `--event-tag` | off | Section 9 |
+| `--no-level-shift` | off | Section 6 |
+| `--no-anomaly-mask`, `--anomaly-sigma`, `--anomaly-cycles` | off / 5 / 4 | Section 7 |
+| entity filters | | `--aff_campaign_id`, `--ppc_account_id`, `--aff_network_id`, `--ppc_network_id`, `--landing_page_id`, `--country_id` |
+
+---
+
+## 11. Troubleshooting
+
+**No `p05`…`p95` columns and `bounds_source` is `gaussian`.** The history is
+too short for a rolling backtest (section 4). Use a longer `--history`.
+
+**`seasonal_applied` is false although I passed `--seasonal`.** The history
+does not repeat week over week after detrending, so the profile would only
+add error. If you are certain the pattern exists, check the weekpart data
+the profile was built from (`p202 report weekpart`) and the history length.
+
+**`p50` is far from the point forecast.** The model has been systematically
+biased on this series recently. Usually a missing seasonal profile
+(section 4's example) or a level shift too small or too recent for the
+detector; `--seasonal` or a shorter `--history` typically fixes it.
+
+**A date in `anomalies_masked` was a real day.** Raise `--anomaly-sigma`, or
+pass `--no-anomaly-mask` for that run. If it happens systematically on an
+install, that is the signal to change the defaults there.
+
+**`composition` is `direct` for leads/income/cost/net.** Either a driver was
+too sparse (many zero-click days) or the response lacked companion metrics;
+`composition_fallback` says which. The forecast is still valid, it just is
+not guaranteed consistent with a separate clicks forecast.
+
+**`level_shift_at` on a series that did not shift.** The detector requires a
+consistent new regime of at least five points at 3σ from the old level, so
+this usually means the change is real but small in your eyes. `--no-level-shift`
+overrides it; `data_points_used` shows how much history it kept.
+
+---
+
+## 12. Measuring accuracy yourself
+
+The package ships two synthetic suites that run rolling backtests over the
+whole pipeline and print per-series accuracy and band coverage:
+
+```bash
+cd go-cli
+go test ./internal/forecast/ -run 'TestMeasureSuite|TestMeasureTransientSuite' -v -measure
+```
+
+The first covers trends, plateaus, weekly patterns, flat noise, level
+shifts, short histories, skewed noise, and multiplicative growth; the second
+covers outages, spikes, closed-Sundays, low-volume Poisson counts, and a
+weekly pattern with an outage, each measured with masking on and off. The
+same suites back the acceptance tests that run on every `go test`, so a
+change that degrades accuracy or band calibration fails the build.
+
+---
+
+## 13. Using the engine from Go
+
+The forecaster is a dependency-free package, `p202/internal/forecast`:
+
+```go
+result, err := forecast.Run(series, forecast.Config{
+    Method:       forecast.MethodAuto,
+    Horizon:      7,
+    Interval:     forecast.IntervalDay,
+    NonNegative:  true,   // clip at zero, enable transient masking
+    LogTransform: true,   // count metric
+})
+// result.Predictions[i].Value / LowerBound / UpperBound / Quantiles["p50"]
+// result.Weights, result.LevelShiftAt, result.AnomaliesMasked, result.BoundsSource
+
+results, err := forecast.RunCoherent(map[string]forecast.Series{
+    forecast.MetricClicks: clicks, forecast.MetricLeads: leads,
+    forecast.MetricIncome: income, forecast.MetricCost: cost,
+}, forecast.Config{Horizon: 7, Interval: forecast.IntervalDay})
+// results[forecast.MetricNet].Predictions[i].Value == income − cost, exactly
+```
+
+`Config` also exposes `SeasonalWeights`, `HourlyWeights`, `MonthDayWeights`,
+`ConfidenceLevel`, `Anchor`, `DisableLevelShift`, `DisableAnomalyMask`,
+`AnomalySigma`, and `AnomalyCycles`; `Result` mirrors every meta key listed
+in section 10. All fields added since the original engine are additive, so
+earlier consumers of `Run` and `Result` keep working unchanged.

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -473,6 +473,19 @@ mask catch what you did not.
 
 ## 11. Troubleshooting
 
+Every failure carries a category, exit code, and usually a recovery hint;
+under `--json` it arrives as a structured envelope on stderr (see
+[Errors](10-go-cli.md#errors)). For example, asking for a metric the
+response did not contain:
+
+```json
+{"error":{"category":"validation","message":"no valid data points found for metric \"epc\"","hint":"The response carried values for total_clicks but not \"epc\". Pick one of those with --metric, or widen --history.","exit_code":1,"command":"p202 forecast"}}
+```
+
+The symptoms below are the ones that produce *successful* runs whose output
+needs interpreting.
+
+
 **No `p05`…`p95` columns and `bounds_source` is `gaussian`.** The history is
 too short for a rolling backtest (section 4). Use a longer `--history`.
 

--- a/documentation/cli/11-forecasting.md
+++ b/documentation/cli/11-forecasting.md
@@ -229,6 +229,9 @@ p202 forecast --all-metrics --horizon 3 --json
       "total_cost": ["2026-07-25", "2026-07-26"], "total_income": ["2026-07-25", "2026-07-26"],
       "total_net": ["2026-07-25", "2026-07-26"]
     },
+    "data_points_used": {
+      "total_clicks": 58, "total_leads": 58, "total_cost": 58, "total_income": 58, "total_net": 58
+    },
     "weights": { "linear": 0.305, "sma": 0.37, "wma": 0.325 }, ...
   }
 }
@@ -413,42 +416,47 @@ any of this runs.
 
 ### Weekday profile (`--seasonal`, day or hour interval)
 
-Weights come from the `reports/weekpart` endpoint (each weekday's total over
-the mean), then two safeguards apply:
+The profile is learned from the fetched history itself (each weekday's mean
+over the overall mean; no separate report call), then three safeguards
+apply:
 
 1. **Shrinkage.** Each multiplier is pulled toward 1.0 by `n / (n + 4)`,
-   where `n` is that weekday's sample count in the fetched history. Two
-   Mondays showing 1.9× become 1.3×; thirteen Mondays keep 1.69×. Thin
-   histories cannot produce extreme weights.
+   where `n` is that weekday's sample count in the history it was estimated
+   from. Two Mondays showing 1.9× become 1.3×; thirteen Mondays keep 1.69×.
+   Thin histories cannot produce extreme weights.
 2. **Gating.** The profile is applied only if the history, after removing
    its trend, actually repeats week over week (lag-7 autocorrelation of at
    least 0.3). Weights built from a series with no weekly structure are
    ignored, and `seasonal_applied: false` says so. A history too short to
    measure the lag (under 8 points or 4 weekly pairs) applies the profile
    as supplied.
-3. **Calibration.** The profile is applied inside the model, in the
-   deployed fit and in every backtest fold, so `mae`/`rmse` and the bands
-   describe the seasonally adjusted forecast you receive, not the flat one
-   it was built from.
+3. **Calibration.** The profile is re-estimated, gate included, from each
+   backtest fold's own history and applied inside the model there, as it is
+   in the deployed fit. `mae`/`rmse` and the bands therefore describe the
+   seasonally adjusted forecast you receive, and no held-out day ever
+   contributes to the multiplier that scales it. Multiplicative profiles
+   need non-negative data, so signed metrics (net, ROI) get none.
 
 **Worked example.** The clicks series with `--seasonal --horizon 7`:
 
 ```json
 "data": [
-  { "date": "2026-07-31", "total_clicks": 497.93 },   // Friday
-  { "date": "2026-08-01", "total_clicks": 398.39 },   // Saturday
-  { "date": "2026-08-02", "total_clicks": 415.03 },   // Sunday
-  { "date": "2026-08-03", "total_clicks": 532.57 },   // Monday
-  { "date": "2026-08-04", "total_clicks": 567.12 }    // Tuesday
+  { "date": "2026-07-31", "total_clicks": 489.91 },   // Friday
+  { "date": "2026-08-01", "total_clicks": 398.54 },   // Saturday
+  { "date": "2026-08-02", "total_clicks": 413.23 },   // Sunday
+  { "date": "2026-08-03", "total_clicks": 532.59 },   // Monday
+  { "date": "2026-08-04", "total_clicks": 556.89 }    // Tuesday
 ],
-"meta": { "seasonal": true, "seasonal_applied": true, "seasonal_profiles": ["weekday"], "rmse": 38.36, ... }
+"meta": { "seasonal": true, "seasonal_applied": true, "seasonal_profiles": ["weekday"], "rmse": 56.09, ... }
 ```
 
 Compare with the unseasonal run's flat 498/day: the weekend now dips and the
 week's peak lands on Tuesday, matching the history, and the rolling error
-falls from 96.17 to 38.36: the flat ensemble was missing the weekly swing
+falls from 96.17 to 56.09: the flat ensemble was missing the weekly swing
 by ~96 clicks a day, and the adjusted forecaster, measured as such, is
-within ~38.
+within ~56. That figure is honest in a specific sense: each backtest fold
+estimated its own profile from the history before it, so no held-out day
+helped shape the multiplier that scaled it.
 
 ### Hourly profile (`--seasonal` with `--interval hour`)
 
@@ -547,8 +555,9 @@ too short for a rolling backtest (section 4). Use a longer `--history`.
 
 **`seasonal_applied` is false although I passed `--seasonal`.** The history
 does not repeat week over week after detrending, so the profile would only
-add error. If you are certain the pattern exists, check the weekpart data
-the profile was built from (`p202 report weekpart`) and the history length.
+add error. If you are certain the pattern exists, eyeball the weekday totals
+(`p202 report weekpart` for the same window) and check the history length;
+a signed metric (net, ROI) never gets a multiplicative profile.
 
 **`p50` is far from the point forecast.** The model has been systematically
 biased on this series recently. Usually a missing seasonal profile

--- a/go-cli/cmd/analytics.go
+++ b/go-cli/cmd/analytics.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -58,7 +57,7 @@ var analyticsCmd = &cobra.Command{
 	Short: "Query performance stats grouped by campaign, traffic source, country, etc. (shorthand for report breakdown)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !envFlagEnabled("CLI_ENABLE_ANALYTICS_SHORTHAND", true) {
-			return fmt.Errorf("analytics shorthand is disabled (set CLI_ENABLE_ANALYTICS_SHORTHAND=1 to enable)")
+			return validationError("analytics shorthand is disabled").WithHint("Set CLI_ENABLE_ANALYTICS_SHORTHAND=1 in the environment, or use `p202 report breakdown` directly.")
 		}
 
 		c, err := api.NewFromConfig()
@@ -69,7 +68,7 @@ var analyticsCmd = &cobra.Command{
 		groupBy, _ := cmd.Flags().GetString("group-by")
 		groupBy = strings.ToLower(strings.TrimSpace(groupBy))
 		if groupBy == "" {
-			return validationError("--group-by is required")
+			return validationError("--group-by is required").WithHint("Example: --group-by country (aliases: lp for landing_page).")
 		}
 		if mapped, ok := analyticsGroupByAliases[groupBy]; ok {
 			groupBy = mapped

--- a/go-cli/cmd/attribution.go
+++ b/go-cli/cmd/attribution.go
@@ -71,10 +71,10 @@ var attrModelCreateCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("model_name")
 		mtype, _ := cmd.Flags().GetString("model_type")
 		if name == "" {
-			return fmt.Errorf("required flag --model_name is missing")
+			return validationError("required flag --model_name is missing")
 		}
 		if mtype == "" {
-			return fmt.Errorf("required flag --model_type is missing")
+			return validationError("required flag --model_type is missing")
 		}
 		body := map[string]interface{}{
 			"model_name": name,
@@ -83,7 +83,7 @@ var attrModelCreateCmd = &cobra.Command{
 		if v, _ := cmd.Flags().GetString("weighting_config"); v != "" {
 			var parsed interface{}
 			if err := json.Unmarshal([]byte(v), &parsed); err != nil {
-				return fmt.Errorf("invalid --weighting_config JSON: %w", err)
+				return withHint(fmt.Errorf("invalid --weighting_config JSON: %w", err), "Pass a JSON object, e.g. --weighting_config '{\"first\":0.4,\"last\":0.6}'; quote it so the shell keeps it intact.")
 			}
 			body["weighting_config"] = parsed
 		}
@@ -120,12 +120,12 @@ var attrModelUpdateCmd = &cobra.Command{
 		if v, _ := cmd.Flags().GetString("weighting_config"); v != "" {
 			var parsed interface{}
 			if err := json.Unmarshal([]byte(v), &parsed); err != nil {
-				return fmt.Errorf("invalid --weighting_config JSON: %w", err)
+				return withHint(fmt.Errorf("invalid --weighting_config JSON: %w", err), "Pass a JSON object, e.g. --weighting_config '{\"first\":0.4,\"last\":0.6}'; quote it so the shell keeps it intact.")
 			}
 			body["weighting_config"] = parsed
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("no fields specified; pass at least one flag to update")
+			return validationError("no fields specified; pass at least one flag to update")
 		}
 		data, err := c.Put("attribution/models/"+args[0], body)
 		if err != nil {

--- a/go-cli/cmd/cli_errors.go
+++ b/go-cli/cmd/cli_errors.go
@@ -127,7 +127,8 @@ func exitCodeForError(err error) int {
 }
 
 // activeCommandPath is the full path ("p202 forecast") of the command that
-// ran, recorded by the root PersistentPreRun so error output can name it.
+// ran, recorded by the root PersistentPreRun so error output can name it;
+// recoverCommandContext fills it in when Cobra fails before that runs.
 var activeCommandPath string
 
 // errorEnvelope builds the machine-readable error record emitted on stderr

--- a/go-cli/cmd/cli_errors.go
+++ b/go-cli/cmd/cli_errors.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+
+	"p202/internal/api"
 )
 
 // Exit codes for automation compatibility.
@@ -23,6 +27,9 @@ type CLIError struct {
 	Category string // "validation", "auth", "network", "server", "partial_failure"
 	Message  string
 	ExitCode int
+	// Hint is the recovery step an operator or agent should take next. It
+	// is printed after the message and carried in the JSON error envelope.
+	Hint string
 }
 
 func (e *CLIError) Error() string {
@@ -31,6 +38,39 @@ func (e *CLIError) Error() string {
 
 func (e *CLIError) CategoryName() string {
 	return e.Category
+}
+
+// HintText implements api.Hinted so HintFor surfaces the hint.
+func (e *CLIError) HintText() string {
+	return e.Hint
+}
+
+// WithHint attaches a recovery hint and returns the error for chaining:
+//
+//	return validationError("--tracker is required").WithHint("run `p202 tracker list` to find ids")
+func (e *CLIError) WithHint(format string, args ...interface{}) *CLIError {
+	e.Hint = fmt.Sprintf(format, args...)
+	return e
+}
+
+// hintedError wraps any error with a recovery hint while preserving the
+// wrapped error's category and exit code (errors.As sees through it).
+type hintedError struct {
+	err  error
+	hint string
+}
+
+func (e *hintedError) Error() string    { return e.err.Error() }
+func (e *hintedError) Unwrap() error    { return e.err }
+func (e *hintedError) HintText() string { return e.hint }
+
+// withHint attaches a recovery hint to an existing error (typically one
+// that wraps an API error with %w). Returns nil for a nil error.
+func withHint(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &hintedError{err: err, hint: fmt.Sprintf(format, args...)}
 }
 
 // validationError creates a CLI validation error (bad input, missing flags, etc.).
@@ -60,24 +100,19 @@ func errString(err error) string {
 }
 
 // exitCodeForError returns the appropriate exit code for an error.
-// Falls back to ExitValidation (1) for unrecognized errors.
+// Falls back to ExitValidation (1) for unrecognized errors. Wrapped errors
+// (fmt.Errorf with %w, withHint) keep the code of the error they wrap, so
+// "fetching data: API error (401)" still exits 2, not 1.
 func exitCodeForError(err error) int {
 	if err == nil {
 		return ExitOK
 	}
-	if cliErr, ok := err.(*CLIError); ok {
+	var cliErr *CLIError
+	if errors.As(err, &cliErr) {
 		return cliErr.ExitCode
 	}
 
-	category := ""
-	type categorized interface {
-		CategoryName() string
-	}
-	if c, ok := err.(categorized); ok {
-		category = c.CategoryName()
-	}
-
-	switch category {
+	switch api.ErrorCategory(err) {
 	case "auth":
 		return ExitAuth
 	case "network":
@@ -89,4 +124,50 @@ func exitCodeForError(err error) int {
 	default:
 		return ExitValidation
 	}
+}
+
+// activeCommandPath is the full path ("p202 forecast") of the command that
+// ran, recorded by the root PersistentPreRun so error output can name it.
+var activeCommandPath string
+
+// errorEnvelope builds the machine-readable error record emitted on stderr
+// under --json/--ndjson: everything an agent needs to decide what to do next
+// without parsing prose.
+func errorEnvelope(err error) map[string]interface{} {
+	env := map[string]interface{}{
+		"message":   err.Error(),
+		"exit_code": exitCodeForError(err),
+	}
+	if category := api.ErrorCategory(err); category != "" {
+		env["category"] = category
+	} else {
+		env["category"] = "validation"
+	}
+	if hint := hintFor(err); hint != "" {
+		env["hint"] = hint
+	}
+	if activeCommandPath != "" {
+		env["command"] = activeCommandPath
+	}
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		env["http_status"] = apiErr.Status
+		if len(apiErr.FieldErrors) > 0 {
+			env["field_errors"] = apiErr.FieldErrors
+		}
+	}
+	return map[string]interface{}{"error": env}
+}
+
+// hintFor returns the recovery hint for an error: an explicit hint attached
+// by the command or the API layer, else a generic pointer to --help for
+// validation errors from a known command.
+func hintFor(err error) string {
+	if hint := api.HintFor(err); hint != "" {
+		return hint
+	}
+	if activeCommandPath != "" && exitCodeForError(err) == ExitValidation && api.ErrorCategory(err) != "auth" {
+		return fmt.Sprintf("Run `%s --help` for the flags this command accepts.", strings.TrimSpace(activeCommandPath))
+	}
+	return ""
 }

--- a/go-cli/cmd/cli_errors_test.go
+++ b/go-cli/cmd/cli_errors_test.go
@@ -117,3 +117,64 @@ func TestPrintError_JSONVsText(t *testing.T) {
 		t.Errorf("text output = %q", out)
 	}
 }
+
+func TestRecoverCommandContext(t *testing.T) {
+	oldPath, oldJSON, oldND := activeCommandPath, jsonOutput, ndjsonOutput
+	defer func() { activeCommandPath, jsonOutput, ndjsonOutput = oldPath, oldJSON, oldND }()
+
+	activeCommandPath, jsonOutput, ndjsonOutput = "", false, false
+	recoverCommandContext([]string{"campaign", "get", "--json"})
+	if activeCommandPath != "p202 campaign get" {
+		t.Errorf("command path = %q, want p202 campaign get", activeCommandPath)
+	}
+	if !jsonOutput {
+		t.Error("--json should select the JSON envelope even when Cobra never parsed flags")
+	}
+
+	activeCommandPath, jsonOutput, ndjsonOutput = "", false, false
+	recoverCommandContext([]string{"bogus", "--ndjson"})
+	if activeCommandPath != "p202" {
+		t.Errorf("unknown command path = %q, want p202", activeCommandPath)
+	}
+	if !ndjsonOutput {
+		t.Error("--ndjson should select the JSON envelope")
+	}
+
+	// Flags after "--" belong to the wrapped command (exec), not to p202.
+	activeCommandPath, jsonOutput, ndjsonOutput = "", false, false
+	recoverCommandContext([]string{"exec", "--all-profiles", "--", "campaign", "list", "--json"})
+	if activeCommandPath != "p202 exec" || jsonOutput {
+		t.Errorf("exec: path %q json=%v, want p202 exec and json=false", activeCommandPath, jsonOutput)
+	}
+
+	// A path recorded by PersistentPreRunE is kept.
+	activeCommandPath = "p202 forecast"
+	recoverCommandContext([]string{"campaign"})
+	if activeCommandPath != "p202 forecast" {
+		t.Errorf("recorded path overwritten: %q", activeCommandPath)
+	}
+}
+
+func TestArgCountErrorNamesCommandInEnvelope(t *testing.T) {
+	// Cobra rejects a missing positional argument before PersistentPreRunE
+	// runs; the envelope must still carry the command and the --help hint.
+	old := activeCommandPath
+	defer func() { activeCommandPath = old }()
+	activeCommandPath = ""
+
+	_, _, err := executeCommand("campaign", "get")
+	if err == nil {
+		t.Fatal("expected an argument-count error")
+	}
+	recoverCommandContext([]string{"campaign", "get"})
+	env := errorEnvelope(err)["error"].(map[string]interface{})
+	if env["command"] != "p202 campaign get" {
+		t.Errorf("command = %v, want p202 campaign get", env["command"])
+	}
+	if hint, _ := env["hint"].(string); !strings.Contains(hint, "p202 campaign get --help") {
+		t.Errorf("hint = %q, want a pointer to `p202 campaign get --help`", hint)
+	}
+	if env["exit_code"] != ExitValidation {
+		t.Errorf("exit_code = %v, want %d", env["exit_code"], ExitValidation)
+	}
+}

--- a/go-cli/cmd/cli_errors_test.go
+++ b/go-cli/cmd/cli_errors_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"p202/internal/api"
+)
+
+func TestExitCodeForError_SeesThroughWrapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"bare 401", &api.APIError{Status: 401, Message: "bad key"}, ExitAuth},
+		{"wrapped 401", fmt.Errorf("fetching historical data: %w", &api.APIError{Status: 401}), ExitAuth},
+		{"wrapped 500", fmt.Errorf("fetching: %w", &api.APIError{Status: 500}), ExitServer},
+		{"wrapped network", fmt.Errorf("fetching: %w", &api.RequestError{Kind: "network", Op: "GET", Err: fmt.Errorf("refused")}), ExitNetwork},
+		{"hinted wrapped 403", withHint(fmt.Errorf("x: %w", &api.APIError{Status: 403}), "check key"), ExitAuth},
+		{"validation", validationError("bad flag"), ExitValidation},
+		{"wrapped validation", fmt.Errorf("outer: %w", validationError("bad flag")), ExitValidation},
+		{"partial", partialFailureError("2 of 5 failed"), ExitPartialFailure},
+		{"plain", fmt.Errorf("something"), ExitValidation},
+		{"nil", nil, ExitOK},
+	}
+	for _, tc := range cases {
+		if got := exitCodeForError(tc.err); got != tc.want {
+			t.Errorf("%s: exit code = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestHintFor_ExplicitHintWins(t *testing.T) {
+	err := validationError("--tracker is required").WithHint("run `p202 tracker list`")
+	if got := hintFor(err); got != "run `p202 tracker list`" {
+		t.Errorf("hint = %q", got)
+	}
+	wrapped := withHint(fmt.Errorf("fetch: %w", &api.APIError{Status: 401}), "custom")
+	if got := hintFor(wrapped); got != "custom" {
+		t.Errorf("explicit hint should win over the 401 default, got %q", got)
+	}
+	// Generic API hints still apply to bare API errors.
+	if got := hintFor(&api.APIError{Status: 500}); !strings.Contains(got, "system health") {
+		t.Errorf("5xx hint = %q", got)
+	}
+	if got := hintFor(&api.APIError{Status: 429}); !strings.Contains(got, "Rate limited") {
+		t.Errorf("429 hint = %q", got)
+	}
+}
+
+func TestHintFor_GenericHelpFallback(t *testing.T) {
+	old := activeCommandPath
+	defer func() { activeCommandPath = old }()
+	activeCommandPath = "p202 rotator create"
+	if got := hintFor(validationError("required flag --name is missing")); !strings.Contains(got, "p202 rotator create --help") {
+		t.Errorf("expected --help fallback naming the command, got %q", got)
+	}
+	activeCommandPath = ""
+	if got := hintFor(validationError("required flag --name is missing")); got != "" {
+		t.Errorf("no command path: expected no fallback hint, got %q", got)
+	}
+}
+
+func TestErrorEnvelope(t *testing.T) {
+	old := activeCommandPath
+	defer func() { activeCommandPath = old }()
+	activeCommandPath = "p202 campaign create"
+
+	err := fmt.Errorf("creating campaign: %w", &api.APIError{
+		Status: 422, Message: "validation failed",
+		FieldErrors: map[string]string{"campaign_name": "required"},
+	})
+	env := errorEnvelope(err)["error"].(map[string]interface{})
+	if env["category"] != "validation" || env["exit_code"] != ExitValidation {
+		t.Errorf("category/exit = %v/%v", env["category"], env["exit_code"])
+	}
+	if env["http_status"] != 422 {
+		t.Errorf("http_status = %v", env["http_status"])
+	}
+	if env["command"] != "p202 campaign create" {
+		t.Errorf("command = %v", env["command"])
+	}
+	fe, _ := env["field_errors"].(map[string]string)
+	if fe["campaign_name"] != "required" {
+		t.Errorf("field_errors = %v", env["field_errors"])
+	}
+	if env["hint"] == nil || env["hint"] == "" {
+		t.Error("expected a hint for a 422 with field errors")
+	}
+}
+
+func TestPrintError_JSONVsText(t *testing.T) {
+	oldJSON, oldND := jsonOutput, ndjsonOutput
+	defer func() { jsonOutput, ndjsonOutput = oldJSON, oldND }()
+	err := withHint(fmt.Errorf("fetching: %w", &api.APIError{Status: 401, Message: "bad key"}), "set a key")
+
+	jsonOutput, ndjsonOutput = true, false
+	var buf bytes.Buffer
+	printError(&buf, err)
+	var parsed map[string]map[string]interface{}
+	if jErr := json.Unmarshal(buf.Bytes(), &parsed); jErr != nil {
+		t.Fatalf("--json error output is not JSON: %v\n%s", jErr, buf.String())
+	}
+	if parsed["error"]["category"] != "auth" || parsed["error"]["hint"] != "set a key" || parsed["error"]["exit_code"] != float64(ExitAuth) {
+		t.Errorf("envelope = %v", parsed["error"])
+	}
+
+	jsonOutput, ndjsonOutput = false, false
+	buf.Reset()
+	printError(&buf, err)
+	out := buf.String()
+	if !strings.HasPrefix(out, "Error [auth]: ") || !strings.Contains(out, "\nHint: set a key\n") {
+		t.Errorf("text output = %q", out)
+	}
+}

--- a/go-cli/cmd/click.go
+++ b/go-cli/cmd/click.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"p202/internal/api"
 	"strconv"
 
@@ -57,14 +56,14 @@ var clickListCmd = &cobra.Command{
 		if pageStr, _ := cmd.Flags().GetString("page"); pageStr != "" {
 			page, err := strconv.Atoi(pageStr)
 			if err != nil || page <= 0 {
-				return fmt.Errorf("--page must be a positive integer")
+				return validationError("--page must be a positive integer")
 			}
 			if _, hasOffset := params["offset"]; !hasOffset {
 				limit := 50
 				if limitStr, hasLimit := params["limit"]; hasLimit {
 					parsedLimit, err := strconv.Atoi(limitStr)
 					if err != nil || parsedLimit <= 0 {
-						return fmt.Errorf("--limit must be a positive integer when --page is used")
+						return validationError("--limit must be a positive integer when --page is used")
 					}
 					limit = parsedLimit
 				}

--- a/go-cli/cmd/config.go
+++ b/go-cli/cmd/config.go
@@ -122,7 +122,7 @@ var configTestCmd = &cobra.Command{
 		}
 		data, err := c.Get("system/health", nil)
 		if err != nil {
-			return fmt.Errorf("connection failed: %w", err)
+			return withHint(fmt.Errorf("connection failed: %w", err), "Check `p202 config get` (URL and key), that the instance is reachable, and that the key is valid in the Prosper202 UI under API keys.")
 		}
 		if !jsonOutput {
 			fmt.Println("Connection successful!")
@@ -140,10 +140,10 @@ var configSetDefaultCmd = &cobra.Command{
 		key := strings.TrimSpace(args[0])
 		value := strings.TrimSpace(args[1])
 		if value == "" {
-			return fmt.Errorf("default value cannot be empty")
+			return validationError("default value cannot be empty")
 		}
 		if !isSupportedDefaultKey(key) {
-			return fmt.Errorf("unsupported default key %q. Supported keys: %s", key, strings.Join(supportedDefaultKeys(), ", "))
+			return validationError("unsupported default key %q. Supported keys: %s", key, strings.Join(supportedDefaultKeys(), ", "))
 		}
 
 		cfg, err := config.Load()
@@ -180,11 +180,11 @@ var configGetDefaultCmd = &cobra.Command{
 		if len(args) == 1 {
 			key := strings.TrimSpace(args[0])
 			if !isSupportedDefaultKey(key) {
-				return fmt.Errorf("unsupported default key %q. Supported keys: %s", key, strings.Join(supportedDefaultKeys(), ", "))
+				return validationError("unsupported default key %q. Supported keys: %s", key, strings.Join(supportedDefaultKeys(), ", "))
 			}
 			value := p.GetDefault(key)
 			if value == "" {
-				return fmt.Errorf("default %q is not set", key)
+				return validationError("default %q is not set", key).WithHint("Set it with `p202 config set-default %s <value>`.", key)
 			}
 			payload, _ := json.Marshal(map[string]interface{}{
 				"data": map[string]string{
@@ -215,7 +215,7 @@ var configUnsetDefaultCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key := strings.TrimSpace(args[0])
 		if !isSupportedDefaultKey(key) {
-			return fmt.Errorf("unsupported default key %q. Supported keys: %s", key, strings.Join(supportedDefaultKeys(), ", "))
+			return validationError("unsupported default key %q. Supported keys: %s", key, strings.Join(supportedDefaultKeys(), ", "))
 		}
 
 		cfg, err := config.Load()
@@ -227,7 +227,7 @@ var configUnsetDefaultCmd = &cobra.Command{
 			return err
 		}
 		if !p.DeleteDefault(key) {
-			return fmt.Errorf("default %q is not set", key)
+			return validationError("default %q is not set", key).WithHint("Set it with `p202 config set-default %s <value>`.", key)
 		}
 		if err := cfg.Save(); err != nil {
 			return err
@@ -246,27 +246,27 @@ func init() {
 func normalizeBaseURL(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
-		return "", fmt.Errorf("URL is required")
+		return "", validationError("URL is required").WithHint("Example: `p202 config set-url https://tracking.example.com`.")
 	}
 	parsed, err := url.Parse(trimmed)
 	if err != nil || parsed == nil {
-		return "", fmt.Errorf("URL must be a valid http(s) URL")
+		return "", validationError("URL must be a valid http(s) URL").WithHint("Example: `p202 config set-url https://tracking.example.com`.")
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", fmt.Errorf("URL must use http or https")
+		return "", validationError("URL must use http or https").WithHint("Example: `p202 config set-url https://tracking.example.com`.")
 	}
 	if parsed.Host == "" {
-		return "", fmt.Errorf("URL must include a host")
+		return "", validationError("URL must include a host").WithHint("Example: `p202 config set-url https://tracking.example.com`.")
 	}
 	return strings.TrimRight(trimmed, "/"), nil
 }
 
 func validateAPIKey(key string) error {
 	if len(key) < 8 {
-		return fmt.Errorf("API key must be at least 8 characters")
+		return validationError("API key must be at least 8 characters").WithHint("Create or copy a key in the Prosper202 UI (API keys), then `p202 config set-key <key>`.")
 	}
 	if strings.ContainsAny(key, " \t\r\n") {
-		return fmt.Errorf("API key must not contain whitespace")
+		return validationError("API key must not contain whitespace").WithHint("Paste the key exactly as shown in the Prosper202 UI; quote it if your shell splits it.")
 	}
 	return nil
 }

--- a/go-cli/cmd/conversion.go
+++ b/go-cli/cmd/conversion.go
@@ -102,11 +102,11 @@ var conversionCreateCmd = &cobra.Command{
 			clickIDStr, _ = cmd.Flags().GetString("click_id_public")
 		}
 		if clickIDStr == "" {
-			return fmt.Errorf("required flag --click_id (or --click_id_public) is missing")
+			return validationError("required flag --click_id (or --click_id_public) is missing")
 		}
 		clickID, err := strconv.Atoi(clickIDStr)
 		if err != nil {
-			return fmt.Errorf("--click_id must be an integer: %s", clickIDStr)
+			return validationError("--click_id must be an integer: %s", clickIDStr).WithHint("Use the internal click id from `p202 click list`, or pass the public id via --click_id_public.")
 		}
 		body := map[string]interface{}{
 			"click_id": clickID,
@@ -150,7 +150,7 @@ var conversionDeleteCmd = &cobra.Command{
 				return parseErr
 			}
 			if len(idList) == 0 {
-				return fmt.Errorf("--ids requires at least one ID")
+				return validationError("--ids requires at least one ID").WithHint("Comma-separate internal ids, e.g. --ids 12,13,14 (find them with the matching `... list`).")
 			}
 
 			force, _ := cmd.Flags().GetBool("force")

--- a/go-cli/cmd/conversion_verify.go
+++ b/go-cli/cmd/conversion_verify.go
@@ -84,7 +84,7 @@ var conversionSimulateCmd = &cobra.Command{
 			} `json:"data"`
 		}
 		if json.Unmarshal(urlData, &resp) != nil || resp.Data.DirectURL == "" {
-			return validationError("tracker has no resolvable link")
+			return validationError("tracker has no resolvable link").WithHint("Check the tracker with `p202 tracker get <id>`; it needs a landing page or redirect URL before it can be verified.")
 		}
 		link := resp.Data.DirectURL
 		if !strings.HasPrefix(link, "http") {
@@ -98,13 +98,13 @@ var conversionSimulateCmd = &cobra.Command{
 		}
 		clickRes, err := probeClient().Get(link + sep + "t202kw=simulate")
 		if err != nil {
-			return fmt.Errorf("click request failed: %w", err)
+			return withHint(fmt.Errorf("click request failed: %w", err), "The tracking link itself could not be fetched; check that the configured URL is reachable from here and that the tracker is active.")
 		}
 		loc := clickRes.Header.Get("Location")
 		clickRes.Body.Close()
 		m := subidRe.FindStringSubmatch(loc)
 		if m == nil {
-			return fmt.Errorf("could not parse a subid from the redirect (%q) — the link may be misconfigured", loc)
+			return withHint(fmt.Errorf("could not parse a subid from the redirect (%q)", loc), "The tracking link did not redirect with a subid; open `p202 tracker get <id>` and confirm the landing page/redirect is configured and BlazerCache is current.")
 		}
 		subid := m[1]
 
@@ -112,7 +112,7 @@ var conversionSimulateCmd = &cobra.Command{
 		pbURL := fmt.Sprintf("%s/tracking202/static/gpb.php?amount=%s&subid=%s", base, payout, subid)
 		pbRes, err := (&http.Client{Timeout: 15 * time.Second}).Get(pbURL)
 		if err != nil {
-			return fmt.Errorf("postback request failed: %w", err)
+			return withHint(fmt.Errorf("postback request failed: %w", err), "The postback URL could not be fetched; check the server URL and that the postback endpoint (tracking202/static/gpb.php) is reachable.")
 		}
 		body, _ := io.ReadAll(pbRes.Body)
 		pbRes.Body.Close()

--- a/go-cli/cmd/crosstab.go
+++ b/go-cli/cmd/crosstab.go
@@ -36,7 +36,7 @@ var reportCrosstabCmd = &cobra.Command{
 		colDim := resolveDimension(mustString(cmd, "cols"))
 		metric := resolveMetric(mustString(cmd, "metric"))
 		if rowDim == "" || colDim == "" {
-			return validationError("--rows and --cols are required")
+			return validationError("--rows and --cols are required").WithHint("Pass two entity dimensions, e.g. --rows campaign --cols country.")
 		}
 		if metric == "" {
 			metric = "total_net"

--- a/go-cli/cmd/crud.go
+++ b/go-cli/cmd/crud.go
@@ -121,7 +121,7 @@ func bulkOrSingleDelete(cmd *cobra.Command, endpoint, noun string) error {
 			return perr
 		}
 		if len(ids) == 0 {
-			return fmt.Errorf("--ids requires at least one ID")
+			return validationError("--ids requires at least one ID").WithHint("Comma-separate internal ids, e.g. --ids 12,13,14 (find them with the matching `... list`).")
 		}
 		if !force && !confirmPrompt("Delete %d %ss?", len(ids), noun) {
 			fmt.Fprintln(os.Stderr, "Cancelled.")
@@ -144,7 +144,7 @@ func bulkOrSingleDelete(cmd *cobra.Command, endpoint, noun string) error {
 	}
 
 	if len(args) != 1 {
-		return fmt.Errorf("provide a single id or use --ids")
+		return validationError("provide a single id or use --ids").WithHint("Pass one id as the argument, or several with --ids 12,13,14.")
 	}
 	if !force && !confirmPrompt("Delete %s %s?", noun, args[0]) {
 		fmt.Fprintln(os.Stderr, "Cancelled.")
@@ -245,7 +245,7 @@ func parseDataArray(data []byte) ([]map[string]interface{}, error) {
 	}
 	rawItems, ok := parsed["data"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("response did not include a data array")
+		return nil, withHint(fmt.Errorf("response did not include a data array"), "The server returned an unexpected shape; check the API version with `p202 system version` and that the URL points at the API root.")
 	}
 	items := make([]map[string]interface{}, 0, len(rawItems))
 	for _, raw := range rawItems {
@@ -300,7 +300,7 @@ func parseIDList(raw string) ([]string, error) {
 			continue
 		}
 		if _, err := strconv.Atoi(id); err != nil {
-			return nil, fmt.Errorf("invalid ID %q: must be a numeric value", id)
+			return nil, validationError("invalid ID %q: must be a numeric value", id).WithHint("Use the internal numeric id from the matching `... list`; public ids from tracking links need --public where supported.")
 		}
 		seen[id] = true
 		out = append(out, id)
@@ -415,7 +415,7 @@ func registerCRUD(entity crudEntity) *cobra.Command {
 			allRows, _ := cmd.Flags().GetBool("all")
 			resolveNames, _ := cmd.Flags().GetBool("resolve-names")
 			if resolveNames && !envFlagEnabled("CLI_ENABLE_RESOLVE_NAMES", true) {
-				return fmt.Errorf("--resolve-names is disabled (set CLI_ENABLE_RESOLVE_NAMES=1 to enable)")
+				return validationError("--resolve-names is disabled").WithHint("Set CLI_ENABLE_RESOLVE_NAMES=1 in the environment to enable it, or drop the flag.")
 			}
 
 			if allRows {
@@ -532,7 +532,7 @@ func registerCRUD(entity crudEntity) *cobra.Command {
 			}
 			for _, f := range entity.Fields {
 				if f.Required && body[f.Name] == "" {
-					return fmt.Errorf("required flag --%s is missing", f.Name)
+					return validationError("required flag --%s is missing", f.Name)
 				}
 			}
 			data, err := c.Post(entity.Endpoint, body)
@@ -566,7 +566,7 @@ func registerCRUD(entity crudEntity) *cobra.Command {
 				}
 			}
 			if len(body) == 0 {
-				return fmt.Errorf("no fields specified; pass at least one flag to update")
+				return validationError("no fields specified; pass at least one flag to update")
 			}
 			data, err := c.Put(entity.Endpoint+"/"+args[0], body)
 			if err != nil {
@@ -605,7 +605,7 @@ func registerCRUD(entity crudEntity) *cobra.Command {
 					return parseErr
 				}
 				if len(idList) == 0 {
-					return fmt.Errorf("--ids requires at least one ID")
+					return validationError("--ids requires at least one ID").WithHint("Comma-separate internal ids, e.g. --ids 12,13,14 (find them with the matching `... list`).")
 				}
 
 				force, _ := cmd.Flags().GetBool("force")
@@ -719,10 +719,10 @@ func init() {
 			},
 		},
 		{
-			Name:     "tracker",
-			Plural:   "trackers (tracking links that tie a traffic source to a campaign and landing page)",
-			Endpoint: "trackers",
-			IDField:  "tracker_id",
+			Name:          "tracker",
+			Plural:        "trackers (tracking links that tie a traffic source to a campaign and landing page)",
+			Endpoint:      "trackers",
+			IDField:       "tracker_id",
 			PublicIDField: "tracker_id_public",
 			Fields: []crudField{
 				{Name: "aff_campaign_id", Desc: "Campaign ID", Required: true},
@@ -899,7 +899,7 @@ func init() {
 				}
 				for _, f := range trackerEntity.Fields {
 					if f.Required && body[f.Name] == "" {
-						return fmt.Errorf("required flag --%s is missing", f.Name)
+						return validationError("required flag --%s is missing", f.Name)
 					}
 				}
 
@@ -978,7 +978,7 @@ func init() {
 
 				concurrency, _ := cmd.Flags().GetInt("concurrency")
 				if concurrency < 1 {
-					return fmt.Errorf("--concurrency must be at least 1")
+					return validationError("--concurrency must be at least 1")
 				}
 				if concurrency > len(trackers) {
 					concurrency = len(trackers)

--- a/go-cli/cmd/diff.go
+++ b/go-cli/cmd/diff.go
@@ -39,11 +39,11 @@ var diffCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := strings.TrimSpace(args[0])
 		if target == "" {
-			return validationError("entity is required").WithHint("Pass an entity to compare, or `all`: %s", strings.Join(sortedPortableEntities(), ", "))
+			return validationError("entity is required (one of: all, %s)", strings.Join(sortedPortableEntities(), ", ")).WithHint("Pass the entity as the first argument, e.g. `p202 diff campaigns --from prod --to staging`; `all` compares every entity.")
 		}
 		if target != "all" {
 			if _, ok := portableEntities[target]; !ok {
-				return validationError("unsupported entity %q", target).WithHint("Supported entities: all, %s", strings.Join(sortedPortableEntities(), ", "))
+				return validationError("unsupported entity %q (supported: all, %s)", target, strings.Join(sortedPortableEntities(), ", ")).WithHint("Pass one of those as the first argument; `all` compares every entity.")
 			}
 		}
 

--- a/go-cli/cmd/diff.go
+++ b/go-cli/cmd/diff.go
@@ -39,18 +39,18 @@ var diffCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := strings.TrimSpace(args[0])
 		if target == "" {
-			return fmt.Errorf("entity is required")
+			return validationError("entity is required").WithHint("Pass an entity to compare, or `all`: %s", strings.Join(sortedPortableEntities(), ", "))
 		}
 		if target != "all" {
 			if _, ok := portableEntities[target]; !ok {
-				return fmt.Errorf("unsupported entity %q", target)
+				return validationError("unsupported entity %q", target).WithHint("Supported entities: all, %s", strings.Join(sortedPortableEntities(), ", "))
 			}
 		}
 
 		fromProfile := firstFlag(cmd, "from", "source")
 		toProfile := firstFlag(cmd, "to", "target")
 		if fromProfile == "" || toProfile == "" {
-			return fmt.Errorf("--from and --to are required")
+			return validationError("--from and --to are required").WithHint("Pass profile names, e.g. --from prod --to staging; `p202 config list-profiles` shows them.")
 		}
 
 		fromClient, err := api.NewFromProfile(fromProfile)

--- a/go-cli/cmd/entity_errors_test.go
+++ b/go-cli/cmd/entity_errors_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// The Go CLI error contract puts lists of valid values in the message
+// itself and keeps the hint for the next action. Every command that takes
+// a portable entity name must report the supported set the same way.
+func TestUnsupportedEntityMessageListsSupportedValues(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, "http://127.0.0.1:9", "test-key")
+
+	cases := []struct {
+		name     string
+		run      func() error
+		allowAll bool
+	}{
+		{"diff", func() error { _, _, err := executeCommand("diff", "bogus", "--from", "a", "--to", "b"); return err }, true},
+		{"export", func() error { _, _, err := executeCommand("export", "bogus"); return err }, true},
+		{"import", func() error { _, _, err := executeCommand("import", "bogus", "missing.json"); return err }, false},
+		{"sync", func() error { _, err := selectedSyncEntities("bogus"); return err }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil {
+				t.Fatal("expected an error for an unsupported entity")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, `unsupported entity "bogus"`) || !strings.Contains(msg, "supported:") {
+				t.Errorf("message should name the bad value and the supported set, got %q", msg)
+			}
+			for _, entity := range sortedPortableEntities() {
+				if !strings.Contains(msg, entity) {
+					t.Errorf("message missing supported entity %q: %q", entity, msg)
+				}
+			}
+			if tc.allowAll != strings.Contains(msg, "supported: all,") {
+				t.Errorf("message should list `all` = %v, got %q", tc.allowAll, msg)
+			}
+			if hint := hintFor(err); hint == "" || strings.Contains(hint, "Supported entities") {
+				t.Errorf("hint should carry the next action, not the value list, got %q", hint)
+			}
+			if exitCodeForError(err) != ExitValidation {
+				t.Errorf("exit code = %d, want %d", exitCodeForError(err), ExitValidation)
+			}
+		})
+	}
+}
+
+func TestDiffMissingEntityMessageListsSupportedValues(t *testing.T) {
+	_, _, err := executeCommand("diff", " ", "--from", "a", "--to", "b")
+	if err == nil {
+		t.Fatal("expected an error for a blank entity")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "entity is required (one of: all,") || !strings.Contains(msg, "campaigns") {
+		t.Errorf("message should list the entities to choose from, got %q", msg)
+	}
+	if hint := hintFor(err); !strings.Contains(hint, "p202 diff") {
+		t.Errorf("hint should show an example invocation, got %q", hint)
+	}
+}

--- a/go-cli/cmd/exec.go
+++ b/go-cli/cmd/exec.go
@@ -40,20 +40,20 @@ var execCmd = &cobra.Command{
 			return err
 		}
 		if len(profiles) == 0 {
-			return fmt.Errorf("exec requires one of --all-profiles, --profiles, or --group")
+			return validationError("exec requires one of --all-profiles, --profiles, or --group").WithHint("Example: `p202 exec --all-profiles -- campaign list --limit 5`.")
 		}
 
 		subArgs := append([]string(nil), args...)
 		if len(subArgs) == 0 {
-			return fmt.Errorf("exec requires a subcommand after --")
+			return validationError("exec requires a subcommand after --").WithHint("Put the command to run after a literal `--`, e.g. `p202 exec --profiles prod,staging -- report summary --period today`.")
 		}
 		if subArgs[0] == "exec" {
-			return fmt.Errorf("recursive exec invocation is not allowed")
+			return validationError("recursive exec invocation is not allowed").WithHint("Run the inner command directly after `--`; do not nest `exec` inside `exec`.")
 		}
 
 		concurrency, _ := cmd.Flags().GetInt("concurrency")
 		if concurrency < 1 {
-			return fmt.Errorf("--concurrency must be at least 1")
+			return validationError("--concurrency must be at least 1")
 		}
 		if concurrency > len(profiles) {
 			concurrency = len(profiles)

--- a/go-cli/cmd/export.go
+++ b/go-cli/cmd/export.go
@@ -50,7 +50,7 @@ var exportCmd = &cobra.Command{
 		} else {
 			endpoint, ok := portableEntities[target]
 			if !ok {
-				return fmt.Errorf("unsupported entity %q", target)
+				return validationError("unsupported entity %q", target).WithHint("Supported entities: all, %s", strings.Join(sortedPortableEntities(), ", "))
 			}
 			rows, err := fetchAllRows(c, endpoint)
 			if err != nil {
@@ -140,7 +140,7 @@ func fetchAllRowsWithParams(c *api.Client, endpoint string, baseParams map[strin
 			step = pg.limit
 		}
 		if step <= 0 {
-			return nil, fmt.Errorf("pagination stalled for %s: invalid page size at offset %d", endpoint, offset)
+			return nil, withHint(fmt.Errorf("pagination stalled for %s: invalid page size at offset %d", endpoint, offset), "The server returned an unusable page; retry, and if it persists check the API version with `p202 system version` and the server logs.")
 		}
 
 		if pg.hasTotal && len(all) >= pg.total {
@@ -152,7 +152,7 @@ func fetchAllRowsWithParams(c *api.Client, endpoint string, baseParams map[strin
 		}
 
 		if added == 0 {
-			return nil, fmt.Errorf("pagination stalled for %s: page at offset %d contained no new rows", endpoint, offset)
+			return nil, withHint(fmt.Errorf("pagination stalled for %s: page at offset %d contained no new rows", endpoint, offset), "The server keeps returning the same page; retry, and if it persists check the API version with `p202 system version` and the server logs.")
 		}
 
 		reportedOffset := offset
@@ -161,7 +161,7 @@ func fetchAllRowsWithParams(c *api.Client, endpoint string, baseParams map[strin
 		}
 		nextOffset := reportedOffset + step
 		if nextOffset <= offset {
-			return nil, fmt.Errorf("pagination stalled for %s: next offset %d did not advance from %d", endpoint, nextOffset, offset)
+			return nil, withHint(fmt.Errorf("pagination stalled for %s: next offset %d did not advance from %d", endpoint, nextOffset, offset), "The server's pagination cursor did not advance; retry, and if it persists check the API version with `p202 system version` and the server logs.")
 		}
 
 		offset = nextOffset

--- a/go-cli/cmd/export.go
+++ b/go-cli/cmd/export.go
@@ -50,7 +50,7 @@ var exportCmd = &cobra.Command{
 		} else {
 			endpoint, ok := portableEntities[target]
 			if !ok {
-				return validationError("unsupported entity %q", target).WithHint("Supported entities: all, %s", strings.Join(sortedPortableEntities(), ", "))
+				return validationError("unsupported entity %q (supported: all, %s)", target, strings.Join(sortedPortableEntities(), ", ")).WithHint("Pass one of those as the first argument; `all` exports every entity.")
 			}
 			rows, err := fetchAllRows(c, endpoint)
 			if err != nil {

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -95,6 +95,13 @@ so leads = clicks x conv_rate, income = leads x avg_payout, and net =
 income - cost hold exactly; --all-metrics forecasts all core metrics
 together this way.
 
+Bounds are empirical quantiles from a rolling backtest (meta "bounds" names
+the pair, e.g. p05-p95 (90%)); short histories fall back to Gaussian bounds
+(meta "bounds_source"). Short outlier runs such as a tracking outage are
+masked from fitting and listed in meta "anomalies_masked"; a detected level
+shift is reported as "level_shift_at" and the new regime is fitted. Use
+--no-anomaly-mask / --no-level-shift to fit the history exactly as-is.
+
 Examples:
   p202 forecast --metric revenue --horizon 7
   p202 forecast --metric clicks --history last90 --method linear
@@ -103,7 +110,8 @@ Examples:
   p202 forecast --metric conv_rate --history last30 --interval week --horizon 4
   p202 forecast --metric revenue --aff_campaign_id 5 --horizon 7
   p202 forecast --metric revenue --events --horizon 14
-  p202 forecast --metric clicks --events --event-tag us-holidays`,
+  p202 forecast --metric clicks --events --event-tag us-holidays
+  p202 forecast --metric clicks --no-anomaly-mask --json`,
 	Aliases: []string{"predict"},
 	RunE:    runForecast,
 }

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -82,9 +82,10 @@ and weighted moving averages, damped-trend Holt-Winters exponential smoothing,
 and an ensemble (the default, alias "auto") that combines the methods weighted
 by rolling-backtest accuracy and reports each member's share.
 
-With --seasonal, predictions are modulated by day-of-week weights derived from
-weekpart report data to account for weekly patterns (e.g., "Tuesdays always
-convert better"). Seasonal adjustment requires --interval day or hour.
+With --seasonal, predictions are modulated by a day-of-week profile learned
+from the fetched history itself (re-estimated inside every backtest fold, so
+the bands describe the profiled forecast) to account for weekly patterns
+(e.g., "Tuesdays always convert better"). Requires --interval day or hour.
 
 Event-aware forecasting (--events, --event-tag) uses stored calendar events and
 requires --interval day.
@@ -351,28 +352,20 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Optionally fetch weekpart data for seasonal adjustment. Weekday
-	// multipliers are shrunk toward 1.0 by each weekday's sample count in
-	// the fetched series, so a thin history can't produce extreme weights;
-	// hourly forecasts additionally get an hour-of-day profile built from
-	// the series itself. The forecast engine gates both profiles on
-	// detrended autocorrelation before applying them.
+	// Seasonal profiles are learned from the fetched history inside the
+	// engine, re-estimated from each backtest fold's own prefix (with
+	// shrinkage by sample count and an autocorrelation gate), so the bands
+	// and errors describe the profiled forecast without a held-out day
+	// ever contributing to its own multiplier. Hourly forecasts get an
+	// hour-of-day profile in addition to the weekday one.
 	if seasonal {
-		weekpartParams := collectForecastFilters(cmd)
-		weekpartParams["period"] = history
-		wpData, wpErr := c.Get("reports/weekpart", weekpartParams)
-		if wpErr == nil {
-			weights := parseWeekpartWeights(wpData, metric)
-			if weights != nil {
-				cfg.SeasonalWeights = forecast.ShrinkWeekdayWeights(weights, forecast.WeekdayCounts(series))
-			}
-		}
+		cfg.WeekdayProfile = true
 		if interval == "hour" && !forecastSignedMetrics[metric] {
-			cfg.HourlyWeights = forecast.BuildHourlyWeights(series)
+			cfg.HourlyProfile = true
 		}
 	}
 	if seasonalMonthly {
-		cfg.MonthDayWeights = forecast.BuildMonthDayWeights(series)
+		cfg.MonthDayProfile = true
 	}
 
 	// ── Event-aware forecasting pipeline ──────────────────────────────
@@ -704,6 +697,7 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 	}
 
 	compositions := map[string]interface{}{}
+	dataPoints := map[string]interface{}{}
 	boundsSources := map[string]interface{}{}
 	boundsLabels := map[string]interface{}{}
 	levelShifts := map[string]interface{}{}
@@ -716,6 +710,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 		if res.Composition != "" {
 			compositions[m] = res.Composition
 		}
+		// Per metric: a derived metric reports the fewest points any of
+		// its drivers was fitted on, which can be below the clicks count.
+		dataPoints[m] = res.DataPoints
 		if res.BoundsSource != "" {
 			boundsSources[m] = res.BoundsSource
 		}
@@ -734,7 +731,7 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 		"method":           string(clicks.Method),
 		"horizon":          clicks.Horizon,
 		"interval":         string(clicks.Interval),
-		"data_points_used": clicks.DataPoints,
+		"data_points_used": dataPoints,
 		"composition":      compositions,
 	}
 	if len(boundsSources) > 0 {
@@ -761,28 +758,6 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 		return nil, fmt.Errorf("marshalling forecast output: %w", err)
 	}
 	return payload, nil
-}
-
-// parseWeekpartWeights extracts seasonal weights from the weekpart API response.
-func parseWeekpartWeights(data []byte, metric string) forecast.SeasonalWeights {
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return nil
-	}
-
-	rawItems, ok := parsed["data"].([]interface{})
-	if !ok {
-		return nil
-	}
-
-	rows := make([]map[string]interface{}, 0, len(rawItems))
-	for _, raw := range rawItems {
-		if obj, ok := raw.(map[string]interface{}); ok {
-			rows = append(rows, obj)
-		}
-	}
-
-	return forecast.BuildWeekdayWeights(rows, metric)
 }
 
 // forecastOutputOpts carries the run context buildForecastOutput reports in
@@ -1163,7 +1138,7 @@ func init() {
 	forecastCmd.Flags().String("days", "", "Alias of --history")
 	forecastCmd.Flags().Int("window", 0, "SMA/WMA window size (0 = auto-select)")
 	forecastCmd.Flags().Bool("all-metrics", false, "Forecast clicks, leads, income, cost, and net together via ratio decomposition (coherent output)")
-	forecastCmd.Flags().Bool("seasonal", false, "Apply day-of-week seasonal adjustment from weekpart data (hour interval also gets an hour-of-day profile)")
+	forecastCmd.Flags().Bool("seasonal", false, "Apply a day-of-week profile learned from the fetched history (hour interval also gets an hour-of-day profile)")
 	forecastCmd.Flags().Bool("seasonal-monthly", false, "Apply day-of-month seasonal adjustment learned from the fetched series (requires --interval day)")
 	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds; snaps to the nearest band: 0.50 (p25-p75), 0.80 (p10-p90), or 0.90 (p05-p95, also used for 0.95/0.99)")
 	forecastCmd.Flags().Bool("no-level-shift", false, "Disable level-shift detection (fit the full history as-is)")

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -299,7 +299,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 			return withHint(validationError("coherent forecast failed: %v", rcErr),
 				"One of the core metrics has too little history to compose from. Use a longer --history, or forecast the metric you need on its own with --metric (it falls back to a direct forecast automatically).")
 		}
-		output, boErr := buildAllMetricsOutput(results, rejected)
+		output, boErr := buildAllMetricsOutput(results, rejected, confidence)
 		if boErr != nil {
 			return boErr
 		}
@@ -659,10 +659,27 @@ func parsedMetricNames(parsed map[string]forecast.Series) []string {
 	return names
 }
 
+// boundsLabel names the band a result's lower/upper pair represents, so a
+// consumer never has to know the invocation to interpret it: conformal
+// bands snap to the nearest emitted quantile pair (say which, so the
+// requested --confidence is not mistaken for it); composed bands pair the
+// operands' endpoints at worst case, valid but with no single nominal
+// coverage to claim. Gaussian bands carry no label.
+func boundsLabel(source string, confidence float64) string {
+	lowerName, upperName, coverage := forecast.BoundLevels(confidence)
+	switch source {
+	case forecast.BoundsConformal:
+		return fmt.Sprintf("%s-%s (%.0f%%)", lowerName, upperName, coverage*100)
+	case forecast.BoundsComposed:
+		return fmt.Sprintf("%s-%s (composed from operand bands, not calibrated)", lowerName, upperName)
+	}
+	return ""
+}
+
 // buildAllMetricsOutput renders the coherent multi-metric forecast: one row
 // per date with value/lower/upper columns for each core metric, plus a meta
 // block reporting each metric's composition.
-func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([]byte, error) {
+func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, confidence float64) ([]byte, error) {
 	clicks := results[forecast.MetricClicks]
 	if clicks == nil || len(clicks.Predictions) == 0 {
 		return nil, fmt.Errorf("coherent forecast returned no click predictions")
@@ -688,6 +705,7 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 
 	compositions := map[string]interface{}{}
 	boundsSources := map[string]interface{}{}
+	boundsLabels := map[string]interface{}{}
 	levelShifts := map[string]interface{}{}
 	anomalies := map[string]interface{}{}
 	for _, m := range forecastCoreMetrics {
@@ -700,6 +718,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 		}
 		if res.BoundsSource != "" {
 			boundsSources[m] = res.BoundsSource
+		}
+		if label := boundsLabel(res.BoundsSource, confidence); label != "" {
+			boundsLabels[m] = label
 		}
 		if res.LevelShiftAt != "" {
 			levelShifts[m] = res.LevelShiftAt
@@ -718,6 +739,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 	}
 	if len(boundsSources) > 0 {
 		meta["bounds_source"] = boundsSources
+	}
+	if len(boundsLabels) > 0 {
+		meta["bounds"] = boundsLabels
 	}
 	if len(levelShifts) > 0 {
 		meta["level_shifts"] = levelShifts
@@ -785,7 +809,7 @@ func roundWeights(weights map[string]float64) map[string]interface{} {
 // buildForecastOutput constructs the JSON output for rendering.
 func buildForecastOutput(result *forecast.Result, metric string, opts forecastOutputOpts) ([]byte, error) {
 	seasonal, eventsActive, futureEvents, impacts := opts.seasonal, opts.eventsActive, opts.futureEvents, opts.impacts
-	lowerName, upperName, coverage := forecast.BoundLevels(opts.confidence)
+	lowerName, upperName, _ := forecast.BoundLevels(opts.confidence)
 	predictions := make([]map[string]interface{}, len(result.Predictions))
 	for i, p := range result.Predictions {
 		row := map[string]interface{}{
@@ -856,15 +880,8 @@ func buildForecastOutput(result *forecast.Result, metric string, opts forecastOu
 	if result.BoundsSource != "" {
 		meta["bounds_source"] = result.BoundsSource
 	}
-	switch result.BoundsSource {
-	case forecast.BoundsConformal:
-		// Conformal bands snap to the nearest emitted quantile pair; say
-		// which one so the requested --confidence is not mistaken for it.
-		meta["bounds"] = fmt.Sprintf("%s-%s (%.0f%%)", lowerName, upperName, coverage*100)
-	case forecast.BoundsComposed:
-		// Operand bands paired at worst case: valid, but with no single
-		// nominal coverage to claim.
-		meta["bounds"] = fmt.Sprintf("%s-%s (composed from operand bands, not calibrated)", lowerName, upperName)
+	if label := boundsLabel(result.BoundsSource, opts.confidence); label != "" {
+		meta["bounds"] = label
 	}
 	if opts.rejected > 0 {
 		meta["buckets_rejected"] = opts.rejected

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -314,8 +314,8 @@ func runForecast(cmd *cobra.Command, args []string) error {
 			return validationError("no valid data points found for metric %q", metric).
 				WithHint("No bucket in the response carried a numeric %q value. Check `p202 report timeseries --period %s` with the same filters to see which metrics the API returns for this window.", metric, history)
 		}
-		return validationError("no valid data points found for metric %q", metric).
-			WithHint("The response carried values for %s but not %q. Pick one of those with --metric, or widen --history.", strings.Join(available, ", "), metric)
+		return validationError("no valid data points found for metric %q (response carried: %s)", metric, strings.Join(available, ", ")).
+			WithHint("Pick one of the metrics the response carried with --metric, or widen --history.")
 	}
 	if len(series) < 3 {
 		return validationError("not enough data points (%d) for forecasting — need at least 3", len(series)).

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -36,6 +36,22 @@ var forecastSignedMetrics = map[string]bool{
 	"roi":       true,
 }
 
+// forecastCoreMetrics are the metrics RunCoherent consumes and produces.
+var forecastCoreMetrics = []string{
+	forecast.MetricClicks, forecast.MetricLeads, forecast.MetricIncome,
+	forecast.MetricCost, forecast.MetricNet,
+}
+
+// forecastDerivedMetrics are composed from driver forecasts (clicks and
+// rates) when requested individually, keeping them consistent with what a
+// clicks forecast implies.
+var forecastDerivedMetrics = map[string]bool{
+	forecast.MetricLeads:  true,
+	forecast.MetricIncome: true,
+	forecast.MetricCost:   true,
+	forecast.MetricNet:    true,
+}
+
 var forecastMetricAliases = map[string]string{
 	"clicks":      "total_clicks",
 	"conversions": "total_leads",
@@ -65,10 +81,17 @@ convert better"). Seasonal adjustment requires --interval day or hour.
 Event-aware forecasting (--events, --event-tag) uses stored calendar events and
 requires --interval day.
 
+Derived metrics (leads, income, cost, net) requested without --seasonal or
+--events are composed from driver forecasts (clicks and the linking rates),
+so leads = clicks x conv_rate, income = leads x avg_payout, and net =
+income - cost hold exactly; --all-metrics forecasts all core metrics
+together this way.
+
 Examples:
   p202 forecast --metric revenue --horizon 7
   p202 forecast --metric clicks --history last90 --method linear
   p202 forecast --metric profit --horizon 14 --method auto --seasonal
+  p202 forecast --all-metrics --horizon 7
   p202 forecast --metric conv_rate --history last30 --interval week --horizon 4
   p202 forecast --metric revenue --aff_campaign_id 5 --horizon 7
   p202 forecast --metric revenue --events --horizon 14
@@ -78,16 +101,23 @@ Examples:
 }
 
 func runForecast(cmd *cobra.Command, args []string) error {
+	allMetrics, _ := cmd.Flags().GetBool("all-metrics")
 	metric, _ := cmd.Flags().GetString("metric")
 	metric = strings.ToLower(strings.TrimSpace(metric))
-	if metric == "" {
-		return validationError("--metric is required. Choose from: %s", forecastMetricList())
-	}
-	if mapped, ok := forecastMetricAliases[metric]; ok {
-		metric = mapped
-	}
-	if !forecastAllowedMetrics[metric] {
-		return validationError("unsupported metric %q. Choose from: %s", metric, forecastMetricList())
+	if allMetrics {
+		if metric != "" {
+			return validationError("--all-metrics forecasts the core metrics together and cannot be combined with --metric")
+		}
+	} else {
+		if metric == "" {
+			return validationError("--metric is required. Choose from: %s", forecastMetricList())
+		}
+		if mapped, ok := forecastMetricAliases[metric]; ok {
+			metric = mapped
+		}
+		if !forecastAllowedMetrics[metric] {
+			return validationError("unsupported metric %q. Choose from: %s", metric, forecastMetricList())
+		}
 	}
 
 	methodStr, _ := cmd.Flags().GetString("method")
@@ -169,6 +199,12 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		// granularity; other intervals would silently produce wrong adjustments.
 		return validationError("--events and --event-tag require --interval day")
 	}
+	if allMetrics && (seasonal || useEvents || eventTag != "") {
+		// Seasonal and event adjustment layers operate on a single metric's
+		// series; combining them with the coherent multi-metric path would
+		// silently skip them for the derived metrics.
+		return validationError("--all-metrics cannot be combined with --seasonal, --events, or --event-tag")
+	}
 	confidence, _ := cmd.Flags().GetFloat64("confidence")
 	if confidence <= 0 || confidence >= 1 {
 		confidence = 0.95
@@ -190,15 +226,6 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("fetching historical data: %w", err)
 	}
 
-	series, err := parseTimeseries(data, metric)
-	if err != nil {
-		return err
-	}
-
-	if len(series) < 3 {
-		return validationError("not enough data points (%d) for forecasting — need at least 3. Try a longer --history period", len(series))
-	}
-
 	// Build forecast config. Metrics that cannot go negative (counts,
 	// amounts, rates) get zero-clipped bounds and quantiles.
 	cfg := forecast.Config{
@@ -209,6 +236,56 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		SMAWindow:       smaWindow,
 		ConfidenceLevel: confidence,
 		NonNegative:     !forecastSignedMetrics[metric],
+	}
+
+	// ── Coherent multi-metric forecasting ─────────────────────────────
+	if allMetrics {
+		coherentSeries, csErr := parseTimeseriesMulti(data, forecastCoreMetrics)
+		if csErr != nil {
+			return csErr
+		}
+		results, rcErr := forecast.RunCoherent(coherentSeries, cfg)
+		if rcErr != nil {
+			return fmt.Errorf("coherent forecast failed: %w", rcErr)
+		}
+		output, boErr := buildAllMetricsOutput(results)
+		if boErr != nil {
+			return boErr
+		}
+		render(output)
+		return nil
+	}
+
+	series, err := parseTimeseries(data, metric)
+	if err != nil {
+		return err
+	}
+
+	if len(series) < 3 {
+		return validationError("not enough data points (%d) for forecasting — need at least 3. Try a longer --history period", len(series))
+	}
+
+	// A derived metric requested on its own (without seasonal or event
+	// layers, which operate on the metric's own series) is forecast via
+	// ratio decomposition so it stays consistent with what the clicks
+	// forecast implies. Any failure — missing companion metrics in the
+	// response, too-sparse drivers upstream — falls back to the direct path.
+	if forecastDerivedMetrics[metric] && !seasonal && !useEvents && eventTag == "" {
+		if coherentSeries, csErr := parseTimeseriesMulti(data, forecastCoreMetrics); csErr == nil {
+			if results, rcErr := forecast.RunCoherent(coherentSeries, cfg); rcErr == nil {
+				if result := results[metric]; result != nil {
+					if !forecastSignedMetrics[metric] {
+						clampNonNegative(result.Predictions)
+					}
+					output, boErr := buildForecastOutput(result, metric, false, false, nil, nil)
+					if boErr != nil {
+						return boErr
+					}
+					render(output)
+					return nil
+				}
+			}
+		}
 	}
 
 	// Optionally fetch weekpart data for seasonal adjustment.
@@ -465,6 +542,102 @@ func extractMetricValue(obj map[string]interface{}, metric string) (float64, boo
 	}
 }
 
+// parseTimeseriesMulti extracts one forecast.Series per requested metric
+// from a single timeseries response. A bucket missing a metric's value is
+// skipped for that metric only.
+func parseTimeseriesMulti(data []byte, metrics []string) (map[string]forecast.Series, error) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid timeseries response: %w", err)
+	}
+
+	rawItems, ok := parsed["data"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("timeseries response missing data array")
+	}
+	if len(rawItems) == 0 {
+		return nil, fmt.Errorf("timeseries returned empty data")
+	}
+
+	out := make(map[string]forecast.Series, len(metrics))
+	for _, raw := range rawItems {
+		obj, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, tErr := parseBucketTime(obj)
+		if tErr != nil {
+			continue
+		}
+		for _, m := range metrics {
+			if val, vOk := extractMetricValue(obj, m); vOk {
+				out[m] = append(out[m], forecast.Point{T: t, V: val})
+			}
+		}
+	}
+
+	for _, m := range metrics {
+		sort.Slice(out[m], func(i, j int) bool { return out[m][i].T.Before(out[m][j].T) })
+	}
+	return out, nil
+}
+
+// buildAllMetricsOutput renders the coherent multi-metric forecast: one row
+// per date with value/lower/upper columns for each core metric, plus a meta
+// block reporting each metric's composition.
+func buildAllMetricsOutput(results map[string]*forecast.Result) ([]byte, error) {
+	clicks := results[forecast.MetricClicks]
+	if clicks == nil || len(clicks.Predictions) == 0 {
+		return nil, fmt.Errorf("coherent forecast returned no click predictions")
+	}
+
+	rows := make([]map[string]interface{}, len(clicks.Predictions))
+	for i := range clicks.Predictions {
+		row := map[string]interface{}{
+			"date": formatPredictionTime(clicks.Predictions[i].T, clicks.Interval),
+		}
+		for _, m := range forecastCoreMetrics {
+			res := results[m]
+			if res == nil || i >= len(res.Predictions) {
+				continue
+			}
+			p := res.Predictions[i]
+			row[m] = roundTo(p.Value, 2)
+			row[m+"_lower"] = roundTo(p.LowerBound, 2)
+			row[m+"_upper"] = roundTo(p.UpperBound, 2)
+		}
+		rows[i] = row
+	}
+
+	compositions := map[string]interface{}{}
+	for _, m := range forecastCoreMetrics {
+		if res := results[m]; res != nil && res.Composition != "" {
+			compositions[m] = res.Composition
+		}
+	}
+
+	meta := map[string]interface{}{
+		"method":           string(clicks.Method),
+		"horizon":          clicks.Horizon,
+		"interval":         string(clicks.Interval),
+		"data_points_used": clicks.DataPoints,
+		"composition":      compositions,
+	}
+	if len(clicks.Weights) > 0 {
+		weights := make(map[string]interface{}, len(clicks.Weights))
+		for m, w := range clicks.Weights {
+			weights[m] = roundTo(w, 3)
+		}
+		meta["weights"] = weights
+	}
+
+	payload, err := json.Marshal(map[string]interface{}{"data": rows, "meta": meta})
+	if err != nil {
+		return nil, fmt.Errorf("marshalling forecast output: %w", err)
+	}
+	return payload, nil
+}
+
 // parseWeekpartWeights extracts seasonal weights from the weekpart API response.
 func parseWeekpartWeights(data []byte, metric string) forecast.SeasonalWeights {
 	var parsed map[string]interface{}
@@ -534,6 +707,9 @@ func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, 
 		"trend_pct":        roundTo(result.TrendPct, 2),
 		"seasonal":         seasonal,
 		"events_active":    eventsActive,
+	}
+	if result.Composition != "" {
+		meta["composition"] = result.Composition
 	}
 	if result.MAE > 0 {
 		meta["mae"] = roundTo(result.MAE, 2)
@@ -837,6 +1013,7 @@ func init() {
 	forecastCmd.Flags().String("period", "", "Alias of --history")
 	forecastCmd.Flags().String("days", "", "Alias of --history")
 	forecastCmd.Flags().Int("window", 0, "SMA/WMA window size (0 = auto-select)")
+	forecastCmd.Flags().Bool("all-metrics", false, "Forecast clicks, leads, income, cost, and net together via ratio decomposition (coherent output)")
 	forecastCmd.Flags().Bool("seasonal", false, "Apply day-of-week seasonal adjustment from weekpart data")
 	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds (0.80, 0.90, 0.95, 0.99)")
 	forecastCmd.Flags().Bool("events", false, "Enable event-aware forecasting using stored forecast events")

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -224,6 +224,14 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	}
 	noLevelShift, _ := cmd.Flags().GetBool("no-level-shift")
 	noAnomalyMask, _ := cmd.Flags().GetBool("no-anomaly-mask")
+	anomalySigma, _ := cmd.Flags().GetFloat64("anomaly-sigma")
+	if anomalySigma <= 0 {
+		return validationError("--anomaly-sigma must be positive (default %.0f)", forecast.DefaultAnomalySigma)
+	}
+	anomalyCycles, _ := cmd.Flags().GetInt("anomaly-cycles")
+	if anomalyCycles < 1 {
+		return validationError("--anomaly-cycles must be at least 1 (default %d)", forecast.DefaultAnomalyCycles)
+	}
 	if seasonalMonthly && forecastSignedMetrics[metric] {
 		// Multiplicative day-of-month profiles are undefined for metrics
 		// that cross zero (a near-zero mean yields unbounded multipliers).
@@ -259,6 +267,8 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		LogTransform:       forecastCountMetrics[metric],
 		DisableLevelShift:  noLevelShift,
 		DisableAnomalyMask: noAnomalyMask,
+		AnomalySigma:       anomalySigma,
+		AnomalyCycles:      anomalyCycles,
 	}
 
 	// ── Coherent multi-metric forecasting ─────────────────────────────
@@ -1099,6 +1109,8 @@ func init() {
 	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds; snaps to the nearest band: 0.50 (p25-p75), 0.80 (p10-p90), or 0.90 (p05-p95, also used for 0.95/0.99)")
 	forecastCmd.Flags().Bool("no-level-shift", false, "Disable level-shift detection (fit the full history as-is)")
 	forecastCmd.Flags().Bool("no-anomaly-mask", false, "Disable transient masking (fit short outlier runs such as tracking outages as data)")
+	forecastCmd.Flags().Float64("anomaly-sigma", forecast.DefaultAnomalySigma, "Transient-masking threshold in robust sigma units (lower masks more aggressively)")
+	forecastCmd.Flags().Int("anomaly-cycles", forecast.DefaultAnomalyCycles, "Seasonal cycles on each side used as same-weekday/hour references for transient masking")
 	forecastCmd.Flags().Bool("events", false, "Enable event-aware forecasting using stored forecast events")
 	forecastCmd.Flags().String("event-tag", "", "Filter forecast events by tag (comma-separated, e.g. us-holidays,promos)")
 

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -687,6 +687,7 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 	}
 
 	compositions := map[string]interface{}{}
+	boundsSources := map[string]interface{}{}
 	levelShifts := map[string]interface{}{}
 	anomalies := map[string]interface{}{}
 	for _, m := range forecastCoreMetrics {
@@ -696,6 +697,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 		}
 		if res.Composition != "" {
 			compositions[m] = res.Composition
+		}
+		if res.BoundsSource != "" {
+			boundsSources[m] = res.BoundsSource
 		}
 		if res.LevelShiftAt != "" {
 			levelShifts[m] = res.LevelShiftAt
@@ -711,6 +715,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 		"interval":         string(clicks.Interval),
 		"data_points_used": clicks.DataPoints,
 		"composition":      compositions,
+	}
+	if len(boundsSources) > 0 {
+		meta["bounds_source"] = boundsSources
 	}
 	if len(levelShifts) > 0 {
 		meta["level_shifts"] = levelShifts
@@ -849,10 +856,15 @@ func buildForecastOutput(result *forecast.Result, metric string, opts forecastOu
 	if result.BoundsSource != "" {
 		meta["bounds_source"] = result.BoundsSource
 	}
-	if result.BoundsSource == forecast.BoundsConformal {
+	switch result.BoundsSource {
+	case forecast.BoundsConformal:
 		// Conformal bands snap to the nearest emitted quantile pair; say
 		// which one so the requested --confidence is not mistaken for it.
 		meta["bounds"] = fmt.Sprintf("%s-%s (%.0f%%)", lowerName, upperName, coverage*100)
+	case forecast.BoundsComposed:
+		// Operand bands paired at worst case: valid, but with no single
+		// nominal coverage to claim.
+		meta["bounds"] = fmt.Sprintf("%s-%s (composed from operand bands, not calibrated)", lowerName, upperName)
 	}
 	if opts.rejected > 0 {
 		meta["buckets_rejected"] = opts.rejected

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -698,6 +698,8 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 
 	compositions := map[string]interface{}{}
 	dataPoints := map[string]interface{}{}
+	maes := map[string]interface{}{}
+	rmses := map[string]interface{}{}
 	boundsSources := map[string]interface{}{}
 	boundsLabels := map[string]interface{}{}
 	levelShifts := map[string]interface{}{}
@@ -713,6 +715,12 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 		// Per metric: a derived metric reports the fewest points any of
 		// its drivers was fitted on, which can be below the clicks count.
 		dataPoints[m] = res.DataPoints
+		// Rolling errors, per metric: compositions are backtested too, so
+		// every metric has its own typical error to judge a forecast by.
+		if res.MAE > 0 {
+			maes[m] = roundTo(res.MAE, 2)
+			rmses[m] = roundTo(res.RMSE, 2)
+		}
 		if res.BoundsSource != "" {
 			boundsSources[m] = res.BoundsSource
 		}
@@ -733,6 +741,10 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 		"interval":         string(clicks.Interval),
 		"data_points_used": dataPoints,
 		"composition":      compositions,
+	}
+	if len(maes) > 0 {
+		meta["mae"] = maes
+		meta["rmse"] = rmses
 	}
 	if len(boundsSources) > 0 {
 		meta["bounds_source"] = boundsSources

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -50,6 +50,13 @@ var forecastCoreMetrics = []string{
 	forecast.MetricCost, forecast.MetricNet,
 }
 
+// forecastCoherentInputs are the observed series RunCoherent consumes; net
+// is composed from them, so its own column is only parsed when net is the
+// metric requested (its direct fallback needs it).
+var forecastCoherentInputs = []string{
+	forecast.MetricClicks, forecast.MetricLeads, forecast.MetricIncome, forecast.MetricCost,
+}
+
 // forecastDerivedMetrics are composed from driver forecasts (clicks and
 // rates) when requested individually, keeping them consistent with what a
 // clicks forecast implies.
@@ -285,9 +292,17 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// metric's own series for the direct path, and the companions for the
 	// coherent path. Buckets or values the parser rejects are counted and
 	// surfaced in the output meta rather than silently dropped.
-	wanted := forecastCoreMetrics
-	if !allMetrics && !forecastDerivedMetrics[metric] && metric != forecast.MetricClicks {
-		wanted = append([]string{metric}, forecastCoreMetrics...)
+	wanted := append([]string(nil), forecastCoherentInputs...)
+	if !allMetrics {
+		inInputs := false
+		for _, m := range wanted {
+			if m == metric {
+				inInputs = true
+			}
+		}
+		if !inInputs {
+			wanted = append(wanted, metric)
+		}
 	}
 	parsed, rejected, err := parseTimeseriesMulti(data, wanted)
 	if err != nil {
@@ -590,9 +605,10 @@ func extractMetricValue(obj map[string]interface{}, metric string) (float64, boo
 
 // parseTimeseriesMulti extracts one forecast.Series per requested metric
 // from a single timeseries response. A bucket whose time cannot be parsed,
-// or a metric value that is present but not numeric, is skipped for that
-// metric and counted in rejected so the caller can surface the loss; a
-// bucket simply lacking a metric is not a rejection.
+// or that carries a present-but-non-numeric value for any requested
+// metric, counts once in rejected (however many fields are bad) so the
+// caller can surface the loss; the bucket's valid metrics are still kept,
+// and a bucket simply lacking a metric is not a rejection.
 func parseTimeseriesMulti(data []byte, metrics []string) (map[string]forecast.Series, int, error) {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(data, &parsed); err != nil {
@@ -620,16 +636,20 @@ func parseTimeseriesMulti(data []byte, metrics []string) (map[string]forecast.Se
 			rejected++
 			continue
 		}
+		rowRejected := false
 		for _, m := range metrics {
 			if _, present := obj[m]; !present {
 				continue
 			}
 			val, vOk := extractMetricValue(obj, m)
 			if !vOk {
-				rejected++
+				rowRejected = true
 				continue
 			}
 			out[m] = append(out[m], forecast.Point{T: t, V: val})
+		}
+		if rowRejected {
+			rejected++
 		}
 	}
 
@@ -717,7 +737,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int, co
 		dataPoints[m] = res.DataPoints
 		// Rolling errors, per metric: compositions are backtested too, so
 		// every metric has its own typical error to judge a forecast by.
-		if res.MAE > 0 {
+		// A measured zero is reported as zero; only "never measured" is
+		// omitted.
+		if res.Backtested() {
 			maes[m] = roundTo(res.MAE, 2)
 			rmses[m] = roundTo(res.RMSE, 2)
 		}
@@ -873,7 +895,7 @@ func buildForecastOutput(result *forecast.Result, metric string, opts forecastOu
 	if opts.rejected > 0 {
 		meta["buckets_rejected"] = opts.rejected
 	}
-	if result.MAE > 0 {
+	if result.Backtested() {
 		meta["mae"] = roundTo(result.MAE, 2)
 		meta["rmse"] = roundTo(result.RMSE, 2)
 	}

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -198,7 +198,8 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		return validationError("not enough data points (%d) for forecasting — need at least 3. Try a longer --history period", len(series))
 	}
 
-	// Build forecast config.
+	// Build forecast config. Metrics that cannot go negative (counts,
+	// amounts, rates) get zero-clipped bounds and quantiles.
 	cfg := forecast.Config{
 		Method:          method,
 		Horizon:         horizon,
@@ -206,6 +207,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		Metric:          metric,
 		SMAWindow:       smaWindow,
 		ConfidenceLevel: confidence,
+		NonNegative:     !forecastSignedMetrics[metric],
 	}
 
 	// Optionally fetch weekpart data for seasonal adjustment.
@@ -495,6 +497,17 @@ func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, 
 			"upper_bound": roundTo(p.UpperBound, 2),
 		}
 
+		// Conformal runs carry the full quantile set; expose the inner
+		// quantiles (p10/p90 already surface as lower/upper at the default
+		// confidence). Users can trim columns with --fields.
+		if len(p.Quantiles) > 0 {
+			for _, q := range []string{"p25", "p50", "p75"} {
+				if v, ok := p.Quantiles[q]; ok {
+					row[q] = roundTo(v, 2)
+				}
+			}
+		}
+
 		// Add trend indicator for first row.
 		if i == 0 {
 			if result.TrendPct > 0 {
@@ -579,7 +592,9 @@ func formatPredictionTime(t time.Time, interval forecast.Interval) string {
 	}
 }
 
-// clampNonNegative floors prediction values and bounds at zero.
+// clampNonNegative floors prediction values, bounds, and quantiles at zero.
+// The forecast package already clips NonNegative runs; this re-clamps after
+// event adjustments, which can push values back below zero.
 func clampNonNegative(preds []forecast.Prediction) {
 	for i := range preds {
 		if preds[i].Value < 0 {
@@ -590,6 +605,11 @@ func clampNonNegative(preds []forecast.Prediction) {
 		}
 		if preds[i].UpperBound < 0 {
 			preds[i].UpperBound = 0
+		}
+		for name, v := range preds[i].Quantiles {
+			if v < 0 {
+				preds[i].Quantiles[name] = 0
+			}
 		}
 	}
 }

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -282,13 +282,14 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	}
 	parsed, rejected, err := parseTimeseriesMulti(data, wanted)
 	if err != nil {
-		return err
+		return withHint(err, "The timeseries request returned nothing usable for --history %s with these filters. Check the window and entity filters with `p202 report timeseries --period %s` (same filters), then retry.", history, history)
 	}
 
 	if allMetrics {
 		results, rcErr := forecast.RunCoherent(parsed, cfg)
 		if rcErr != nil {
-			return fmt.Errorf("coherent forecast failed: %w", rcErr)
+			return withHint(validationError("coherent forecast failed: %v", rcErr),
+				"One of the core metrics has too little history to compose from. Use a longer --history, or forecast the metric you need on its own with --metric (it falls back to a direct forecast automatically).")
 		}
 		output, boErr := buildAllMetricsOutput(results, rejected)
 		if boErr != nil {
@@ -300,10 +301,17 @@ func runForecast(cmd *cobra.Command, args []string) error {
 
 	series := parsed[metric]
 	if len(series) == 0 {
-		return fmt.Errorf("no valid data points found for metric %q", metric)
+		available := parsedMetricNames(parsed)
+		if len(available) == 0 {
+			return validationError("no valid data points found for metric %q", metric).
+				WithHint("No bucket in the response carried a numeric %q value. Check `p202 report timeseries --period %s` with the same filters to see which metrics the API returns for this window.", metric, history)
+		}
+		return validationError("no valid data points found for metric %q", metric).
+			WithHint("The response carried values for %s but not %q. Pick one of those with --metric, or widen --history.", strings.Join(available, ", "), metric)
 	}
 	if len(series) < 3 {
-		return validationError("not enough data points (%d) for forecasting — need at least 3. Try a longer --history period", len(series))
+		return validationError("not enough data points (%d) for forecasting — need at least 3", len(series)).
+			WithHint("Use a longer --history (e.g. last30 or last90) or a finer --interval; rolling backtests and conformal bands need ~12 points, so aim for at least that.")
 	}
 
 	// A derived metric requested on its own (without seasonal or event
@@ -391,7 +399,8 @@ func runForecast(cmd *cobra.Command, args []string) error {
 				// Mask event days from training data for clean baseline fitting.
 				series = forecast.MaskEventDays(series, pastEvents)
 				if len(series) < 3 {
-					return validationError("after masking event days, only %d data points remain — need at least 3", len(series))
+					return validationError("after masking event days, only %d data points remain — need at least 3", len(series)).
+						WithHint("The event windows cover most of the history. Use a longer --history, narrow the events with --event-tag, or shorten lead/lag days on the events.")
 				}
 
 				// Masking may drop the most recent observations, but predictions
@@ -411,7 +420,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// Run the baseline forecast on clean data.
 	result, err := forecast.Run(series, cfg)
 	if err != nil {
-		return fmt.Errorf("forecast failed: %w", err)
+		return withHint(fmt.Errorf("forecast failed: %w", err), "Use a longer --history or a coarser --interval so more points are available.")
 	}
 
 	// Apply event adjustments to predictions.
@@ -627,6 +636,19 @@ func parseTimeseriesMulti(data []byte, metrics []string) (map[string]forecast.Se
 		sort.Slice(out[m], func(i, j int) bool { return out[m][i].T.Before(out[m][j].T) })
 	}
 	return out, rejected, nil
+}
+
+// parsedMetricNames lists the metrics a parsed response carried values for,
+// sorted, for error hints.
+func parsedMetricNames(parsed map[string]forecast.Series) []string {
+	names := make([]string, 0, len(parsed))
+	for m, s := range parsed {
+		if len(s) > 0 {
+			names = append(names, m)
+		}
+	}
+	sort.Strings(names)
+	return names
 }
 
 // buildAllMetricsOutput renders the coherent multi-metric forecast: one row
@@ -921,7 +943,7 @@ func fetchAllForecastEvents(c *api.Client) ([]forecast.Event, error) {
 	for page := 0; page < maxForecastEventPages; page++ {
 		data, err := c.Get("forecast-events", params)
 		if err != nil {
-			return nil, fmt.Errorf("fetching forecast events: %w", err)
+			return nil, withHint(fmt.Errorf("fetching forecast events: %w", err), "Events come from the forecast-events endpoint; run `p202 forecast-event list` to confirm it works, or drop --events/--event-tag to forecast without the calendar.")
 		}
 
 		events, err := parseForecastEvents(data)

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -223,6 +223,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		confidence = 0.95
 	}
 	noLevelShift, _ := cmd.Flags().GetBool("no-level-shift")
+	noAnomalyMask, _ := cmd.Flags().GetBool("no-anomaly-mask")
 	if seasonalMonthly && forecastSignedMetrics[metric] {
 		// Multiplicative day-of-month profiles are undefined for metrics
 		// that cross zero (a near-zero mean yields unbounded multipliers).
@@ -248,15 +249,16 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// Build forecast config. Metrics that cannot go negative (counts,
 	// amounts, rates) get zero-clipped bounds and quantiles.
 	cfg := forecast.Config{
-		Method:            method,
-		Horizon:           horizon,
-		Interval:          forecast.Interval(interval),
-		Metric:            metric,
-		SMAWindow:         smaWindow,
-		ConfidenceLevel:   confidence,
-		NonNegative:       !forecastSignedMetrics[metric],
-		LogTransform:      forecastCountMetrics[metric],
-		DisableLevelShift: noLevelShift,
+		Method:             method,
+		Horizon:            horizon,
+		Interval:           forecast.Interval(interval),
+		Metric:             metric,
+		SMAWindow:          smaWindow,
+		ConfidenceLevel:    confidence,
+		NonNegative:        !forecastSignedMetrics[metric],
+		LogTransform:       forecastCountMetrics[metric],
+		DisableLevelShift:  noLevelShift,
+		DisableAnomalyMask: noAnomalyMask,
 	}
 
 	// ── Coherent multi-metric forecasting ─────────────────────────────
@@ -646,6 +648,7 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 
 	compositions := map[string]interface{}{}
 	levelShifts := map[string]interface{}{}
+	anomalies := map[string]interface{}{}
 	for _, m := range forecastCoreMetrics {
 		res := results[m]
 		if res == nil {
@@ -656,6 +659,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 		}
 		if res.LevelShiftAt != "" {
 			levelShifts[m] = res.LevelShiftAt
+		}
+		if len(res.AnomaliesMasked) > 0 {
+			anomalies[m] = res.AnomaliesMasked
 		}
 	}
 
@@ -668,6 +674,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([
 	}
 	if len(levelShifts) > 0 {
 		meta["level_shifts"] = levelShifts
+	}
+	if len(anomalies) > 0 {
+		meta["anomalies_masked"] = anomalies
 	}
 	if len(clicks.Weights) > 0 {
 		meta["weights"] = roundWeights(clicks.Weights)
@@ -787,6 +796,9 @@ func buildForecastOutput(result *forecast.Result, metric string, opts forecastOu
 	}
 	if result.LevelShiftAt != "" {
 		meta["level_shift_at"] = result.LevelShiftAt
+	}
+	if len(result.AnomaliesMasked) > 0 {
+		meta["anomalies_masked"] = result.AnomaliesMasked
 	}
 	if seasonal {
 		meta["seasonal_applied"] = result.SeasonalApplied
@@ -1086,6 +1098,7 @@ func init() {
 	forecastCmd.Flags().Bool("seasonal-monthly", false, "Apply day-of-month seasonal adjustment learned from the fetched series (requires --interval day)")
 	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds; snaps to the nearest band: 0.50 (p25-p75), 0.80 (p10-p90), or 0.90 (p05-p95, also used for 0.95/0.99)")
 	forecastCmd.Flags().Bool("no-level-shift", false, "Disable level-shift detection (fit the full history as-is)")
+	forecastCmd.Flags().Bool("no-anomaly-mask", false, "Disable transient masking (fit short outlier runs such as tracking outages as data)")
 	forecastCmd.Flags().Bool("events", false, "Enable event-aware forecasting using stored forecast events")
 	forecastCmd.Flags().String("event-tag", "", "Filter forecast events by tag (comma-separated, e.g. us-holidays,promos)")
 

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -36,6 +36,14 @@ var forecastSignedMetrics = map[string]bool{
 	"roi":       true,
 }
 
+// forecastCountMetrics are count-like series fitted on log1p scale, which
+// makes multiplicative growth additive and stabilizes variance.
+var forecastCountMetrics = map[string]bool{
+	"total_clicks":         true,
+	"total_click_throughs": true,
+	"total_leads":          true,
+}
+
 // forecastCoreMetrics are the metrics RunCoherent consumes and produces.
 var forecastCoreMetrics = []string{
 	forecast.MetricClicks, forecast.MetricLeads, forecast.MetricIncome,
@@ -192,6 +200,11 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		// systematically skew the totals.
 		return validationError("--seasonal requires --interval day or hour")
 	}
+	seasonalMonthly, _ := cmd.Flags().GetBool("seasonal-monthly")
+	if seasonalMonthly && interval != "day" {
+		// Day-of-month profiles only make sense on daily buckets.
+		return validationError("--seasonal-monthly requires --interval day")
+	}
 	useEvents, _ := cmd.Flags().GetBool("events")
 	eventTag, _ := cmd.Flags().GetString("event-tag")
 	if (useEvents || eventTag != "") && interval != "day" {
@@ -199,11 +212,11 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		// granularity; other intervals would silently produce wrong adjustments.
 		return validationError("--events and --event-tag require --interval day")
 	}
-	if allMetrics && (seasonal || useEvents || eventTag != "") {
+	if allMetrics && (seasonal || seasonalMonthly || useEvents || eventTag != "") {
 		// Seasonal and event adjustment layers operate on a single metric's
 		// series; combining them with the coherent multi-metric path would
 		// silently skip them for the derived metrics.
-		return validationError("--all-metrics cannot be combined with --seasonal, --events, or --event-tag")
+		return validationError("--all-metrics cannot be combined with --seasonal, --seasonal-monthly, --events, or --event-tag")
 	}
 	confidence, _ := cmd.Flags().GetFloat64("confidence")
 	if confidence <= 0 || confidence >= 1 {
@@ -236,6 +249,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		SMAWindow:       smaWindow,
 		ConfidenceLevel: confidence,
 		NonNegative:     !forecastSignedMetrics[metric],
+		LogTransform:    forecastCountMetrics[metric],
 	}
 
 	// ── Coherent multi-metric forecasting ─────────────────────────────
@@ -270,7 +284,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// ratio decomposition so it stays consistent with what the clicks
 	// forecast implies. Any failure — missing companion metrics in the
 	// response, too-sparse drivers upstream — falls back to the direct path.
-	if forecastDerivedMetrics[metric] && !seasonal && !useEvents && eventTag == "" {
+	if forecastDerivedMetrics[metric] && !seasonal && !seasonalMonthly && !useEvents && eventTag == "" {
 		if coherentSeries, csErr := parseTimeseriesMulti(data, forecastCoreMetrics); csErr == nil {
 			if results, rcErr := forecast.RunCoherent(coherentSeries, cfg); rcErr == nil {
 				if result := results[metric]; result != nil {
@@ -288,7 +302,12 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Optionally fetch weekpart data for seasonal adjustment.
+	// Optionally fetch weekpart data for seasonal adjustment. Weekday
+	// multipliers are shrunk toward 1.0 by each weekday's sample count in
+	// the fetched series, so a thin history can't produce extreme weights;
+	// hourly forecasts additionally get an hour-of-day profile built from
+	// the series itself. The forecast engine gates both profiles on
+	// detrended autocorrelation before applying them.
 	if seasonal {
 		weekpartParams := collectForecastFilters(cmd)
 		weekpartParams["period"] = history
@@ -296,9 +315,15 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		if wpErr == nil {
 			weights := parseWeekpartWeights(wpData, metric)
 			if weights != nil {
-				cfg.SeasonalWeights = weights
+				cfg.SeasonalWeights = forecast.ShrinkWeekdayWeights(weights, forecast.WeekdayCounts(series))
 			}
 		}
+		if interval == "hour" {
+			cfg.HourlyWeights = forecast.BuildHourlyWeights(series)
+		}
+	}
+	if seasonalMonthly {
+		cfg.MonthDayWeights = forecast.BuildMonthDayWeights(series)
 	}
 
 	// ── Event-aware forecasting pipeline ──────────────────────────────
@@ -610,9 +635,17 @@ func buildAllMetricsOutput(results map[string]*forecast.Result) ([]byte, error) 
 	}
 
 	compositions := map[string]interface{}{}
+	levelShifts := map[string]interface{}{}
 	for _, m := range forecastCoreMetrics {
-		if res := results[m]; res != nil && res.Composition != "" {
+		res := results[m]
+		if res == nil {
+			continue
+		}
+		if res.Composition != "" {
 			compositions[m] = res.Composition
+		}
+		if res.LevelShiftAt != "" {
+			levelShifts[m] = res.LevelShiftAt
 		}
 	}
 
@@ -622,6 +655,9 @@ func buildAllMetricsOutput(results map[string]*forecast.Result) ([]byte, error) 
 		"interval":         string(clicks.Interval),
 		"data_points_used": clicks.DataPoints,
 		"composition":      compositions,
+	}
+	if len(levelShifts) > 0 {
+		meta["level_shifts"] = levelShifts
 	}
 	if len(clicks.Weights) > 0 {
 		weights := make(map[string]interface{}, len(clicks.Weights))
@@ -710,6 +746,12 @@ func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, 
 	}
 	if result.Composition != "" {
 		meta["composition"] = result.Composition
+	}
+	if result.LevelShiftAt != "" {
+		meta["level_shift_at"] = result.LevelShiftAt
+	}
+	if seasonal {
+		meta["seasonal_applied"] = result.SeasonalApplied
 	}
 	if result.MAE > 0 {
 		meta["mae"] = roundTo(result.MAE, 2)
@@ -1014,7 +1056,8 @@ func init() {
 	forecastCmd.Flags().String("days", "", "Alias of --history")
 	forecastCmd.Flags().Int("window", 0, "SMA/WMA window size (0 = auto-select)")
 	forecastCmd.Flags().Bool("all-metrics", false, "Forecast clicks, leads, income, cost, and net together via ratio decomposition (coherent output)")
-	forecastCmd.Flags().Bool("seasonal", false, "Apply day-of-week seasonal adjustment from weekpart data")
+	forecastCmd.Flags().Bool("seasonal", false, "Apply day-of-week seasonal adjustment from weekpart data (hour interval also gets an hour-of-day profile)")
+	forecastCmd.Flags().Bool("seasonal-monthly", false, "Apply day-of-month seasonal adjustment learned from the fetched series (requires --interval day)")
 	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds (0.80, 0.90, 0.95, 0.99)")
 	forecastCmd.Flags().Bool("events", false, "Enable event-aware forecasting using stored forecast events")
 	forecastCmd.Flags().String("event-tag", "", "Filter forecast events by tag (comma-separated, e.g. us-holidays,promos)")

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -222,6 +222,12 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	if confidence <= 0 || confidence >= 1 {
 		confidence = 0.95
 	}
+	noLevelShift, _ := cmd.Flags().GetBool("no-level-shift")
+	if seasonalMonthly && forecastSignedMetrics[metric] {
+		// Multiplicative day-of-month profiles are undefined for metrics
+		// that cross zero (a near-zero mean yields unbounded multipliers).
+		return validationError("--seasonal-monthly is not supported for signed metrics (%s); it needs a non-negative metric", metric)
+	}
 
 	// Build API client.
 	c, err := api.NewFromConfig()
@@ -242,27 +248,37 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// Build forecast config. Metrics that cannot go negative (counts,
 	// amounts, rates) get zero-clipped bounds and quantiles.
 	cfg := forecast.Config{
-		Method:          method,
-		Horizon:         horizon,
-		Interval:        forecast.Interval(interval),
-		Metric:          metric,
-		SMAWindow:       smaWindow,
-		ConfidenceLevel: confidence,
-		NonNegative:     !forecastSignedMetrics[metric],
-		LogTransform:    forecastCountMetrics[metric],
+		Method:            method,
+		Horizon:           horizon,
+		Interval:          forecast.Interval(interval),
+		Metric:            metric,
+		SMAWindow:         smaWindow,
+		ConfidenceLevel:   confidence,
+		NonNegative:       !forecastSignedMetrics[metric],
+		LogTransform:      forecastCountMetrics[metric],
+		DisableLevelShift: noLevelShift,
 	}
 
 	// ── Coherent multi-metric forecasting ─────────────────────────────
+	// Parse every core metric from the single response: the requested
+	// metric's own series for the direct path, and the companions for the
+	// coherent path. Buckets or values the parser rejects are counted and
+	// surfaced in the output meta rather than silently dropped.
+	wanted := forecastCoreMetrics
+	if !allMetrics && !forecastDerivedMetrics[metric] && metric != forecast.MetricClicks {
+		wanted = append([]string{metric}, forecastCoreMetrics...)
+	}
+	parsed, rejected, err := parseTimeseriesMulti(data, wanted)
+	if err != nil {
+		return err
+	}
+
 	if allMetrics {
-		coherentSeries, csErr := parseTimeseriesMulti(data, forecastCoreMetrics)
-		if csErr != nil {
-			return csErr
-		}
-		results, rcErr := forecast.RunCoherent(coherentSeries, cfg)
+		results, rcErr := forecast.RunCoherent(parsed, cfg)
 		if rcErr != nil {
 			return fmt.Errorf("coherent forecast failed: %w", rcErr)
 		}
-		output, boErr := buildAllMetricsOutput(results)
+		output, boErr := buildAllMetricsOutput(results, rejected)
 		if boErr != nil {
 			return boErr
 		}
@@ -270,11 +286,10 @@ func runForecast(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	series, err := parseTimeseries(data, metric)
-	if err != nil {
-		return err
+	series := parsed[metric]
+	if len(series) == 0 {
+		return fmt.Errorf("no valid data points found for metric %q", metric)
 	}
-
 	if len(series) < 3 {
 		return validationError("not enough data points (%d) for forecasting — need at least 3. Try a longer --history period", len(series))
 	}
@@ -282,23 +297,29 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// A derived metric requested on its own (without seasonal or event
 	// layers, which operate on the metric's own series) is forecast via
 	// ratio decomposition so it stays consistent with what the clicks
-	// forecast implies. Any failure — missing companion metrics in the
-	// response, too-sparse drivers upstream — falls back to the direct path.
+	// forecast implies. When that is impossible — companion metrics missing
+	// from the response, too-sparse drivers upstream — the direct path
+	// serves the forecast and the meta records why composition was skipped.
+	coherentFallback := ""
 	if forecastDerivedMetrics[metric] && !seasonal && !seasonalMonthly && !useEvents && eventTag == "" {
-		if coherentSeries, csErr := parseTimeseriesMulti(data, forecastCoreMetrics); csErr == nil {
-			if results, rcErr := forecast.RunCoherent(coherentSeries, cfg); rcErr == nil {
-				if result := results[metric]; result != nil {
-					if !forecastSignedMetrics[metric] {
-						clampNonNegative(result.Predictions)
-					}
-					output, boErr := buildForecastOutput(result, metric, false, false, nil, nil)
-					if boErr != nil {
-						return boErr
-					}
-					render(output)
-					return nil
-				}
+		results, rcErr := forecast.RunCoherent(parsed, cfg)
+		if rcErr == nil && results[metric] != nil {
+			result := results[metric]
+			if !forecastSignedMetrics[metric] {
+				forecast.ClipNonNegative(result.Predictions)
 			}
+			output, boErr := buildForecastOutput(result, metric, forecastOutputOpts{
+				confidence: confidence, rejected: rejected,
+			})
+			if boErr != nil {
+				return boErr
+			}
+			render(output)
+			return nil
+		}
+		coherentFallback = "composition unavailable"
+		if rcErr != nil {
+			coherentFallback = rcErr.Error()
 		}
 	}
 
@@ -318,7 +339,7 @@ func runForecast(cmd *cobra.Command, args []string) error {
 				cfg.SeasonalWeights = forecast.ShrinkWeekdayWeights(weights, forecast.WeekdayCounts(series))
 			}
 		}
-		if interval == "hour" {
+		if interval == "hour" && !forecastSignedMetrics[metric] {
 			cfg.HourlyWeights = forecast.BuildHourlyWeights(series)
 		}
 	}
@@ -389,11 +410,24 @@ func runForecast(cmd *cobra.Command, args []string) error {
 	// Trending methods can project below zero on declining series; clamp
 	// metrics that cannot be negative (clicks, income, rates) at zero.
 	if !forecastSignedMetrics[metric] {
-		clampNonNegative(result.Predictions)
+		forecast.ClipNonNegative(result.Predictions)
+	}
+	if coherentFallback != "" {
+		// The docs promise a composition label on every derived-metric
+		// forecast; a direct fallback is labeled as such with its reason.
+		result.Composition = forecast.CompositionDirect
 	}
 
 	// Render output.
-	output, err := buildForecastOutput(result, metric, seasonal, useEvents || eventTag != "", futureEvents, learnedImpacts)
+	output, err := buildForecastOutput(result, metric, forecastOutputOpts{
+		seasonal:     seasonal || seasonalMonthly,
+		eventsActive: useEvents || eventTag != "",
+		futureEvents: futureEvents,
+		impacts:      learnedImpacts,
+		confidence:   confidence,
+		rejected:     rejected,
+		fallbackNote: coherentFallback,
+	})
 	if err != nil {
 		return err
 	}
@@ -413,52 +447,17 @@ func collectForecastFilters(cmd *cobra.Command) map[string]string {
 	return params
 }
 
-// parseTimeseries extracts a forecast.Series from the API timeseries response.
+// parseTimeseries extracts a forecast.Series for one metric from the API
+// timeseries response (a thin wrapper over parseTimeseriesMulti).
 func parseTimeseries(data []byte, metric string) (forecast.Series, error) {
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return nil, fmt.Errorf("invalid timeseries response: %w", err)
+	parsed, _, err := parseTimeseriesMulti(data, []string{metric})
+	if err != nil {
+		return nil, err
 	}
-
-	rawItems, ok := parsed["data"].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("timeseries response missing data array")
-	}
-
-	if len(rawItems) == 0 {
-		return nil, fmt.Errorf("timeseries returned empty data")
-	}
-
-	series := make(forecast.Series, 0, len(rawItems))
-	for _, raw := range rawItems {
-		obj, ok := raw.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		t, tErr := parseBucketTime(obj)
-		if tErr != nil {
-			continue
-		}
-
-		val, vOk := extractMetricValue(obj, metric)
-		if !vOk {
-			continue
-		}
-
-		series = append(series, forecast.Point{T: t, V: val})
-	}
-
-	if len(series) == 0 {
+	if len(parsed[metric]) == 0 {
 		return nil, fmt.Errorf("no valid data points found for metric %q", metric)
 	}
-
-	// Sort by time.
-	sort.Slice(series, func(i, j int) bool {
-		return series[i].T.Before(series[j].T)
-	})
-
-	return series, nil
+	return parsed[metric], nil
 }
 
 // parseBucketTime extracts a time from a timeseries bucket.
@@ -568,49 +567,60 @@ func extractMetricValue(obj map[string]interface{}, metric string) (float64, boo
 }
 
 // parseTimeseriesMulti extracts one forecast.Series per requested metric
-// from a single timeseries response. A bucket missing a metric's value is
-// skipped for that metric only.
-func parseTimeseriesMulti(data []byte, metrics []string) (map[string]forecast.Series, error) {
+// from a single timeseries response. A bucket whose time cannot be parsed,
+// or a metric value that is present but not numeric, is skipped for that
+// metric and counted in rejected so the caller can surface the loss; a
+// bucket simply lacking a metric is not a rejection.
+func parseTimeseriesMulti(data []byte, metrics []string) (map[string]forecast.Series, int, error) {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(data, &parsed); err != nil {
-		return nil, fmt.Errorf("invalid timeseries response: %w", err)
+		return nil, 0, fmt.Errorf("invalid timeseries response: %w", err)
 	}
 
 	rawItems, ok := parsed["data"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("timeseries response missing data array")
+		return nil, 0, fmt.Errorf("timeseries response missing data array")
 	}
 	if len(rawItems) == 0 {
-		return nil, fmt.Errorf("timeseries returned empty data")
+		return nil, 0, fmt.Errorf("timeseries returned empty data")
 	}
 
+	rejected := 0
 	out := make(map[string]forecast.Series, len(metrics))
 	for _, raw := range rawItems {
 		obj, ok := raw.(map[string]interface{})
 		if !ok {
+			rejected++
 			continue
 		}
 		t, tErr := parseBucketTime(obj)
 		if tErr != nil {
+			rejected++
 			continue
 		}
 		for _, m := range metrics {
-			if val, vOk := extractMetricValue(obj, m); vOk {
-				out[m] = append(out[m], forecast.Point{T: t, V: val})
+			if _, present := obj[m]; !present {
+				continue
 			}
+			val, vOk := extractMetricValue(obj, m)
+			if !vOk {
+				rejected++
+				continue
+			}
+			out[m] = append(out[m], forecast.Point{T: t, V: val})
 		}
 	}
 
 	for _, m := range metrics {
 		sort.Slice(out[m], func(i, j int) bool { return out[m][i].T.Before(out[m][j].T) })
 	}
-	return out, nil
+	return out, rejected, nil
 }
 
 // buildAllMetricsOutput renders the coherent multi-metric forecast: one row
 // per date with value/lower/upper columns for each core metric, plus a meta
 // block reporting each metric's composition.
-func buildAllMetricsOutput(results map[string]*forecast.Result) ([]byte, error) {
+func buildAllMetricsOutput(results map[string]*forecast.Result, rejected int) ([]byte, error) {
 	clicks := results[forecast.MetricClicks]
 	if clicks == nil || len(clicks.Predictions) == 0 {
 		return nil, fmt.Errorf("coherent forecast returned no click predictions")
@@ -660,11 +670,10 @@ func buildAllMetricsOutput(results map[string]*forecast.Result) ([]byte, error) 
 		meta["level_shifts"] = levelShifts
 	}
 	if len(clicks.Weights) > 0 {
-		weights := make(map[string]interface{}, len(clicks.Weights))
-		for m, w := range clicks.Weights {
-			weights[m] = roundTo(w, 3)
-		}
-		meta["weights"] = weights
+		meta["weights"] = roundWeights(clicks.Weights)
+	}
+	if rejected > 0 {
+		meta["buckets_rejected"] = rejected
 	}
 
 	payload, err := json.Marshal(map[string]interface{}{"data": rows, "meta": meta})
@@ -696,8 +705,31 @@ func parseWeekpartWeights(data []byte, metric string) forecast.SeasonalWeights {
 	return forecast.BuildWeekdayWeights(rows, metric)
 }
 
+// forecastOutputOpts carries the run context buildForecastOutput reports in
+// the output meta.
+type forecastOutputOpts struct {
+	seasonal     bool // any seasonal profile requested
+	eventsActive bool
+	futureEvents []forecast.Event
+	impacts      map[string]forecast.LearnedImpact
+	confidence   float64
+	rejected     int    // response buckets/values the parser rejected
+	fallbackNote string // why a derived metric was forecast directly
+}
+
+// roundWeights rounds ensemble member weights for display.
+func roundWeights(weights map[string]float64) map[string]interface{} {
+	out := make(map[string]interface{}, len(weights))
+	for m, w := range weights {
+		out[m] = roundTo(w, 3)
+	}
+	return out
+}
+
 // buildForecastOutput constructs the JSON output for rendering.
-func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, eventsActive bool, futureEvents []forecast.Event, impacts map[string]forecast.LearnedImpact) ([]byte, error) {
+func buildForecastOutput(result *forecast.Result, metric string, opts forecastOutputOpts) ([]byte, error) {
+	seasonal, eventsActive, futureEvents, impacts := opts.seasonal, opts.eventsActive, opts.futureEvents, opts.impacts
+	lowerName, upperName, coverage := forecast.BoundLevels(opts.confidence)
 	predictions := make([]map[string]interface{}, len(result.Predictions))
 	for i, p := range result.Predictions {
 		row := map[string]interface{}{
@@ -707,11 +739,14 @@ func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, 
 			"upper_bound": roundTo(p.UpperBound, 2),
 		}
 
-		// Conformal runs carry the full quantile set; expose the inner
-		// quantiles (p10/p90 already surface as lower/upper at the default
-		// confidence). Users can trim columns with --fields.
+		// Conformal runs carry the full quantile set; expose every quantile
+		// except the pair already shown as lower/upper. Users can trim
+		// columns with --fields.
 		if len(p.Quantiles) > 0 {
-			for _, q := range []string{"p25", "p50", "p75"} {
+			for _, q := range []string{"p05", "p10", "p25", "p50", "p75", "p90", "p95"} {
+				if q == lowerName || q == upperName {
+					continue
+				}
 				if v, ok := p.Quantiles[q]; ok {
 					row[q] = roundTo(v, 2)
 				}
@@ -747,22 +782,35 @@ func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, 
 	if result.Composition != "" {
 		meta["composition"] = result.Composition
 	}
+	if opts.fallbackNote != "" {
+		meta["composition_fallback"] = opts.fallbackNote
+	}
 	if result.LevelShiftAt != "" {
 		meta["level_shift_at"] = result.LevelShiftAt
 	}
 	if seasonal {
 		meta["seasonal_applied"] = result.SeasonalApplied
+		if len(result.SeasonalProfiles) > 0 {
+			meta["seasonal_profiles"] = result.SeasonalProfiles
+		}
+	}
+	if result.BoundsSource != "" {
+		meta["bounds_source"] = result.BoundsSource
+	}
+	if result.BoundsSource == forecast.BoundsConformal {
+		// Conformal bands snap to the nearest emitted quantile pair; say
+		// which one so the requested --confidence is not mistaken for it.
+		meta["bounds"] = fmt.Sprintf("%s-%s (%.0f%%)", lowerName, upperName, coverage*100)
+	}
+	if opts.rejected > 0 {
+		meta["buckets_rejected"] = opts.rejected
 	}
 	if result.MAE > 0 {
 		meta["mae"] = roundTo(result.MAE, 2)
 		meta["rmse"] = roundTo(result.RMSE, 2)
 	}
 	if len(result.Weights) > 0 {
-		weights := make(map[string]interface{}, len(result.Weights))
-		for m, w := range result.Weights {
-			weights[m] = roundTo(w, 3)
-		}
-		meta["weights"] = weights
+		meta["weights"] = roundWeights(result.Weights)
 	}
 
 	if eventsActive && len(futureEvents) > 0 {
@@ -815,28 +863,6 @@ func formatPredictionTime(t time.Time, interval forecast.Interval) string {
 		return t.Format("2006-01-02") + " (wk)"
 	default:
 		return t.Format("2006-01-02")
-	}
-}
-
-// clampNonNegative floors prediction values, bounds, and quantiles at zero.
-// The forecast package already clips NonNegative runs; this re-clamps after
-// event adjustments, which can push values back below zero.
-func clampNonNegative(preds []forecast.Prediction) {
-	for i := range preds {
-		if preds[i].Value < 0 {
-			preds[i].Value = 0
-		}
-		if preds[i].LowerBound < 0 {
-			preds[i].LowerBound = 0
-		}
-		if preds[i].UpperBound < 0 {
-			preds[i].UpperBound = 0
-		}
-		for name, v := range preds[i].Quantiles {
-			if v < 0 {
-				preds[i].Quantiles[name] = 0
-			}
-		}
 	}
 }
 
@@ -1058,7 +1084,8 @@ func init() {
 	forecastCmd.Flags().Bool("all-metrics", false, "Forecast clicks, leads, income, cost, and net together via ratio decomposition (coherent output)")
 	forecastCmd.Flags().Bool("seasonal", false, "Apply day-of-week seasonal adjustment from weekpart data (hour interval also gets an hour-of-day profile)")
 	forecastCmd.Flags().Bool("seasonal-monthly", false, "Apply day-of-month seasonal adjustment learned from the fetched series (requires --interval day)")
-	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds (0.80, 0.90, 0.95, 0.99)")
+	forecastCmd.Flags().Float64("confidence", 0.95, "Confidence level for prediction bounds; snaps to the nearest band: 0.50 (p25-p75), 0.80 (p10-p90), or 0.90 (p05-p95, also used for 0.95/0.99)")
+	forecastCmd.Flags().Bool("no-level-shift", false, "Disable level-shift detection (fit the full history as-is)")
 	forecastCmd.Flags().Bool("events", false, "Enable event-aware forecasting using stored forecast events")
 	forecastCmd.Flags().String("event-tag", "", "Filter forecast events by tag (comma-separated, e.g. us-holidays,promos)")
 

--- a/go-cli/cmd/forecast.go
+++ b/go-cli/cmd/forecast.go
@@ -54,8 +54,9 @@ var forecastCmd = &cobra.Command{
 
 Fetches historical time-series data from your Prosper202 instance and projects
 it forward using the selected algorithm. Supports linear regression, simple
-and weighted moving averages, Holt-Winters exponential smoothing, and automatic
-method selection that picks the best fit via backtesting.
+and weighted moving averages, damped-trend Holt-Winters exponential smoothing,
+and an ensemble (the default, alias "auto") that combines the methods weighted
+by rolling-backtest accuracy and reports each member's share.
 
 With --seasonal, predictions are modulated by day-of-week weights derived from
 weekpart report data to account for weekly patterns (e.g., "Tuesdays always
@@ -538,6 +539,13 @@ func buildForecastOutput(result *forecast.Result, metric string, seasonal bool, 
 		meta["mae"] = roundTo(result.MAE, 2)
 		meta["rmse"] = roundTo(result.RMSE, 2)
 	}
+	if len(result.Weights) > 0 {
+		weights := make(map[string]interface{}, len(result.Weights))
+		for m, w := range result.Weights {
+			weights[m] = roundTo(w, 3)
+		}
+		meta["weights"] = weights
+	}
 
 	if eventsActive && len(futureEvents) > 0 {
 		names := make([]string, 0, len(futureEvents))
@@ -822,7 +830,7 @@ func filterEventsByTag(events []forecast.Event, tagFilter string) []forecast.Eve
 
 func init() {
 	forecastCmd.Flags().StringP("metric", "m", "", "Metric to forecast (clicks, revenue, profit, roi, epc, conv_rate, cost, conversions, cpa)")
-	forecastCmd.Flags().String("method", "auto", "Forecasting method: auto, linear, sma, wma, holtwinters")
+	forecastCmd.Flags().String("method", "auto", "Forecasting method: auto (ensemble), ensemble, linear, sma, wma, holtwinters")
 	forecastCmd.Flags().IntP("horizon", "n", 7, "Number of periods to forecast forward")
 	forecastCmd.Flags().StringP("interval", "i", "day", "Forecast granularity: hour, day, week, month")
 	forecastCmd.Flags().String("history", "last90", "Historical data period: today, yesterday, last7, last30, last90 (aliases: --period, --days)")

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1330,3 +1330,18 @@ func TestForecastReportsMaskedAnomaliesAndOptOut(t *testing.T) {
 		t.Error("--no-anomaly-mask still masked points")
 	}
 }
+
+func TestForecastAnomalyKnobsValidated(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, "http://localhost:9", "test-key")
+
+	if _, _, err := executeCommand("forecast", "--metric=clicks", "--anomaly-sigma=0"); err == nil ||
+		!strings.Contains(err.Error(), "--anomaly-sigma") {
+		t.Errorf("expected --anomaly-sigma validation error, got %v", err)
+	}
+	if _, _, err := executeCommand("forecast", "--metric=clicks", "--anomaly-cycles=0"); err == nil ||
+		!strings.Contains(err.Error(), "--anomaly-cycles") {
+		t.Errorf("expected --anomaly-cycles validation error, got %v", err)
+	}
+}

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1434,10 +1434,14 @@ func TestForecastAllMetricsReportsBoundsSourcePerMetric(t *testing.T) {
 			t.Errorf("data_points_used[%s] = %v, want a positive count", m, counts[m])
 		}
 	}
-	// This fixture has exact identities, so rolling errors are zero and
-	// the maps are omitted; the noisy all-metrics test covers presence.
-	if _, present := meta["mae"]; present {
-		t.Errorf("mae map should be omitted when every rolling error is zero, got %v", meta["mae"])
+	maes, ok := meta["mae"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected per-metric mae map in meta, got %v", meta["mae"])
+	}
+	for _, m := range forecastCoreMetrics {
+		if _, present := maes[m]; !present {
+			t.Errorf("mae map missing %s", m)
+		}
 	}
 	for _, m := range forecastCoreMetrics {
 		// Derived metrics are backtested as compositions, so with 40 points

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1421,11 +1421,19 @@ func TestForecastAllMetricsReportsBoundsSourcePerMetric(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected per-metric bounds_source map in meta, got %v", meta["bounds_source"])
 	}
+	labels, ok := meta["bounds"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected per-metric bounds map in meta, got %v", meta["bounds"])
+	}
 	for _, m := range forecastCoreMetrics {
 		// Derived metrics are backtested as compositions, so with 40 points
-		// every metric's band is conformal — none is a "composed" fallback.
+		// every metric's band is conformal — none is a "composed" fallback —
+		// and each names the quantile pair its lower/upper columns carry.
 		if sources[m] != forecast.BoundsConformal {
 			t.Errorf("bounds_source[%s] = %v, want conformal", m, sources[m])
+		}
+		if labels[m] != "p05-p95 (90%)" {
+			t.Errorf("bounds[%s] = %v, want p05-p95 (90%%)", m, labels[m])
 		}
 	}
 

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1346,7 +1346,7 @@ func TestForecastAnomalyKnobsValidated(t *testing.T) {
 	}
 }
 
-func TestForecastMissingMetricHintListsAvailable(t *testing.T) {
+func TestForecastMissingMetricListsAvailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte(makeTimeseriesResponse(30, "total_clicks")))
@@ -1361,9 +1361,13 @@ func TestForecastMissingMetricHintListsAvailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when the metric is absent from the response")
 	}
-	hint := hintFor(err)
-	if !strings.Contains(hint, "total_clicks") || !strings.Contains(hint, "--metric") {
-		t.Errorf("hint should list the available metrics and the flag to change, got %q", hint)
+	// The list of valid values lives in the message (visible even when the
+	// hint is ignored); the hint names the flag to change.
+	if !strings.Contains(err.Error(), "response carried: total_clicks") {
+		t.Errorf("message should list the metrics the response carried, got %q", err.Error())
+	}
+	if hint := hintFor(err); !strings.Contains(hint, "--metric") {
+		t.Errorf("hint should name the flag to change, got %q", hint)
 	}
 	if exitCodeForError(err) != ExitValidation {
 		t.Errorf("exit code = %d, want %d", exitCodeForError(err), ExitValidation)

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -256,7 +256,7 @@ func TestForecastPassesFilters(t *testing.T) {
 	}
 }
 
-func TestForecastWithSeasonalFetchesWeekpart(t *testing.T) {
+func TestForecastSeasonalLearnsFromFetchedHistory(t *testing.T) {
 	requestPaths := []string{}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -280,22 +280,21 @@ func TestForecastWithSeasonalFetchesWeekpart(t *testing.T) {
 		t.Fatalf("forecast error: %v", err)
 	}
 
-	// Should have called both timeseries and weekpart.
+	// The weekday profile is learned from the fetched history (per
+	// backtest fold), so only the timeseries report is requested: a
+	// weekpart profile computed over the whole window would leak held-out
+	// days into their own multiplier.
 	foundTimeseries := false
-	foundWeekpart := false
 	for _, p := range requestPaths {
 		if strings.HasSuffix(p, "/reports/timeseries") {
 			foundTimeseries = true
 		}
 		if strings.HasSuffix(p, "/reports/weekpart") {
-			foundWeekpart = true
+			t.Error("--seasonal must not fetch reports/weekpart; the profile comes from the history itself")
 		}
 	}
 	if !foundTimeseries {
 		t.Error("expected call to reports/timeseries")
-	}
-	if !foundWeekpart {
-		t.Error("expected call to reports/weekpart when --seasonal is set")
 	}
 
 	// Meta should reflect seasonal=true.
@@ -1424,6 +1423,15 @@ func TestForecastAllMetricsReportsBoundsSourcePerMetric(t *testing.T) {
 	labels, ok := meta["bounds"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("expected per-metric bounds map in meta, got %v", meta["bounds"])
+	}
+	counts, ok := meta["data_points_used"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected per-metric data_points_used map in meta, got %v", meta["data_points_used"])
+	}
+	for _, m := range forecastCoreMetrics {
+		if n, _ := counts[m].(float64); n <= 0 {
+			t.Errorf("data_points_used[%s] = %v, want a positive count", m, counts[m])
+		}
 	}
 	for _, m := range forecastCoreMetrics {
 		// Derived metrics are backtested as compositions, so with 40 points

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -609,12 +609,12 @@ func TestParseISOWeekRejectsInvalid(t *testing.T) {
 	}
 }
 
-func TestClampNonNegative(t *testing.T) {
+func TestClipNonNegative(t *testing.T) {
 	preds := []forecast.Prediction{
 		{Value: -5, LowerBound: -10, UpperBound: -1},
 		{Value: 3, LowerBound: -2, UpperBound: 8},
 	}
-	clampNonNegative(preds)
+	forecast.ClipNonNegative(preds)
 	if preds[0].Value != 0 || preds[0].LowerBound != 0 || preds[0].UpperBound != 0 {
 		t.Errorf("negative prediction not fully clamped: %+v", preds[0])
 	}
@@ -1080,8 +1080,11 @@ func TestForecastDerivedMetricFallsBackWithoutCompanions(t *testing.T) {
 		t.Fatalf("output is not valid JSON: %v", err)
 	}
 	meta := output["meta"].(map[string]interface{})
-	if _, ok := meta["composition"]; ok {
-		t.Errorf("expected no composition tag on direct fallback, got %v", meta["composition"])
+	if meta["composition"] != "direct" {
+		t.Errorf("meta.composition = %v, want direct on fallback", meta["composition"])
+	}
+	if _, ok := meta["composition_fallback"]; !ok {
+		t.Errorf("expected composition_fallback reason in meta, got %v", meta)
 	}
 	data := output["data"].([]interface{})
 	if len(data) != 5 {
@@ -1158,5 +1161,126 @@ func TestForecastSeasonalReportsApplied(t *testing.T) {
 	meta := output["meta"].(map[string]interface{})
 	if _, ok := meta["seasonal_applied"]; !ok {
 		t.Errorf("expected seasonal_applied in meta, got %v", meta)
+	}
+}
+
+func TestForecastDerivedFallbackReportsDirectComposition(t *testing.T) {
+	// Companion metrics present but too sparse for RunCoherent (only 2 cost
+	// values): the direct path must still label the output and say why.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buckets := make([]map[string]interface{}, 30)
+		for i := 0; i < 30; i++ {
+			b := map[string]interface{}{
+				"bucket_start": 1704067200 + i*86400,
+				"total_clicks": 100.0 + float64(i),
+				"total_leads":  10.0 + float64(i)/10,
+				"total_income": 500.0,
+			}
+			if i < 2 {
+				b["total_cost"] = 200.0
+			}
+			buckets[i] = b
+		}
+		data, _ := json.Marshal(map[string]interface{}{"data": buckets})
+		w.WriteHeader(200)
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=leads", "--horizon=3", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if meta["composition"] != "direct" {
+		t.Errorf("meta.composition = %v, want direct", meta["composition"])
+	}
+	if _, ok := meta["composition_fallback"]; !ok {
+		t.Errorf("expected composition_fallback reason in meta, got %v", meta)
+	}
+}
+
+func TestForecastRejectsSeasonalMonthlyForSignedMetric(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, "http://localhost:9", "test-key")
+
+	_, _, err := executeCommand("forecast", "--metric=profit", "--seasonal-monthly")
+	if err == nil || !strings.Contains(err.Error(), "signed metrics") {
+		t.Errorf("expected signed-metric validation error, got %v", err)
+	}
+}
+
+func TestForecastReportsRejectedBuckets(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buckets := make([]map[string]interface{}, 0, 31)
+		for i := 0; i < 30; i++ {
+			buckets = append(buckets, map[string]interface{}{
+				"bucket_start": 1704067200 + i*86400,
+				"total_income": 100.0 + float64(i),
+			})
+		}
+		buckets = append(buckets, map[string]interface{}{"bucket_start": "not-a-time", "total_income": 5.0})
+		data, _ := json.Marshal(map[string]interface{}{"data": buckets})
+		w.WriteHeader(200)
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=revenue", "--horizon=3", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if meta["buckets_rejected"] != 1.0 {
+		t.Errorf("meta.buckets_rejected = %v, want 1", meta["buckets_rejected"])
+	}
+	if meta["bounds"] == nil {
+		t.Errorf("expected bounds label in meta, got %v", meta)
+	}
+}
+
+func TestForecastSeasonalMonthlyReportsApplied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(makeTimeseriesResponse(60, "total_clicks")))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=clicks", "--horizon=5", "--seasonal-monthly", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if meta["seasonal_applied"] != true {
+		t.Errorf("meta.seasonal_applied = %v, want true for --seasonal-monthly", meta["seasonal_applied"])
+	}
+	profiles, _ := meta["seasonal_profiles"].([]interface{})
+	if len(profiles) != 1 || profiles[0] != "monthday" {
+		t.Errorf("meta.seasonal_profiles = %v, want [monthday]", meta["seasonal_profiles"])
 	}
 }

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -926,5 +927,196 @@ func TestRoundTo(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("roundTo(%.5f, %d) = %.5f, want %.5f", tc.v, tc.n, got, tc.want)
 		}
+	}
+}
+
+// makeCoherentTimeseriesResponse builds a timeseries response carrying all
+// core metrics with consistent identities: leads = clicks*0.1, cost =
+// clicks*2, income = leads*50, net = income - cost.
+func makeCoherentTimeseriesResponse(n int) string {
+	buckets := make([]map[string]interface{}, n)
+	for i := 0; i < n; i++ {
+		clicks := 100.0 + float64(i)*5
+		leads := clicks * 0.1
+		cost := clicks * 2
+		income := leads * 50
+		buckets[i] = map[string]interface{}{
+			"bucket_start": 1704067200 + i*86400,
+			"total_clicks": clicks,
+			"total_leads":  leads,
+			"total_cost":   cost,
+			"total_income": income,
+			"total_net":    income - cost,
+		}
+	}
+	data, _ := json.Marshal(map[string]interface{}{"data": buckets})
+	return string(data)
+}
+
+func TestForecastAllMetricsCoherent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(makeCoherentTimeseriesResponse(40)))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--all-metrics", "--horizon=5", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nGot: %s", err, stdout)
+	}
+	data, ok := output["data"].([]interface{})
+	if !ok || len(data) != 5 {
+		t.Fatalf("expected 5 prediction rows, got: %s", stdout)
+	}
+	row, ok := data[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("row is not an object")
+	}
+	for _, col := range []string{"date", "total_clicks", "total_leads", "total_income",
+		"total_cost", "total_net", "total_clicks_lower", "total_net_upper"} {
+		if _, ok := row[col]; !ok {
+			t.Errorf("row missing column %q", col)
+		}
+	}
+	// Net identity holds in the rendered output (within rounding).
+	income := row["total_income"].(float64)
+	cost := row["total_cost"].(float64)
+	net := row["total_net"].(float64)
+	if math.Abs(net-(income-cost)) > 0.02 {
+		t.Errorf("net %v != income-cost %v in output", net, income-cost)
+	}
+
+	meta, ok := output["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatal("output missing meta")
+	}
+	comps, ok := meta["composition"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("meta missing composition map: %v", meta)
+	}
+	if comps["total_clicks"] != "direct" {
+		t.Errorf("clicks composition = %v, want direct", comps["total_clicks"])
+	}
+	if comps["total_leads"] != "derived" {
+		t.Errorf("leads composition = %v, want derived", comps["total_leads"])
+	}
+}
+
+func TestForecastAllMetricsRejectsMetricAndSeasonal(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, "http://localhost:9", "test-key")
+
+	if _, _, err := executeCommand("forecast", "--all-metrics", "--metric=clicks"); err == nil ||
+		!strings.Contains(err.Error(), "--all-metrics") {
+		t.Errorf("expected --all-metrics/--metric conflict error, got %v", err)
+	}
+	if _, _, err := executeCommand("forecast", "--all-metrics", "--seasonal"); err == nil ||
+		!strings.Contains(err.Error(), "--all-metrics") {
+		t.Errorf("expected --all-metrics/--seasonal conflict error, got %v", err)
+	}
+	if _, _, err := executeCommand("forecast", "--all-metrics", "--events"); err == nil ||
+		!strings.Contains(err.Error(), "--all-metrics") {
+		t.Errorf("expected --all-metrics/--events conflict error, got %v", err)
+	}
+}
+
+func TestForecastDerivedMetricUsesComposition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(makeCoherentTimeseriesResponse(40)))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=leads", "--horizon=5", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if meta["composition"] != "derived" {
+		t.Errorf("meta.composition = %v, want derived", meta["composition"])
+	}
+	if meta["metric"] != "total_leads" {
+		t.Errorf("meta.metric = %v, want total_leads", meta["metric"])
+	}
+}
+
+func TestForecastDerivedMetricFallsBackWithoutCompanions(t *testing.T) {
+	// Response carries only the requested metric: composition is impossible
+	// and the direct path must serve the forecast without a composition tag.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(makeTimeseriesResponse(30, "total_leads")))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=leads", "--horizon=5", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if _, ok := meta["composition"]; ok {
+		t.Errorf("expected no composition tag on direct fallback, got %v", meta["composition"])
+	}
+	data := output["data"].([]interface{})
+	if len(data) != 5 {
+		t.Errorf("expected 5 predictions, got %d", len(data))
+	}
+}
+
+func TestForecastDerivedMetricWithSeasonalStaysDirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		if strings.HasSuffix(r.URL.Path, "/reports/weekpart") {
+			w.Write([]byte(makeWeekpartResponse("total_leads")))
+			return
+		}
+		w.Write([]byte(makeCoherentTimeseriesResponse(40)))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=leads", "--horizon=5", "--seasonal", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if _, ok := meta["composition"]; ok {
+		t.Errorf("expected direct path with --seasonal, got composition %v", meta["composition"])
+	}
+	if meta["seasonal"] != true {
+		t.Errorf("meta.seasonal = %v, want true", meta["seasonal"])
 	}
 }

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1120,3 +1120,43 @@ func TestForecastDerivedMetricWithSeasonalStaysDirect(t *testing.T) {
 		t.Errorf("meta.seasonal = %v, want true", meta["seasonal"])
 	}
 }
+
+func TestForecastSeasonalMonthlyRequiresDayInterval(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, "http://localhost:9", "test-key")
+
+	_, _, err := executeCommand("forecast", "--metric=clicks", "--seasonal-monthly", "--interval=week")
+	if err == nil || !strings.Contains(err.Error(), "--seasonal-monthly requires --interval day") {
+		t.Errorf("expected interval validation error, got %v", err)
+	}
+}
+
+func TestForecastSeasonalReportsApplied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		if strings.HasSuffix(r.URL.Path, "/reports/weekpart") {
+			w.Write([]byte(makeWeekpartResponse("total_clicks")))
+			return
+		}
+		w.Write([]byte(makeTimeseriesResponse(30, "total_clicks")))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=clicks", "--horizon=5", "--seasonal", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if _, ok := meta["seasonal_applied"]; !ok {
+		t.Errorf("expected seasonal_applied in meta, got %v", meta)
+	}
+}

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1345,3 +1345,50 @@ func TestForecastAnomalyKnobsValidated(t *testing.T) {
 		t.Errorf("expected --anomaly-cycles validation error, got %v", err)
 	}
 }
+
+func TestForecastMissingMetricHintListsAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(makeTimeseriesResponse(30, "total_clicks")))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	_, _, err := executeCommand("forecast", "--metric=epc")
+	if err == nil {
+		t.Fatal("expected error when the metric is absent from the response")
+	}
+	hint := hintFor(err)
+	if !strings.Contains(hint, "total_clicks") || !strings.Contains(hint, "--metric") {
+		t.Errorf("hint should list the available metrics and the flag to change, got %q", hint)
+	}
+	if exitCodeForError(err) != ExitValidation {
+		t.Errorf("exit code = %d, want %d", exitCodeForError(err), ExitValidation)
+	}
+}
+
+func TestForecastAPIErrorKeepsAuthExitCodeAndHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"message":"invalid api key"}`))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "bad-key-123")
+
+	_, _, err := executeCommand("forecast", "--metric=clicks")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := exitCodeForError(err); got != ExitAuth {
+		t.Errorf("exit code = %d, want %d (auth) despite wrapping", got, ExitAuth)
+	}
+	if !strings.Contains(hintFor(err), "config set-key") {
+		t.Errorf("expected key hint, got %q", hintFor(err))
+	}
+}

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1433,6 +1433,11 @@ func TestForecastAllMetricsReportsBoundsSourcePerMetric(t *testing.T) {
 			t.Errorf("data_points_used[%s] = %v, want a positive count", m, counts[m])
 		}
 	}
+	// This fixture has exact identities, so rolling errors are zero and
+	// the maps are omitted; the noisy all-metrics test covers presence.
+	if _, present := meta["mae"]; present {
+		t.Errorf("mae map should be omitted when every rolling error is zero, got %v", meta["mae"])
+	}
 	for _, m := range forecastCoreMetrics {
 		// Derived metrics are backtested as compositions, so with 40 points
 		// every metric's band is conformal — none is a "composed" fallback —
@@ -1462,5 +1467,55 @@ func TestForecastAllMetricsReportsBoundsSourcePerMetric(t *testing.T) {
 	}
 	if meta["bounds"] != "p05-p95 (90%)" {
 		t.Errorf("bounds label = %v, want p05-p95 (90%%)", meta["bounds"])
+	}
+}
+
+func TestForecastAllMetricsReportsErrorsPerMetric(t *testing.T) {
+	// Noisy but coherent history: every metric, compositions included, is
+	// backtested, so the all-metrics meta carries its own mae/rmse.
+	rng := rand.New(rand.NewSource(11))
+	buckets := make([]map[string]interface{}, 40)
+	for i := range buckets {
+		clicks := 300 + 40*rng.Float64()
+		leads := clicks * (0.08 + 0.02*rng.Float64())
+		cost := clicks * (1.5 + 0.3*rng.Float64())
+		income := leads * (40 + 10*rng.Float64())
+		buckets[i] = map[string]interface{}{
+			"bucket_start": 1704067200 + i*86400,
+			"total_clicks": clicks, "total_leads": leads, "total_cost": cost,
+			"total_income": income, "total_net": income - cost,
+		}
+	}
+	body, _ := json.Marshal(map[string]interface{}{"data": buckets})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--all-metrics", "--horizon=5", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	maes, ok := meta["mae"].(map[string]interface{})
+	rmses, ok2 := meta["rmse"].(map[string]interface{})
+	if !ok || !ok2 {
+		t.Fatalf("expected per-metric mae and rmse maps, got mae=%v rmse=%v", meta["mae"], meta["rmse"])
+	}
+	for _, m := range forecastCoreMetrics {
+		mae, _ := maes[m].(float64)
+		rmse, _ := rmses[m].(float64)
+		if mae <= 0 || rmse < mae {
+			t.Errorf("%s: mae=%v rmse=%v, want positive errors with rmse >= mae", m, maes[m], rmses[m])
+		}
 	}
 }

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1524,3 +1524,93 @@ func TestForecastAllMetricsReportsErrorsPerMetric(t *testing.T) {
 		}
 	}
 }
+
+func TestForecastRejectedBucketsCountRowsOnce(t *testing.T) {
+	// One row with two non-numeric inputs counts once; a row whose only bad
+	// field is total_net, which coherent forecasting does not consume,
+	// counts zero.
+	buckets := []map[string]interface{}{}
+	for i := 0; i < 30; i++ {
+		clicks := 100.0 + float64(i)
+		buckets = append(buckets, map[string]interface{}{
+			"bucket_start": 1704067200 + i*86400,
+			"total_clicks": clicks, "total_leads": clicks * 0.1, "total_cost": clicks * 2,
+			"total_income": clicks * 5, "total_net": clicks * 3,
+		})
+	}
+	buckets = append(buckets, map[string]interface{}{
+		"bucket_start": 1704067200 + 30*86400,
+		"total_clicks": "bad", "total_leads": "bad", "total_cost": 260.0, "total_income": 650.0, "total_net": 390.0,
+	})
+	buckets = append(buckets, map[string]interface{}{
+		"bucket_start": 1704067200 + 31*86400,
+		"total_clicks": 131.0, "total_leads": 13.1, "total_cost": 262.0, "total_income": 655.0, "total_net": "bad",
+	})
+	body, _ := json.Marshal(map[string]interface{}{"data": buckets})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--all-metrics", "--horizon=3", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	if meta["buckets_rejected"] != 1.0 {
+		t.Errorf("buckets_rejected = %v, want 1 (one bad row, counted once; a bad net-only row not at all)", meta["buckets_rejected"])
+	}
+}
+
+func TestForecastAllMetricsReportsZeroErrors(t *testing.T) {
+	// A constant, exactly coherent history is forecast perfectly: the
+	// rolling errors are a measured zero and must be reported as such, not
+	// dropped as if no backtest had run.
+	buckets := make([]map[string]interface{}, 40)
+	for i := range buckets {
+		buckets[i] = map[string]interface{}{
+			"bucket_start": 1704067200 + i*86400,
+			"total_clicks": 200.0, "total_leads": 20.0, "total_cost": 300.0,
+			"total_income": 900.0, "total_net": 600.0,
+		}
+	}
+	body, _ := json.Marshal(map[string]interface{}{"data": buckets})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--all-metrics", "--horizon=3", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	maes, ok := meta["mae"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected mae map even when every error is zero, got %v", meta["mae"])
+	}
+	for _, m := range forecastCoreMetrics {
+		v, present := maes[m].(float64)
+		if !present || v != 0 {
+			t.Errorf("mae[%s] = %v, want a reported 0", m, maes[m])
+		}
+	}
+}

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1396,3 +1396,55 @@ func TestForecastAPIErrorKeepsAuthExitCodeAndHint(t *testing.T) {
 		t.Errorf("expected key hint, got %q", hintFor(err))
 	}
 }
+
+func TestForecastAllMetricsReportsBoundsSourcePerMetric(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(makeCoherentTimeseriesResponse(40)))
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--all-metrics", "--horizon=5", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	sources, ok := meta["bounds_source"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected per-metric bounds_source map in meta, got %v", meta["bounds_source"])
+	}
+	for _, m := range forecastCoreMetrics {
+		// Derived metrics are backtested as compositions, so with 40 points
+		// every metric's band is conformal — none is a "composed" fallback.
+		if sources[m] != forecast.BoundsConformal {
+			t.Errorf("bounds_source[%s] = %v, want conformal", m, sources[m])
+		}
+	}
+
+	// A single derived metric reports the same calibrated band label.
+	stdout, _, err = executeCommand("forecast", "--metric=leads", "--horizon=5", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta = output["meta"].(map[string]interface{})
+	if meta["composition"] != "derived" {
+		t.Fatalf("composition = %v, want derived", meta["composition"])
+	}
+	if meta["bounds_source"] != forecast.BoundsConformal {
+		t.Errorf("bounds_source = %v, want conformal", meta["bounds_source"])
+	}
+	if meta["bounds"] != "p05-p95 (90%)" {
+		t.Errorf("bounds label = %v, want p05-p95 (90%%)", meta["bounds"])
+	}
+}

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -1284,3 +1284,49 @@ func TestForecastSeasonalMonthlyReportsApplied(t *testing.T) {
 		t.Errorf("meta.seasonal_profiles = %v, want [monthday]", meta["seasonal_profiles"])
 	}
 }
+
+func TestForecastReportsMaskedAnomaliesAndOptOut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buckets := make([]map[string]interface{}, 60)
+		for i := 0; i < 60; i++ {
+			v := 500.0 + float64(i%3)
+			if i == 40 {
+				v = 0 // tracking outage
+			}
+			buckets[i] = map[string]interface{}{"bucket_start": 1704067200 + i*86400, "total_income": v}
+		}
+		data, _ := json.Marshal(map[string]interface{}{"data": buckets})
+		w.WriteHeader(200)
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	writeTestConfig(t, tmp, srv.URL, "test-key")
+
+	stdout, _, err := executeCommand("forecast", "--metric=revenue", "--horizon=3", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	var output map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	meta := output["meta"].(map[string]interface{})
+	masked, _ := meta["anomalies_masked"].([]interface{})
+	if len(masked) != 1 {
+		t.Errorf("meta.anomalies_masked = %v, want one masked day", meta["anomalies_masked"])
+	}
+
+	stdout, _, err = executeCommand("forecast", "--metric=revenue", "--horizon=3", "--no-anomaly-mask", "--json")
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if _, ok := output["meta"].(map[string]interface{})["anomalies_masked"]; ok {
+		t.Error("--no-anomaly-mask still masked points")
+	}
+}

--- a/go-cli/cmd/forecast_test.go
+++ b/go-cli/cmd/forecast_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"

--- a/go-cli/cmd/import_data.go
+++ b/go-cli/cmd/import_data.go
@@ -30,7 +30,7 @@ var dataImportCmd = &cobra.Command{
 		entity := args[0]
 		endpoint, ok := portableEntities[entity]
 		if !ok {
-			return validationError("unsupported entity %q", entity).WithHint("Supported entities: %s", strings.Join(sortedPortableEntities(), ", "))
+			return validationError("unsupported entity %q (supported: %s)", entity, strings.Join(sortedPortableEntities(), ", ")).WithHint("Pass one of those as the first argument, e.g. `p202 import campaigns campaigns.json`.")
 		}
 
 		raw, err := os.ReadFile(args[1])

--- a/go-cli/cmd/import_data.go
+++ b/go-cli/cmd/import_data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"p202/internal/api"
 
@@ -29,7 +30,7 @@ var dataImportCmd = &cobra.Command{
 		entity := args[0]
 		endpoint, ok := portableEntities[entity]
 		if !ok {
-			return fmt.Errorf("unsupported entity %q", entity)
+			return validationError("unsupported entity %q", entity).WithHint("Supported entities: %s", strings.Join(sortedPortableEntities(), ", "))
 		}
 
 		raw, err := os.ReadFile(args[1])
@@ -97,16 +98,16 @@ func parseImportRecords(raw []byte) ([]map[string]interface{}, error) {
 
 	var obj map[string]interface{}
 	if err := json.Unmarshal(raw, &obj); err != nil {
-		return nil, fmt.Errorf("invalid import file JSON: %w", err)
+		return nil, withHint(fmt.Errorf("invalid import file JSON: %w", err), "The file must be JSON as written by `p202 export <entity> --output <file>`: an array of records, or an object with a `data` array.")
 	}
 
 	rawData, ok := obj["data"]
 	if !ok {
-		return nil, fmt.Errorf("import file must be a JSON array or object with data array")
+		return nil, validationError("import file must be a JSON array or object with data array").WithHint("Produce it with `p202 export <entity> --output <file>`, or wrap your records as {\"data\": [...]}.")
 	}
 	items, ok := rawData.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("import file data field must be an array")
+		return nil, validationError("import file data field must be an array").WithHint("Produce it with `p202 export <entity> --output <file>`, or wrap your records as {\"data\": [...]}.")
 	}
 	out := make([]map[string]interface{}, 0, len(items))
 	for _, item := range items {

--- a/go-cli/cmd/multi_report.go
+++ b/go-cli/cmd/multi_report.go
@@ -39,7 +39,7 @@ func resolveMultiProfiles(cmd *cobra.Command) ([]string, error) {
 		selectedModes++
 	}
 	if selectedModes > 1 {
-		return nil, fmt.Errorf("use only one of --all-profiles, --profiles, or --group")
+		return nil, validationError("use only one of --all-profiles, --profiles, or --group")
 	}
 	if selectedModes == 0 {
 		return nil, nil
@@ -57,7 +57,7 @@ func resolveMultiProfiles(cmd *cobra.Command) ([]string, error) {
 	if allProfiles {
 		names := cfg.ProfileNames()
 		if len(names) == 0 {
-			return nil, fmt.Errorf("no profiles configured")
+			return nil, validationError("no profiles configured").WithHint("Add one with `p202 config add-profile <name> --url <url> --key <key>`.")
 		}
 		return names, nil
 	}
@@ -65,7 +65,7 @@ func resolveMultiProfiles(cmd *cobra.Command) ([]string, error) {
 	if groupTag != "" {
 		matches := cfg.ResolveGroup(groupTag)
 		if len(matches) == 0 {
-			return nil, fmt.Errorf("no profiles found for group %q", groupTag)
+			return nil, validationError("no profiles found for group %q", groupTag).WithHint("Tag profiles with `p202 config tag-profile <profile> %s`; `p202 config list-profiles` shows current tags.", groupTag)
 		}
 		return matches, nil
 	}
@@ -79,13 +79,13 @@ func resolveMultiProfiles(cmd *cobra.Command) ([]string, error) {
 			continue
 		}
 		if !available[name] {
-			return nil, fmt.Errorf("profile %q not found", name)
+			return nil, validationError("profile %q not found", name).WithHint("`p202 config list-profiles` shows configured profiles; add one with `p202 config add-profile <name> --url <url> --key <key>`.")
 		}
 		seen[name] = true
 		profiles = append(profiles, name)
 	}
 	if len(profiles) == 0 {
-		return nil, fmt.Errorf("--profiles requires at least one valid profile name")
+		return nil, validationError("--profiles requires at least one valid profile name").WithHint("Comma-separate names from `p202 config list-profiles`, e.g. --profiles prod,staging.")
 	}
 	sort.Strings(profiles)
 	return profiles, nil

--- a/go-cli/cmd/profile.go
+++ b/go-cli/cmd/profile.go
@@ -42,7 +42,7 @@ var configAddProfileCmd = &cobra.Command{
 			cfg.Profiles = map[string]*configpkg.Profile{}
 		}
 		if _, exists := cfg.Profiles[name]; exists {
-			return fmt.Errorf("profile %q already exists", name)
+			return validationError("profile %q already exists", name).WithHint("Use a different name, or `p202 config remove-profile %s` first.", name)
 		}
 
 		cfg.Profiles[name] = &configpkg.Profile{
@@ -76,13 +76,13 @@ var configRemoveProfileCmd = &cobra.Command{
 			return err
 		}
 		if len(cfg.Profiles) == 0 {
-			return fmt.Errorf("no profiles configured")
+			return validationError("no profiles configured").WithHint("Add one with `p202 config add-profile <name> --url <url> --key <key>`.")
 		}
 		if _, exists := cfg.Profiles[name]; !exists {
-			return fmt.Errorf("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
+			return validationError("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
 		}
 		if strings.TrimSpace(cfg.ActiveProfile) == name {
-			return fmt.Errorf("cannot remove active profile %q; run `p202 config use <name>` first", name)
+			return validationError("cannot remove active profile %q", name).WithHint("Switch to another profile with `p202 config use <name>` first, then remove this one.")
 		}
 
 		force, _ := cmd.Flags().GetBool("force")
@@ -116,10 +116,10 @@ var configUseProfileCmd = &cobra.Command{
 			return err
 		}
 		if len(cfg.Profiles) == 0 {
-			return fmt.Errorf("no profiles configured")
+			return validationError("no profiles configured").WithHint("Add one with `p202 config add-profile <name> --url <url> --key <key>`.")
 		}
 		if _, exists := cfg.Profiles[name]; !exists {
-			return fmt.Errorf("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
+			return validationError("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
 		}
 
 		cfg.ActiveProfile = name
@@ -186,7 +186,7 @@ var configRenameProfileCmd = &cobra.Command{
 			return err
 		}
 		if oldName == newName {
-			return fmt.Errorf("old and new profile names are the same")
+			return validationError("old and new profile names are the same")
 		}
 
 		cfg, err := configpkg.Load()
@@ -194,14 +194,14 @@ var configRenameProfileCmd = &cobra.Command{
 			return err
 		}
 		if len(cfg.Profiles) == 0 {
-			return fmt.Errorf("no profiles configured")
+			return validationError("no profiles configured").WithHint("Add one with `p202 config add-profile <name> --url <url> --key <key>`.")
 		}
 		p, exists := cfg.Profiles[oldName]
 		if !exists {
-			return fmt.Errorf("profile %q not found. available profiles: %s", oldName, strings.Join(cfg.ProfileNames(), ", "))
+			return validationError("profile %q not found. available profiles: %s", oldName, strings.Join(cfg.ProfileNames(), ", "))
 		}
 		if _, exists := cfg.Profiles[newName]; exists {
-			return fmt.Errorf("profile %q already exists", newName)
+			return validationError("profile %q already exists", newName)
 		}
 
 		cfg.Profiles[newName] = p
@@ -221,10 +221,10 @@ var configRenameProfileCmd = &cobra.Command{
 func normalizeProfileName(raw string) (string, error) {
 	name := strings.TrimSpace(raw)
 	if name == "" {
-		return "", fmt.Errorf("profile name is required")
+		return "", validationError("profile name is required")
 	}
 	if strings.ContainsAny(name, " \t\r\n,") {
-		return "", fmt.Errorf("profile name must not contain whitespace or commas")
+		return "", validationError("profile name must not contain whitespace or commas")
 	}
 	return name, nil
 }

--- a/go-cli/cmd/profile_tags.go
+++ b/go-cli/cmd/profile_tags.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"unicode"
@@ -28,7 +27,7 @@ var configTagProfileCmd = &cobra.Command{
 		}
 		profile, exists := cfg.Profiles[name]
 		if !exists || profile == nil {
-			return fmt.Errorf("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
+			return validationError("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
 		}
 
 		tagSet := map[string]bool{}
@@ -73,7 +72,7 @@ var configUntagProfileCmd = &cobra.Command{
 		}
 		profile, exists := cfg.Profiles[name]
 		if !exists || profile == nil {
-			return fmt.Errorf("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
+			return validationError("profile %q not found. available profiles: %s", name, strings.Join(cfg.ProfileNames(), ", "))
 		}
 
 		removeSet := map[string]bool{}
@@ -107,7 +106,7 @@ var configUntagProfileCmd = &cobra.Command{
 func normalizeTag(raw string) (string, error) {
 	tag := strings.ToLower(strings.TrimSpace(raw))
 	if tag == "" {
-		return "", fmt.Errorf("tag cannot be empty")
+		return "", validationError("tag cannot be empty")
 	}
 	for _, ch := range tag {
 		if unicode.IsLetter(ch) || unicode.IsDigit(ch) {
@@ -117,7 +116,7 @@ func normalizeTag(raw string) (string, error) {
 		case ':', '-', '_', '.':
 			continue
 		default:
-			return "", fmt.Errorf("invalid tag %q: only letters, digits, and : - _ . are allowed", raw)
+			return "", validationError("invalid tag %q: only letters, digits, and : - _ . are allowed", raw).WithHint("Example tags: env:production, region-eu, team_a.")
 		}
 	}
 	return tag, nil

--- a/go-cli/cmd/root.go
+++ b/go-cli/cmd/root.go
@@ -59,8 +59,38 @@ func Execute() {
 	rootCmd.Long = "p202 is a command-line tool for managing a Prosper202 tracking instance.\n" +
 		"Designed for both human operators and AI agents." + buildAliasHelp()
 	if err := rootCmd.Execute(); err != nil {
+		recoverCommandContext(os.Args[1:])
 		printError(os.Stderr, err)
 		os.Exit(exitCodeForError(err))
+	}
+}
+
+// recoverCommandContext fills in what Cobra never got to set when it
+// rejected the invocation before PersistentPreRunE ran (a wrong argument
+// count, an unknown subcommand): the command path the error output names
+// and hints with, and the output-mode flags that select the JSON envelope.
+// Both are recovered from the raw arguments so an agent still receives a
+// structured, hinted error for the most common mistakes.
+func recoverCommandContext(args []string) {
+	if activeCommandPath == "" {
+		if cmd, _, err := rootCmd.Find(args); err == nil && cmd != nil {
+			activeCommandPath = cmd.CommandPath()
+		} else {
+			activeCommandPath = rootCmd.CommandPath()
+		}
+	}
+	if jsonOutput || ndjsonOutput {
+		return
+	}
+	for _, a := range args {
+		switch a {
+		case "--":
+			return
+		case "--json":
+			jsonOutput = true
+		case "--ndjson":
+			ndjsonOutput = true
+		}
 	}
 }
 

--- a/go-cli/cmd/root.go
+++ b/go-cli/cmd/root.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -23,16 +26,17 @@ var profileName string
 var groupName string
 
 var rootCmd = &cobra.Command{
-	Use:           "p202",
-	Short:         "Prosper202 CLI",
+	Use:   "p202",
+	Short: "Prosper202 CLI",
 	Long: "p202 is a command-line tool for managing a Prosper202 tracking instance.\n" +
-		"Designed for both human operators and AI agents.",  // alias list appended dynamically in Execute()
+		"Designed for both human operators and AI agents.", // alias list appended dynamically in Execute()
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		activeCommandPath = cmd.CommandPath()
 		configpkg.SetActiveOverride(profileName)
 		if jsonOutput && csvOutput {
-			return fmt.Errorf("--json and --csv cannot be used together")
+			return validationError("--json and --csv cannot be used together").WithHint("Pick one output mode.")
 		}
 		return nil
 	},
@@ -55,15 +59,35 @@ func Execute() {
 	rootCmd.Long = "p202 is a command-line tool for managing a Prosper202 tracking instance.\n" +
 		"Designed for both human operators and AI agents." + buildAliasHelp()
 	if err := rootCmd.Execute(); err != nil {
-		if category := api.ErrorCategory(err); category != "" {
-			fmt.Fprintf(os.Stderr, "Error [%s]: %v\n", category, err)
-		} else {
-			fmt.Fprintln(os.Stderr, "Error:", err)
-		}
-		if hint := api.HintFor(err); hint != "" {
-			fmt.Fprintf(os.Stderr, "Hint: %s\n", hint)
-		}
+		printError(os.Stderr, err)
 		os.Exit(exitCodeForError(err))
+	}
+}
+
+// printError writes the failure to w. Under --json/--ndjson it is a single
+// JSON envelope ({"error": {category, message, hint, exit_code, command,
+// http_status, field_errors}}) so agents never parse prose; otherwise a
+// human-readable "Error [category]: ..." line followed by a "Hint:" line
+// when there is a recovery step to suggest.
+func printError(w io.Writer, err error) {
+	if jsonOutput || ndjsonOutput {
+		// No HTML escaping: hints contain "<key>"-style placeholders that
+		// agents should see verbatim.
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if mErr := enc.Encode(errorEnvelope(err)); mErr == nil {
+			w.Write(buf.Bytes())
+			return
+		}
+	}
+	if category := api.ErrorCategory(err); category != "" {
+		fmt.Fprintf(w, "Error [%s]: %v\n", category, err)
+	} else {
+		fmt.Fprintln(w, "Error:", err)
+	}
+	if hint := hintFor(err); hint != "" {
+		fmt.Fprintf(w, "Hint: %s\n", hint)
 	}
 }
 

--- a/go-cli/cmd/rotator.go
+++ b/go-cli/cmd/rotator.go
@@ -87,7 +87,7 @@ var rotatorCreateCmd = &cobra.Command{
 		}
 		name, _ := cmd.Flags().GetString("name")
 		if name == "" {
-			return fmt.Errorf("required flag --name is missing")
+			return validationError("required flag --name is missing")
 		}
 		body := map[string]interface{}{"name": name}
 		for _, f := range []string{"default_url", "default_campaign", "default_lp"} {
@@ -120,7 +120,7 @@ var rotatorUpdateCmd = &cobra.Command{
 			}
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("no fields specified; pass at least one flag to update")
+			return validationError("no fields specified; pass at least one flag to update")
 		}
 		data, err := c.Put("rotators/"+args[0], body)
 		if err != nil {
@@ -153,7 +153,7 @@ var rotatorDeleteCmd = &cobra.Command{
 				return parseErr
 			}
 			if len(idList) == 0 {
-				return fmt.Errorf("--ids requires at least one ID")
+				return validationError("--ids requires at least one ID").WithHint("Comma-separate internal ids, e.g. --ids 12,13,14 (find them with the matching `... list`).")
 			}
 
 			force, _ := cmd.Flags().GetBool("force")
@@ -203,7 +203,7 @@ var rotatorRuleCreateCmd = &cobra.Command{
 		}
 		ruleName, _ := cmd.Flags().GetString("rule_name")
 		if ruleName == "" {
-			return fmt.Errorf("required flag --rule_name is missing")
+			return validationError("required flag --rule_name is missing")
 		}
 		body := map[string]interface{}{
 			"rule_name": ruleName,
@@ -214,7 +214,7 @@ var rotatorRuleCreateCmd = &cobra.Command{
 		if v, _ := cmd.Flags().GetString("criteria_json"); v != "" {
 			var criteria interface{}
 			if err := json.Unmarshal([]byte(v), &criteria); err != nil {
-				return fmt.Errorf("invalid --criteria_json: %w", err)
+				return withHint(fmt.Errorf("invalid --criteria_json: %w", err), "Pass a JSON object; `p202 rotator criteria-values` shows accepted keys and values. Quote it so the shell keeps it intact.")
 			}
 			body["criteria"] = criteria
 		} else if code, _ := cmd.Flags().GetString("country"); code != "" {
@@ -222,14 +222,14 @@ var rotatorRuleCreateCmd = &cobra.Command{
 			// never has to know the exact "Name(CC)" value string.
 			value := countryCriteriaValue(code)
 			if value == "" {
-				return validationError("unknown country code %q (see `rotator criteria-values --search ...`); or use --criteria_json", code)
+				return validationError("unknown country code %q", code).WithHint("Find codes with `p202 rotator criteria-values --search <name>`, or pass raw criteria via --criteria_json.")
 			}
 			body["criteria"] = []map[string]string{{"type": "country", "statement": "is", "value": value}}
 		}
 		if v, _ := cmd.Flags().GetString("redirects_json"); v != "" {
 			var redirects interface{}
 			if err := json.Unmarshal([]byte(v), &redirects); err != nil {
-				return fmt.Errorf("invalid --redirects_json: %w", err)
+				return withHint(fmt.Errorf("invalid --redirects_json: %w", err), "Pass a JSON array of {url, weight} objects; quote it so the shell keeps it intact.")
 			}
 			body["redirects"] = redirects
 		} else if camp, _ := cmd.Flags().GetString("redirect-campaign"); camp != "" {
@@ -267,7 +267,7 @@ var rotatorRuleDeleteCmd = &cobra.Command{
 				return parseErr
 			}
 			if len(idList) == 0 {
-				return fmt.Errorf("--ids requires at least one rule ID")
+				return validationError("--ids requires at least one rule ID").WithHint("Comma-separate rule ids, e.g. --ids 3,4 (find them with `p202 rotator rules <rotator_id>`).")
 			}
 			rotatorID := args[0]
 			force, _ := cmd.Flags().GetBool("force")
@@ -338,7 +338,7 @@ var rotatorRuleUpdateCmd = &cobra.Command{
 		}
 		ruleID = strings.TrimSpace(ruleID)
 		if ruleID == "" {
-			return fmt.Errorf("rule id is required (pass it as the second argument or via --rule_id)")
+			return validationError("rule id is required (pass it as the second argument or via --rule_id)").WithHint("`p202 rotator rules <rotator_id>` lists rule ids.")
 		}
 
 		body := map[string]interface{}{}
@@ -354,19 +354,19 @@ var rotatorRuleUpdateCmd = &cobra.Command{
 		if v, _ := cmd.Flags().GetString("criteria_json"); v != "" {
 			var criteria interface{}
 			if err := json.Unmarshal([]byte(v), &criteria); err != nil {
-				return fmt.Errorf("invalid --criteria_json: %w", err)
+				return withHint(fmt.Errorf("invalid --criteria_json: %w", err), "Pass a JSON object; `p202 rotator criteria-values` shows accepted keys and values. Quote it so the shell keeps it intact.")
 			}
 			body["criteria"] = criteria
 		}
 		if v, _ := cmd.Flags().GetString("redirects_json"); v != "" {
 			var redirects interface{}
 			if err := json.Unmarshal([]byte(v), &redirects); err != nil {
-				return fmt.Errorf("invalid --redirects_json: %w", err)
+				return withHint(fmt.Errorf("invalid --redirects_json: %w", err), "Pass a JSON array of {url, weight} objects; quote it so the shell keeps it intact.")
 			}
 			body["redirects"] = redirects
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("no fields specified; pass at least one flag to update")
+			return validationError("no fields specified; pass at least one flag to update")
 		}
 
 		data, err := c.Put("rotators/"+args[0]+"/rules/"+ruleID, body)

--- a/go-cli/cmd/shell.go
+++ b/go-cli/cmd/shell.go
@@ -84,7 +84,7 @@ func runShell(cmd *cobra.Command, args []string) error {
 func verifyShellAccess() error {
 	client, err := api.NewFromConfig()
 	if err != nil {
-		return fmt.Errorf("shell requires a configured API key: %w", err)
+		return withHint(fmt.Errorf("shell requires a configured API key: %w", err), "Run `p202 config set-url <url>` and `p202 config set-key <key>` first.")
 	}
 
 	if !client.SupportsCapability("shell") {
@@ -92,7 +92,7 @@ func verifyShellAccess() error {
 		if capErr := client.CapabilitiesError(); capErr != nil {
 			return fmt.Errorf("could not verify shell access: %w", capErr)
 		}
-		return fmt.Errorf("shell access is not enabled for this API key. Contact support to upgrade your plan")
+		return validationError("shell access is not enabled for this API key").WithHint("Contact support to enable shell access, or run commands directly (`p202 <command>`) instead of the shell.")
 	}
 	return nil
 }
@@ -387,7 +387,7 @@ Batch mode (for AI agents):
 func switchProfile(name string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", fmt.Errorf("profile name is required")
+		return "", validationError("profile name is required")
 	}
 
 	cfg, err := configpkg.Load()
@@ -395,7 +395,7 @@ func switchProfile(name string) (string, error) {
 		return "", err
 	}
 	if _, exists := cfg.Profiles[name]; !exists {
-		return "", fmt.Errorf("profile %q not found. available: %s", name, strings.Join(cfg.ProfileNames(), ", "))
+		return "", validationError("profile %q not found. available: %s", name, strings.Join(cfg.ProfileNames(), ", "))
 	}
 
 	// Shell access is granted per API key, so switching profiles must pass
@@ -434,7 +434,7 @@ func executeShellCommand(line string) ([]byte, error) {
 
 	// Prevent recursive shell invocation
 	if tokens[0] == "shell" {
-		return nil, fmt.Errorf("cannot run shell from within shell")
+		return nil, validationError("cannot run shell from within shell")
 	}
 
 	// Save session-level state. Cobra retains parsed flag values and their

--- a/go-cli/cmd/sync.go
+++ b/go-cli/cmd/sync.go
@@ -495,7 +495,7 @@ func selectedSyncEntities(entity string) ([]string, error) {
 		return append([]string(nil), syncDependencyOrder...), nil
 	}
 	if _, ok := portableEntities[entity]; !ok {
-		return nil, validationError("unsupported entity %q", entity).WithHint("Supported entities: all, %s", strings.Join(sortedPortableEntities(), ", "))
+		return nil, validationError("unsupported entity %q (supported: all, %s)", entity, strings.Join(sortedPortableEntities(), ", ")).WithHint("Pass one of those as the first argument; `all` syncs every entity in dependency order.")
 	}
 	return []string{entity}, nil
 }

--- a/go-cli/cmd/sync.go
+++ b/go-cli/cmd/sync.go
@@ -100,7 +100,7 @@ var syncStatusCmd = &cobra.Command{
 		fromProfile := firstFlag(cmd, "from", "source")
 		toProfile := firstFlag(cmd, "to", "target")
 		if fromProfile == "" || toProfile == "" {
-			return fmt.Errorf("--from and --to are required")
+			return validationError("--from and --to are required").WithHint("Pass profile names, e.g. --from prod --to staging; `p202 config list-profiles` shows them.")
 		}
 		if handled, err := tryServerSyncRead("sync/status", fromProfile, toProfile); err != nil {
 			return err
@@ -182,7 +182,7 @@ var syncHistoryCmd = &cobra.Command{
 		fromProfile := firstFlag(cmd, "from", "source")
 		toProfile := firstFlag(cmd, "to", "target")
 		if fromProfile == "" || toProfile == "" {
-			return fmt.Errorf("--from and --to are required")
+			return validationError("--from and --to are required").WithHint("Pass profile names, e.g. --from prod --to staging; `p202 config list-profiles` shows them.")
 		}
 		if handled, err := tryServerSyncRead("sync/history", fromProfile, toProfile); err != nil {
 			return err
@@ -476,7 +476,7 @@ func readSyncFlags(cmd *cobra.Command) (syncOptions, string, string, error) {
 	fromProfile := firstFlag(cmd, "from", "source")
 	toProfile := firstFlag(cmd, "to", "target")
 	if fromProfile == "" || toProfile == "" {
-		return syncOptions{}, "", "", fmt.Errorf("--from and --to are required")
+		return syncOptions{}, "", "", validationError("--from and --to are required").WithHint("Pass profile names, e.g. --from prod --to staging; `p202 config list-profiles` shows them.")
 	}
 
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
@@ -495,7 +495,7 @@ func selectedSyncEntities(entity string) ([]string, error) {
 		return append([]string(nil), syncDependencyOrder...), nil
 	}
 	if _, ok := portableEntities[entity]; !ok {
-		return nil, fmt.Errorf("unsupported entity %q", entity)
+		return nil, validationError("unsupported entity %q", entity).WithHint("Supported entities: all, %s", strings.Join(sortedPortableEntities(), ", "))
 	}
 	return []string{entity}, nil
 }
@@ -523,12 +523,12 @@ func buildSyncPayload(entity string, sourceRow map[string]interface{}, sourceLoo
 
 		sourceNatural := referenceNaturalByEntity(refEntity, rawSourceID, sourceLookups)
 		if sourceNatural == "" {
-			return nil, fmt.Errorf("unresolvable source foreign key %s=%s (entity %s)", fkField, rawSourceID, entity)
+			return nil, withHint(fmt.Errorf("unresolvable source foreign key %s=%s (entity %s)", fkField, rawSourceID, entity), "The source record references a %s that does not exist on the source; fix or remove the dangling reference there, or sync with --skip-errors to leave that record out.", fkField)
 		}
 
 		targetID := referenceIDByNatural(refEntity, sourceNatural, targetLookups)
 		if targetID == "" {
-			return nil, fmt.Errorf("unresolvable target foreign key %s via %s=%s", fkField, refEntity, sourceNatural)
+			return nil, withHint(fmt.Errorf("unresolvable target foreign key %s via %s=%s", fkField, refEntity, sourceNatural), "The target has no %s matching the source's; sync that entity first (dependency order: aff-network/ppc-network -> ppc-account -> campaign -> landing-page -> text-ad -> rotator -> tracker) or run `p202 sync all`.", refEntity)
 		}
 
 		payload[fkField] = parseNumericOrString(targetID)

--- a/go-cli/cmd/user.go
+++ b/go-cli/cmd/user.go
@@ -68,10 +68,10 @@ var userCreateCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("user_name")
 		email, _ := cmd.Flags().GetString("user_email")
 		if name == "" {
-			return fmt.Errorf("required flag --user_name is missing")
+			return validationError("required flag --user_name is missing")
 		}
 		if email == "" {
-			return fmt.Errorf("required flag --user_email is missing")
+			return validationError("required flag --user_email is missing")
 		}
 		body := map[string]interface{}{
 			"user_name":  name,
@@ -89,7 +89,7 @@ var userCreateCmd = &cobra.Command{
 			pass = string(passBytes)
 		}
 		if pass == "" {
-			return fmt.Errorf("password is required")
+			return validationError("password is required").WithHint("Pass --password, or pipe it on stdin when prompted; it is never echoed.")
 		}
 		body["user_pass"] = pass
 
@@ -139,7 +139,7 @@ var userUpdateCmd = &cobra.Command{
 			}
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("no fields specified; pass at least one flag to update")
+			return validationError("no fields specified; pass at least one flag to update")
 		}
 		data, err := c.Put("users/"+args[0], body)
 		if err != nil {
@@ -194,11 +194,11 @@ var userRoleAssignCmd = &cobra.Command{
 		}
 		roleIDStr := roleIDFrom(cmd, args)
 		if roleIDStr == "" {
-			return fmt.Errorf("role id is required (pass it as the second argument or via --role_id)")
+			return validationError("role id is required (pass it as the second argument or via --role_id)").WithHint("`p202 user roles` lists role ids.")
 		}
 		roleID, err := strconv.Atoi(roleIDStr)
 		if err != nil {
-			return fmt.Errorf("role_id must be an integer: %s", roleIDStr)
+			return validationError("role_id must be an integer: %s", roleIDStr).WithHint("`p202 user roles` lists role ids.")
 		}
 		data, err := c.Post("users/"+args[0]+"/roles", map[string]interface{}{
 			"role_id": roleID,
@@ -222,7 +222,7 @@ var userRoleRemoveCmd = &cobra.Command{
 		}
 		roleID := roleIDFrom(cmd, args)
 		if roleID == "" {
-			return fmt.Errorf("role id is required (pass it as the second argument or via --role_id)")
+			return validationError("role id is required (pass it as the second argument or via --role_id)").WithHint("`p202 user roles` lists role ids.")
 		}
 		force, _ := cmd.Flags().GetBool("force")
 		if !force && !confirmPrompt("Remove role %s from user %s?", roleID, args[0]) {
@@ -455,7 +455,7 @@ var userPrefsUpdateCmd = &cobra.Command{
 			}
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("no preferences specified; pass at least one flag to update")
+			return validationError("no preferences specified; pass at least one flag to update")
 		}
 		data, err := c.Put("users/"+args[0]+"/preferences", body)
 		if err != nil {

--- a/go-cli/cmd/verify.go
+++ b/go-cli/cmd/verify.go
@@ -253,7 +253,7 @@ var trackerTestCmd = &cobra.Command{
 		}
 		link := resp.Data.DirectURL
 		if link == "" {
-			return validationError("tracker has no resolvable link")
+			return validationError("tracker has no resolvable link").WithHint("Check the tracker with `p202 tracker get <id>`; it needs a landing page or redirect URL before it can be verified.")
 		}
 		if !strings.HasPrefix(link, "http") {
 			scheme := "http"

--- a/go-cli/internal/api/client.go
+++ b/go-cli/internal/api/client.go
@@ -88,11 +88,24 @@ func ErrorCategory(err error) string {
 	return ""
 }
 
+// Hinted is implemented by errors that carry their own recovery hint.
+type Hinted interface {
+	HintText() string
+}
+
 // HintFor returns an actionable recovery hint for an error, or "" when there is
 // nothing useful to add. It augments — never replaces — the error message.
+// An explicit hint attached to the error wins; otherwise the HTTP status or
+// request failure kind selects a generic one.
 func HintFor(err error) string {
 	if err == nil {
 		return ""
+	}
+	var hinted Hinted
+	if errors.As(err, &hinted) {
+		if h := strings.TrimSpace(hinted.HintText()); h != "" {
+			return h
+		}
 	}
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
@@ -101,15 +114,26 @@ func HintFor(err error) string {
 			return "Verify your API key: run `p202 config get`, then `p202 config set-key <key>` if it's wrong."
 		case apiErr.Status == 404:
 			return "Not found. Run the matching `... list` to find valid ids (ids are internal — not the public ones in tracking links; some commands accept --public)."
+		case apiErr.Status == 409:
+			return "A matching record already exists. Run the matching `... list` to find it, then `... update` it instead of creating."
 		case apiErr.Status == 422 && len(apiErr.FieldErrors) > 0:
 			return "Fix the field(s) listed above and retry."
+		case apiErr.Status == 400 || apiErr.Status == 422:
+			return "The server rejected the request values; fix what the message names and retry (`--help` lists the flags)."
+		case apiErr.Status == 429:
+			return "Rate limited. Wait and retry with backoff; reduce --concurrency for bulk operations."
+		case apiErr.Status >= 500:
+			return "Server-side failure. Retry after a short wait; if it persists, run `p202 system health` and check the server logs."
 		}
 		return ""
 	}
 	var reqErr *RequestError
 	if errors.As(err, &reqErr) {
-		if reqErr.Kind == "network" {
-			return "Check the server URL (`p202 config get`) and that the instance is reachable."
+		switch reqErr.Kind {
+		case "network":
+			return "Check the server URL (`p202 config get`) and that the instance is reachable; run `p202 config test` to verify the connection."
+		case "validation":
+			return "The request could not be built from the given values; check them and retry."
 		}
 	}
 	return ""

--- a/go-cli/internal/forecast/anomaly.go
+++ b/go-cli/internal/forecast/anomaly.go
@@ -24,15 +24,16 @@ import (
 const (
 	// anomalyMinPoints is the shortest series checked for transients.
 	anomalyMinPoints = 20
-	// anomalyCycles is how many cycles on each side supply same-slot
-	// reference values.
-	anomalyCycles = 4
+	// DefaultAnomalyCycles is how many cycles on each side supply same-slot
+	// reference values (Config.AnomalyCycles overrides).
+	DefaultAnomalyCycles = 4
 	// anomalyMinRefs is the minimum same-slot references a point needs to
 	// be judged; with fewer, the rolling median of neighbors is used.
 	anomalyMinRefs = 3
-	// anomalyThreshold is the deviation, in robust sigma units (MAD scaled
-	// to the normal), beyond which a point is a transient.
-	anomalyThreshold = 5.0
+	// DefaultAnomalySigma is the deviation, in robust sigma units (MAD
+	// scaled to the normal), beyond which a point is a transient
+	// (Config.AnomalySigma overrides).
+	DefaultAnomalySigma = 5.0
 	// madToSigma converts a median absolute deviation to a normal sigma.
 	madToSigma = 1.4826
 )
@@ -51,11 +52,20 @@ func anomalyCycle(interval Interval) time.Duration {
 }
 
 // detectTransients returns the indices of short anomalous runs in s (on
-// whatever scale s is expressed in), sorted ascending.
-func detectTransients(s Series, interval Interval) []int {
+// whatever scale s is expressed in), sorted ascending. sigma is the
+// deviation threshold in robust sigma units and cycles the number of
+// seasonal cycles on each side used for same-slot references; non-positive
+// values take the defaults.
+func detectTransients(s Series, interval Interval, sigma float64, cycles int) []int {
 	n := len(s)
 	if n < anomalyMinPoints {
 		return nil
+	}
+	if sigma <= 0 {
+		sigma = DefaultAnomalySigma
+	}
+	if cycles <= 0 {
+		cycles = DefaultAnomalyCycles
 	}
 	byTime := make(map[time.Time]float64, n)
 	for _, p := range s {
@@ -69,7 +79,7 @@ func detectTransients(s Series, interval Interval) []int {
 	for i, p := range s {
 		var refs []float64
 		if cycle > 0 {
-			for k := -anomalyCycles; k <= anomalyCycles; k++ {
+			for k := -cycles; k <= cycles; k++ {
 				if k == 0 {
 					continue
 				}
@@ -94,16 +104,16 @@ func detectTransients(s Series, interval Interval) []int {
 	for i, r := range resid {
 		abs[i] = math.Abs(r)
 	}
-	sigma := madToSigma * median(abs)
-	if sigma <= 0 {
+	scale := madToSigma * median(abs)
+	if scale <= 0 {
 		// A series with no typical deviation (e.g. constant): use a small
 		// floor so only genuine departures stand out.
-		sigma = 1e-6 * (math.Abs(mean(seriesValues(s))) + 1)
+		scale = 1e-6 * (math.Abs(mean(seriesValues(s))) + 1)
 	}
 
 	flagged := make([]bool, n)
 	for i, r := range resid {
-		flagged[i] = math.Abs(r) > anomalyThreshold*sigma
+		flagged[i] = math.Abs(r) > sigma*scale
 	}
 
 	// Keep only runs shorter than a regime change.

--- a/go-cli/internal/forecast/anomaly.go
+++ b/go-cli/internal/forecast/anomaly.go
@@ -1,0 +1,157 @@
+package forecast
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// Transient anomaly masking. A tracking outage, a one-off viral day, or an
+// untagged promo is not information about the future; fitting it (and, on
+// log scale, fitting a zero) drags the forecast and collapses the bands
+// exactly when the alerting layer needs a healthy baseline.
+//
+// The test is "abnormal for this series at this point of its cycle": each
+// observation is compared with the same weekday (daily data) or the same
+// hour (hourly data) in the surrounding cycles, so a business closed on
+// Sundays or a low-volume tracker whose counts hover near zero is never
+// masked, while a zero Tuesday in a 500-a-day series is. Deviations are
+// measured in robust units (median absolute deviation of all such
+// residuals), and only short runs are masked: anything at least
+// levelShiftMinSegment long is a regime change and is left to the
+// level-shift detector.
+
+const (
+	// anomalyMinPoints is the shortest series checked for transients.
+	anomalyMinPoints = 20
+	// anomalyCycles is how many cycles on each side supply same-slot
+	// reference values.
+	anomalyCycles = 4
+	// anomalyMinRefs is the minimum same-slot references a point needs to
+	// be judged; with fewer, the rolling median of neighbors is used.
+	anomalyMinRefs = 3
+	// anomalyThreshold is the deviation, in robust sigma units (MAD scaled
+	// to the normal), beyond which a point is a transient.
+	anomalyThreshold = 5.0
+	// madToSigma converts a median absolute deviation to a normal sigma.
+	madToSigma = 1.4826
+)
+
+// anomalyCycle returns the seasonal cycle used for same-slot references, or
+// 0 when the interval has none (week/month use a plain rolling median).
+func anomalyCycle(interval Interval) time.Duration {
+	switch interval {
+	case IntervalDay:
+		return 7 * 24 * time.Hour
+	case IntervalHour:
+		return 24 * time.Hour
+	default:
+		return 0
+	}
+}
+
+// detectTransients returns the indices of short anomalous runs in s (on
+// whatever scale s is expressed in), sorted ascending.
+func detectTransients(s Series, interval Interval) []int {
+	n := len(s)
+	if n < anomalyMinPoints {
+		return nil
+	}
+	byTime := make(map[time.Time]float64, n)
+	for _, p := range s {
+		byTime[p.T] = p.V
+	}
+	cycle := anomalyCycle(interval)
+
+	// Reference level per point: median of same-slot values in the
+	// surrounding cycles, else median of the nearest neighbors.
+	resid := make([]float64, n)
+	for i, p := range s {
+		var refs []float64
+		if cycle > 0 {
+			for k := -anomalyCycles; k <= anomalyCycles; k++ {
+				if k == 0 {
+					continue
+				}
+				if v, ok := byTime[p.T.Add(time.Duration(k)*cycle)]; ok {
+					refs = append(refs, v)
+				}
+			}
+		}
+		if len(refs) < anomalyMinRefs {
+			refs = refs[:0]
+			for j := i - 4; j <= i+4; j++ {
+				if j == i || j < 0 || j >= n {
+					continue
+				}
+				refs = append(refs, s[j].V)
+			}
+		}
+		resid[i] = p.V - median(refs)
+	}
+
+	abs := make([]float64, n)
+	for i, r := range resid {
+		abs[i] = math.Abs(r)
+	}
+	sigma := madToSigma * median(abs)
+	if sigma <= 0 {
+		// A series with no typical deviation (e.g. constant): use a small
+		// floor so only genuine departures stand out.
+		sigma = 1e-6 * (math.Abs(mean(seriesValues(s))) + 1)
+	}
+
+	flagged := make([]bool, n)
+	for i, r := range resid {
+		flagged[i] = math.Abs(r) > anomalyThreshold*sigma
+	}
+
+	// Keep only runs shorter than a regime change.
+	var out []int
+	for i := 0; i < n; {
+		if !flagged[i] {
+			i++
+			continue
+		}
+		j := i
+		for j < n && flagged[j] {
+			j++
+		}
+		if j-i < levelShiftMinSegment {
+			for k := i; k < j; k++ {
+				out = append(out, k)
+			}
+		}
+		i = j
+	}
+	return out
+}
+
+// maskIndices returns a copy of s without the given (ascending) indices.
+func maskIndices(s Series, idx []int) Series {
+	if len(idx) == 0 {
+		return s
+	}
+	drop := make(map[int]bool, len(idx))
+	for _, i := range idx {
+		drop[i] = true
+	}
+	out := make(Series, 0, len(s)-len(idx))
+	for i, p := range s {
+		if !drop[i] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// median returns the median of v (0 for an empty slice) without modifying
+// it.
+func median(v []float64) float64 {
+	if len(v) == 0 {
+		return 0
+	}
+	c := append([]float64(nil), v...)
+	sort.Float64s(c)
+	return quantileSorted(c, 0.5)
+}

--- a/go-cli/internal/forecast/anomaly.go
+++ b/go-cli/internal/forecast/anomaly.go
@@ -36,6 +36,11 @@ const (
 	DefaultAnomalySigma = 5.0
 	// madToSigma converts a median absolute deviation to a normal sigma.
 	madToSigma = 1.4826
+	// anomalyMinFactor is the magnitude floor: however tight the series'
+	// noise, a point is a transient only if it is at least this factor
+	// below or above its reference (halved or doubled), measured on
+	// value+1 so zeros are handled. A 15% dip is never a transient.
+	anomalyMinFactor = 2.0
 )
 
 // anomalyCycle returns the seasonal cycle used for same-slot references, or
@@ -51,12 +56,13 @@ func anomalyCycle(interval Interval) time.Duration {
 	}
 }
 
-// detectTransients returns the indices of short anomalous runs in s (on
-// whatever scale s is expressed in), sorted ascending. sigma is the
+// detectTransients returns the indices of short anomalous runs in s,
+// sorted ascending. logScale says whether s is on log1p scale (so the
+// magnitude floor can be applied as a log difference) or raw. sigma is the
 // deviation threshold in robust sigma units and cycles the number of
 // seasonal cycles on each side used for same-slot references; non-positive
 // values take the defaults.
-func detectTransients(s Series, interval Interval, sigma float64, cycles int) []int {
+func detectTransients(s Series, interval Interval, logScale bool, sigma float64, cycles int) []int {
 	n := len(s)
 	if n < anomalyMinPoints {
 		return nil
@@ -76,6 +82,7 @@ func detectTransients(s Series, interval Interval, sigma float64, cycles int) []
 	// Reference level per point: median of same-slot values in the
 	// surrounding cycles, else median of the nearest neighbors.
 	resid := make([]float64, n)
+	ref := make([]float64, n)
 	for i, p := range s {
 		var refs []float64
 		if cycle > 0 {
@@ -97,7 +104,8 @@ func detectTransients(s Series, interval Interval, sigma float64, cycles int) []
 				refs = append(refs, s[j].V)
 			}
 		}
-		resid[i] = p.V - median(refs)
+		ref[i] = median(refs)
+		resid[i] = p.V - ref[i]
 	}
 
 	abs := make([]float64, n)
@@ -111,9 +119,21 @@ func detectTransients(s Series, interval Interval, sigma float64, cycles int) []
 		scale = 1e-6 * (math.Abs(mean(seriesValues(s))) + 1)
 	}
 
+	minLogDiff := math.Log(anomalyMinFactor)
 	flagged := make([]bool, n)
 	for i, r := range resid {
-		flagged[i] = math.Abs(r) > sigma*scale
+		if math.Abs(r) <= sigma*scale {
+			continue
+		}
+		// Magnitude floor on the original scale, expressed as a log1p
+		// difference either directly or via the (value+1)/(reference+1)
+		// ratio.
+		logDiff := math.Abs(r)
+		if !logScale {
+			v, rf := math.Max(s[i].V, 0), math.Max(ref[i], 0)
+			logDiff = math.Abs(math.Log1p(v) - math.Log1p(rf))
+		}
+		flagged[i] = logDiff >= minLogDiff
 	}
 
 	// Keep only runs shorter than a regime change.

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -62,6 +62,7 @@ func methodForecast(m Method, s Series, cfg Config) ([]Prediction, float64, erro
 // evalRow is one (cut point, horizon step) observation from the rolling
 // backtest: the held-out actual and each method's prediction for it.
 type evalRow struct {
+	cut    int // training prefix length c the prediction was made from
 	step   int // 1-based horizon step
 	actual float64
 	preds  map[Method]float64
@@ -134,6 +135,7 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 				idx, exists := rowIdx[h]
 				if !exists {
 					eval.rows = append(eval.rows, evalRow{
+						cut:    c,
 						step:   h,
 						actual: s[i].V,
 						preds:  map[Method]float64{},
@@ -148,11 +150,12 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 	return eval
 }
 
-// errorStats returns MAE and RMSE for a method across all rolling-backtest
-// rows it produced predictions for. Returns (0, 0) when it produced none.
-func (e *rollingEval) errorStats(m Method) (mae, rmse float64) {
+// errorStats returns MAE and RMSE for a method across the n rolling-backtest
+// rows it produced predictions for. n == 0 (with zero errors) means the
+// method produced no rolling predictions at all — an RMSE of 0 with n > 0 is
+// a genuinely perfect fit, so callers must branch on n, not on the RMSE.
+func (e *rollingEval) errorStats(m Method) (mae, rmse float64, n int) {
 	sumAbs, sumSq := 0.0, 0.0
-	n := 0
 	for _, r := range e.rows {
 		pred, ok := r.preds[m]
 		if !ok {
@@ -164,9 +167,9 @@ func (e *rollingEval) errorStats(m Method) (mae, rmse float64) {
 		n++
 	}
 	if n == 0 {
-		return 0, 0
+		return 0, 0, 0
 	}
-	return sumAbs / float64(n), math.Sqrt(sumSq / float64(n))
+	return sumAbs / float64(n), math.Sqrt(sumSq / float64(n)), n
 }
 
 // residualsByStep buckets a method's residuals (actual − predicted) by
@@ -181,6 +184,101 @@ func (e *rollingEval) residualsByStep(m Method) map[int][]float64 {
 		out[r.step] = append(out[r.step], r.actual-pred)
 	}
 	return out
+}
+
+// recencyDecay discounts rolling-backtest errors per cut point of age when
+// scoring methods for ensemble weights: a cut k points older than the newest
+// counts decay^k. This makes weights track each method's skill in the
+// current regime rather than its average over all history.
+const recencyDecay = 0.85
+
+// recencyRMSE returns each method's recency-weighted rolling RMSE and, per
+// method, whether it produced any rolling predictions at all. maxCut is the
+// newest cut in the eval (0 when there are no rows).
+func (e *rollingEval) recencyRMSE(candidates []Method) map[Method]float64 {
+	maxCut := 0
+	for _, r := range e.rows {
+		if r.cut > maxCut {
+			maxCut = r.cut
+		}
+	}
+	out := map[Method]float64{}
+	for _, m := range candidates {
+		sumW, sumSq := 0.0, 0.0
+		n := 0
+		for _, r := range e.rows {
+			pred, ok := r.preds[m]
+			if !ok {
+				continue
+			}
+			w := math.Pow(recencyDecay, float64(maxCut-r.cut))
+			diff := r.actual - pred
+			sumSq += w * diff * diff
+			sumW += w
+			n++
+		}
+		if n == 0 || sumW <= 0 {
+			continue
+		}
+		out[m] = math.Sqrt(sumSq / sumW)
+	}
+	return out
+}
+
+// ensembleCombine returns the weighted-average prediction for a row over the
+// member methods that predicted it, renormalizing weights over the available
+// members. Returns false when none of the members predicted the row.
+func ensembleCombine(r evalRow, weights map[Method]float64, members []Method) (float64, bool) {
+	sumW, sumV := 0.0, 0.0
+	for _, m := range members {
+		pred, ok := r.preds[m]
+		if !ok {
+			continue
+		}
+		w := weights[m]
+		sumW += w
+		sumV += w * pred
+	}
+	if sumW <= 0 {
+		return 0, false
+	}
+	return sumV / sumW, true
+}
+
+// ensembleResidualsByStep buckets the weighted ensemble's residuals by
+// horizon step, so conformal bounds reflect the combined forecaster that is
+// actually deployed rather than any single member.
+func (e *rollingEval) ensembleResidualsByStep(weights map[Method]float64, members []Method) map[int][]float64 {
+	out := map[int][]float64{}
+	for _, r := range e.rows {
+		pred, ok := ensembleCombine(r, weights, members)
+		if !ok {
+			continue
+		}
+		out[r.step] = append(out[r.step], r.actual-pred)
+	}
+	return out
+}
+
+// ensembleErrorStats returns MAE and RMSE of the weighted ensemble across all
+// rolling-backtest rows.
+func (e *rollingEval) ensembleErrorStats(weights map[Method]float64, members []Method) (mae, rmse float64) {
+	sumAbs, sumSq := 0.0, 0.0
+	n := 0
+	for _, r := range e.rows {
+		pred, ok := ensembleCombine(r, weights, members)
+		if !ok {
+			continue
+		}
+		diff := r.actual - pred
+		sumAbs += math.Abs(diff)
+		sumSq += diff * diff
+		n++
+	}
+	if n == 0 {
+		return 0, 0
+	}
+	return sumAbs / float64(n), math.Sqrt(sumSq / float64(n))
 }
 
 // totalResiduals counts residuals across all steps.

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -167,6 +167,7 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 				continue
 			}
 			applyProfile(preds, profile, cfg.LogTransform)
+			clipPointPredictions(preds, cfg)
 			for i := c; i < len(s); i++ {
 				h, ok := stepFor(s[i].T)
 				if !ok || h > len(preds) {

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -35,11 +35,13 @@ var quantileLevels = []struct {
 	name string
 	q    float64
 }{
+	{"p05", 0.05},
 	{"p10", 0.10},
 	{"p25", 0.25},
 	{"p50", 0.50},
 	{"p75", 0.75},
 	{"p90", 0.90},
+	{"p95", 0.95},
 }
 
 // methodForecast dispatches to the forecaster for m. Forecasters return raw
@@ -57,6 +59,19 @@ func methodForecast(m Method, s Series, cfg Config) ([]Prediction, float64, erro
 	default:
 		return nil, 0, fmt.Errorf("unknown method %q", m)
 	}
+}
+
+// holtWintersMinPoints is the shortest history Holt-Winters is fitted on;
+// its level/trend initialization is unstable below it.
+const holtWintersMinPoints = 14
+
+// methodMinPoints returns the minimum training length a method is fitted
+// on, both for auto-candidacy and for rolling-backtest cuts.
+func methodMinPoints(m Method) int {
+	if m == MethodHoltWinters {
+		return holtWintersMinPoints
+	}
+	return minTrainPoints
 }
 
 // evalRow is one (cut point, horizon step) observation from the rolling
@@ -123,7 +138,7 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 		testCfg.SeasonalWeights = nil
 		testCfg.Anchor = time.Time{}
 
-		train := s[:c]
+		train := trainingView(s, cfg, c)
 		trainEnd := train[len(train)-1].T
 
 		// Map each held-out point to its horizon step by calendar distance.
@@ -139,6 +154,11 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 		}
 
 		for _, m := range methods {
+			// Respect each method's minimum history: a fit the deployed
+			// model would never make must not feed residuals or weights.
+			if c < methodMinPoints(m) {
+				continue
+			}
 			preds, _, err := methodForecast(m, train, testCfg)
 			if err != nil || len(preds) == 0 {
 				continue
@@ -166,14 +186,33 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 	return eval
 }
 
-// errorStats returns MAE and RMSE for a method across the n rolling-backtest
-// rows it produced predictions for. n == 0 (with zero errors) means the
-// method produced no rolling predictions at all — an RMSE of 0 with n > 0 is
-// a genuinely perfect fit, so callers must branch on n, not on the RMSE.
-func (e *rollingEval) errorStats(m Method) (mae, rmse float64, n int) {
+// rowPredictor reads one forecaster's prediction for a backtest row; ok is
+// false when that forecaster produced no prediction for the row.
+type rowPredictor func(r evalRow) (pred float64, ok bool)
+
+// methodPredictor returns the rowPredictor for a single method.
+func (e *rollingEval) methodPredictor(m Method) rowPredictor {
+	return func(r evalRow) (float64, bool) {
+		pred, ok := r.preds[m]
+		return pred, ok
+	}
+}
+
+// ensemblePredictor returns the rowPredictor for a weighted ensemble.
+func ensemblePredictor(weights map[Method]float64, members []Method) rowPredictor {
+	return func(r evalRow) (float64, bool) {
+		return ensembleCombine(r, weights, members)
+	}
+}
+
+// errorStats returns MAE and RMSE for a forecaster across the n rolling-
+// backtest rows it produced predictions for. n == 0 (with zero errors)
+// means it produced no rolling predictions at all — an RMSE of 0 with n > 0
+// is a genuinely perfect fit, so callers must branch on n, not the RMSE.
+func (e *rollingEval) errorStats(predict rowPredictor) (mae, rmse float64, n int) {
 	sumAbs, sumSq := 0.0, 0.0
 	for _, r := range e.rows {
-		pred, ok := r.preds[m]
+		pred, ok := predict(r)
 		if !ok {
 			continue
 		}
@@ -188,12 +227,12 @@ func (e *rollingEval) errorStats(m Method) (mae, rmse float64, n int) {
 	return sumAbs / float64(n), math.Sqrt(sumSq / float64(n)), n
 }
 
-// residualsByStep buckets a method's residuals (actual − predicted) by
-// horizon step.
-func (e *rollingEval) residualsByStep(m Method) map[int][]float64 {
+// residualsByStep buckets a forecaster's residuals (actual − predicted, on
+// the model scale) by horizon step.
+func (e *rollingEval) residualsByStep(predict rowPredictor) map[int][]float64 {
 	out := map[int][]float64{}
 	for _, r := range e.rows {
-		pred, ok := r.preds[m]
+		pred, ok := predict(r)
 		if !ok {
 			continue
 		}
@@ -208,9 +247,9 @@ func (e *rollingEval) residualsByStep(m Method) map[int][]float64 {
 // current regime rather than its average over all history.
 const recencyDecay = 0.85
 
-// recencyRMSE returns each method's recency-weighted rolling RMSE and, per
-// method, whether it produced any rolling predictions at all. maxCut is the
-// newest cut in the eval (0 when there are no rows).
+// recencyRMSE returns each candidate's recency-weighted rolling RMSE (on
+// the model scale, where members are compared); candidates that produced
+// no rolling predictions are absent from the result.
 func (e *rollingEval) recencyRMSE(candidates []Method) map[Method]float64 {
 	maxCut := 0
 	for _, r := range e.rows {
@@ -259,42 +298,6 @@ func ensembleCombine(r evalRow, weights map[Method]float64, members []Method) (f
 		return 0, false
 	}
 	return sumV / sumW, true
-}
-
-// ensembleResidualsByStep buckets the weighted ensemble's residuals by
-// horizon step, so conformal bounds reflect the combined forecaster that is
-// actually deployed rather than any single member.
-func (e *rollingEval) ensembleResidualsByStep(weights map[Method]float64, members []Method) map[int][]float64 {
-	out := map[int][]float64{}
-	for _, r := range e.rows {
-		pred, ok := ensembleCombine(r, weights, members)
-		if !ok {
-			continue
-		}
-		out[r.step] = append(out[r.step], r.actual-pred)
-	}
-	return out
-}
-
-// ensembleErrorStats returns MAE and RMSE of the weighted ensemble across all
-// rolling-backtest rows.
-func (e *rollingEval) ensembleErrorStats(weights map[Method]float64, members []Method) (mae, rmse float64) {
-	sumAbs, sumSq := 0.0, 0.0
-	n := 0
-	for _, r := range e.rows {
-		pred, ok := ensembleCombine(r, weights, members)
-		if !ok {
-			continue
-		}
-		diff := e.errDiff(r.actual, pred)
-		sumAbs += math.Abs(diff)
-		sumSq += diff * diff
-		n++
-	}
-	if n == 0 {
-		return 0, 0
-	}
-	return sumAbs / float64(n), math.Sqrt(sumSq / float64(n))
 }
 
 // totalResiduals counts residuals across all steps.
@@ -430,13 +433,33 @@ func quantileSorted(sorted []float64, q float64) float64 {
 }
 
 // boundPair maps a confidence level to the quantile pair used for
-// LowerBound/UpperBound: the nearest emitted pair. P10/P90 form an 80%
-// interval, P25/P75 a 50% one; levels of 0.65 and above snap to P10/P90.
+// LowerBound/UpperBound — the nearest emitted pair. P25/P75 form a 50%
+// interval, P10/P90 an 80% one, and P05/P95 a 90% one; levels of 0.85 and
+// above (including the 0.95 default and 0.99) snap to P05/P95, the widest
+// band the residual pool supports.
 func boundPair(confidence float64) (lower, upper string) {
-	if confidence < 0.65 {
+	switch {
+	case confidence < 0.65:
 		return "p25", "p75"
+	case confidence < 0.85:
+		return "p10", "p90"
+	default:
+		return "p05", "p95"
 	}
-	return "p10", "p90"
+}
+
+// BoundLevels reports the nominal coverage of the band a confidence level
+// maps to (see boundPair), for documentation and CLI metadata.
+func BoundLevels(confidence float64) (lower, upper string, coverage float64) {
+	lower, upper = boundPair(confidence)
+	switch lower {
+	case "p25":
+		return lower, upper, 0.50
+	case "p10":
+		return lower, upper, 0.80
+	default:
+		return lower, upper, 0.90
+	}
 }
 
 // applyConformalBounds attaches empirical quantiles and bounds to
@@ -470,10 +493,11 @@ func applyConformalBounds(preds []Prediction, sq map[int]map[string]float64, cfg
 	}
 }
 
-// clipNonNegative floors prediction values, bounds, and quantiles at zero.
-// Applied when cfg.NonNegative marks the metric as a count/amount that
-// cannot go below zero (clicks, leads, cost, income).
-func clipNonNegative(preds []Prediction) {
+// ClipNonNegative floors prediction values, bounds, and quantiles at zero.
+// Run applies it when cfg.NonNegative marks the metric as a count/amount
+// that cannot go below zero (clicks, leads, cost, income); callers that
+// scale predictions afterwards (event adjustments) re-apply it.
+func ClipNonNegative(preds []Prediction) {
 	for i := range preds {
 		if preds[i].Value < 0 {
 			preds[i].Value = 0

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -130,7 +130,14 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 		eval.invert = math.Expm1
 	}
 	for c := len(s) - 1; c >= lowestCut; c-- {
-		steps := len(s) - c
+		train := trainingView(s, cfg, c)
+		trainEnd := train[len(train)-1].T
+
+		// This cut's horizon is the calendar distance to the farthest
+		// held-out point (masked gaps make it exceed the observation
+		// count), capped at the configured horizon, so residuals around a
+		// gap are kept rather than rejected as out of range.
+		steps := calendarSteps(trainEnd, s[len(s)-1].T, cfg.Interval)
 		if steps > horizon {
 			steps = horizon
 		}
@@ -140,20 +147,10 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 		testCfg.SeasonalWeights = nil
 		testCfg.Anchor = time.Time{}
 
-		train := trainingView(s, cfg, c)
-		trainEnd := train[len(train)-1].T
-
 		// Map each held-out point to its horizon step by calendar distance.
 		// Rows are created lazily so methods share the same row set.
 		rowIdx := map[int]int{} // step -> index into eval.rows (this cut only)
-		stepFor := func(t time.Time) (int, bool) {
-			exact := intervalSteps(trainEnd, t, cfg.Interval)
-			h := int(math.Round(exact))
-			if math.Abs(exact-float64(h)) > 0.01 || h < 1 || h > steps {
-				return 0, false
-			}
-			return h, true
-		}
+		stepFor := func(t time.Time) (int, bool) { return stepIndex(trainEnd, t, cfg.Interval, steps) }
 
 		for _, m := range methods {
 			// Respect each method's minimum history: a fit the deployed
@@ -167,6 +164,7 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 			if err != nil || len(preds) == 0 {
 				continue
 			}
+			applyProfile(preds, cfg)
 			for i := c; i < len(s); i++ {
 				h, ok := stepFor(s[i].T)
 				if !ok || h > len(preds) {

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -131,6 +131,9 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 	}
 	for c := len(s) - 1; c >= lowestCut; c-- {
 		train := trainingView(s, cfg, c)
+		if len(train) == 0 {
+			continue
+		}
 		trainEnd := train[len(train)-1].T
 
 		// This cut's horizon is the calendar distance to the farthest
@@ -146,8 +149,8 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 		testCfg.Horizon = steps
 		testCfg.Anchor = time.Time{}
 
-		// This fold's seasonal profile, from its own prefix.
-		profile, _ := profileFor(s, cfg, c)
+		// This fold's seasonal profile, from its own training view.
+		profile, _ := profileFor(train, cfg)
 
 		// Map each held-out point to its horizon step by calendar distance.
 		// Rows are created lazily so methods share the same row set.
@@ -169,6 +172,10 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 			applyProfile(preds, profile, cfg.LogTransform)
 			clipPointPredictions(preds, cfg)
 			for i := c; i < len(s); i++ {
+				// Masked transients are not scored (see Config.excluded).
+				if cfg.excluded[s[i].T] {
+					continue
+				}
 				h, ok := stepFor(s[i].T)
 				if !ok || h > len(preds) {
 					continue

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -1,0 +1,379 @@
+package forecast
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+// Rolling-origin backtesting and conformal prediction bounds.
+//
+// Instead of a single train/test split, the series is re-fit at many cut
+// points stepping back from the end. Residuals (actual − predicted) are
+// collected per horizon step h, giving an empirical error distribution for
+// "h steps out" that makes no symmetry or normality assumptions. Prediction
+// bounds are then the empirical quantiles of those residuals added to the
+// point forecast (split conformal prediction).
+
+const (
+	// minTrainPoints is the smallest training prefix a rolling cut may use.
+	minTrainPoints = 8
+	// maxRefits caps the number of rolling-origin refits per method.
+	maxRefits = 50
+	// minBucketSamples is the target residual count per horizon-step bucket;
+	// thinner buckets are merged with adjacent steps until they reach it.
+	minBucketSamples = 8
+	// minTotalResiduals is the smallest residual pool conformal bounds are
+	// computed from; below it Run falls back to Gaussian bounds.
+	minTotalResiduals = 8
+)
+
+// quantileLevels are the emitted quantiles, ascending. LowerBound/UpperBound
+// map to the pair nearest the configured confidence level (see boundPair).
+var quantileLevels = []struct {
+	name string
+	q    float64
+}{
+	{"p10", 0.10},
+	{"p25", 0.25},
+	{"p50", 0.50},
+	{"p75", 0.75},
+	{"p90", 0.90},
+}
+
+// methodForecast dispatches to the forecaster for m. Forecasters return raw
+// point predictions; bounds are attached afterwards by the caller.
+func methodForecast(m Method, s Series, cfg Config) ([]Prediction, float64, error) {
+	switch m {
+	case MethodLinear:
+		return linearForecast(s, cfg)
+	case MethodSMA:
+		return smaForecast(s, cfg)
+	case MethodWMA:
+		return wmaForecast(s, cfg)
+	case MethodHoltWinters:
+		return holtWintersForecast(s, cfg)
+	default:
+		return nil, 0, fmt.Errorf("unknown method %q", m)
+	}
+}
+
+// evalRow is one (cut point, horizon step) observation from the rolling
+// backtest: the held-out actual and each method's prediction for it.
+type evalRow struct {
+	step   int // 1-based horizon step
+	actual float64
+	preds  map[Method]float64
+}
+
+// rollingEval aggregates rolling-origin backtest results for one or more
+// methods evaluated on identical cuts.
+type rollingEval struct {
+	rows []evalRow
+}
+
+// runRollingBacktest refits each method on training prefixes s[:c] for cut
+// points c stepping back one point at a time from the end of the series
+// (capped at maxRefits cuts, so residuals reflect the most recent regime),
+// and records held-out residuals bucketed by horizon step. Test points are
+// matched to prediction steps by calendar distance from the training end, so
+// masked-day gaps in the series don't misalign residuals.
+func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
+	nCuts := len(s) - minTrainPoints
+	if nCuts <= 0 {
+		return &rollingEval{}
+	}
+	lowestCut := minTrainPoints
+	if nCuts > maxRefits {
+		lowestCut = len(s) - maxRefits
+	}
+
+	horizon := cfg.Horizon
+	if horizon < 1 {
+		horizon = 1
+	}
+
+	eval := &rollingEval{}
+	for c := len(s) - 1; c >= lowestCut; c-- {
+		steps := len(s) - c
+		if steps > horizon {
+			steps = horizon
+		}
+
+		testCfg := cfg
+		testCfg.Horizon = steps
+		testCfg.SeasonalWeights = nil
+		testCfg.Anchor = time.Time{}
+
+		train := s[:c]
+		trainEnd := train[len(train)-1].T
+
+		// Map each held-out point to its horizon step by calendar distance.
+		// Rows are created lazily so methods share the same row set.
+		rowIdx := map[int]int{} // step -> index into eval.rows (this cut only)
+		stepFor := func(t time.Time) (int, bool) {
+			exact := intervalSteps(trainEnd, t, cfg.Interval)
+			h := int(math.Round(exact))
+			if math.Abs(exact-float64(h)) > 0.01 || h < 1 || h > steps {
+				return 0, false
+			}
+			return h, true
+		}
+
+		for _, m := range methods {
+			preds, _, err := methodForecast(m, train, testCfg)
+			if err != nil || len(preds) == 0 {
+				continue
+			}
+			for i := c; i < len(s); i++ {
+				h, ok := stepFor(s[i].T)
+				if !ok || h > len(preds) {
+					continue
+				}
+				idx, exists := rowIdx[h]
+				if !exists {
+					eval.rows = append(eval.rows, evalRow{
+						step:   h,
+						actual: s[i].V,
+						preds:  map[Method]float64{},
+					})
+					idx = len(eval.rows) - 1
+					rowIdx[h] = idx
+				}
+				eval.rows[idx].preds[m] = preds[h-1].Value
+			}
+		}
+	}
+	return eval
+}
+
+// errorStats returns MAE and RMSE for a method across all rolling-backtest
+// rows it produced predictions for. Returns (0, 0) when it produced none.
+func (e *rollingEval) errorStats(m Method) (mae, rmse float64) {
+	sumAbs, sumSq := 0.0, 0.0
+	n := 0
+	for _, r := range e.rows {
+		pred, ok := r.preds[m]
+		if !ok {
+			continue
+		}
+		diff := r.actual - pred
+		sumAbs += math.Abs(diff)
+		sumSq += diff * diff
+		n++
+	}
+	if n == 0 {
+		return 0, 0
+	}
+	return sumAbs / float64(n), math.Sqrt(sumSq / float64(n))
+}
+
+// residualsByStep buckets a method's residuals (actual − predicted) by
+// horizon step.
+func (e *rollingEval) residualsByStep(m Method) map[int][]float64 {
+	out := map[int][]float64{}
+	for _, r := range e.rows {
+		pred, ok := r.preds[m]
+		if !ok {
+			continue
+		}
+		out[r.step] = append(out[r.step], r.actual-pred)
+	}
+	return out
+}
+
+// totalResiduals counts residuals across all steps.
+func totalResiduals(byStep map[int][]float64) int {
+	n := 0
+	for _, b := range byStep {
+		n += len(b)
+	}
+	return n
+}
+
+// stepQuantiles computes empirical residual quantiles for each horizon step
+// 1..maxStep. Steps whose bucket holds fewer than minBucketSamples residuals
+// are merged with adjacent steps (h±1, widening symmetrically) until the pool
+// is large enough or every observed bucket has been absorbed. Steps beyond
+// the largest observed step reuse the pool of the farthest observed steps.
+//
+// To keep uncertainty growing with horizon, each quantile offset is made
+// monotone across steps: lower offsets never rise, upper offsets never fall.
+func stepQuantiles(byStep map[int][]float64, maxStep int) map[int]map[string]float64 {
+	if len(byStep) == 0 || maxStep < 1 {
+		return nil
+	}
+	maxObserved := 0
+	for h := range byStep {
+		if h > maxObserved {
+			maxObserved = h
+		}
+	}
+
+	out := make(map[int]map[string]float64, maxStep)
+	for h := 1; h <= maxStep; h++ {
+		center := h
+		if center > maxObserved {
+			center = maxObserved
+		}
+		pool := gatherPool(byStep, center, maxObserved)
+		if len(pool) == 0 {
+			continue
+		}
+		sort.Float64s(pool)
+		qs := make(map[string]float64, len(quantileLevels))
+		for _, lv := range quantileLevels {
+			qs[lv.name] = quantileConformal(pool, lv.q)
+		}
+		out[h] = qs
+	}
+
+	// Enforce monotone widening across steps.
+	for h := 2; h <= maxStep; h++ {
+		cur, prev := out[h], out[h-1]
+		if cur == nil || prev == nil {
+			continue
+		}
+		for _, lv := range quantileLevels {
+			switch {
+			case lv.q < 0.5 && cur[lv.name] > prev[lv.name]:
+				cur[lv.name] = prev[lv.name]
+			case lv.q > 0.5 && cur[lv.name] < prev[lv.name]:
+				cur[lv.name] = prev[lv.name]
+			}
+		}
+	}
+	return out
+}
+
+// gatherPool collects the residual bucket at center, merging adjacent step
+// buckets outward until minBucketSamples is reached or the range 1..maxStep
+// is exhausted.
+func gatherPool(byStep map[int][]float64, center, maxStep int) []float64 {
+	pool := append([]float64(nil), byStep[center]...)
+	for radius := 1; len(pool) < minBucketSamples; radius++ {
+		lo, hi := center-radius, center+radius
+		if lo < 1 && hi > maxStep {
+			break
+		}
+		if lo >= 1 {
+			pool = append(pool, byStep[lo]...)
+		}
+		if hi <= maxStep {
+			pool = append(pool, byStep[hi]...)
+		}
+	}
+	return pool
+}
+
+// quantileConformal returns the q-quantile of an ascending-sorted residual
+// slice using the split-conformal finite-sample correction: rank ⌈(n+1)q⌉
+// for upper quantiles and ⌊(n+1)q⌋ for lower ones. Compared to interpolated
+// quantiles this widens slightly at small n, which is what makes the
+// resulting intervals hold their nominal coverage on future observations.
+// The median uses plain interpolation (no coverage role).
+func quantileConformal(sorted []float64, q float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	switch {
+	case q > 0.5:
+		k := int(math.Ceil(q * float64(n+1)))
+		if k > n {
+			k = n
+		}
+		return sorted[k-1]
+	case q < 0.5:
+		k := int(math.Floor(q * float64(n+1)))
+		if k < 1 {
+			k = 1
+		}
+		return sorted[k-1]
+	default:
+		return quantileSorted(sorted, 0.5)
+	}
+}
+
+// quantileSorted returns the q-quantile of an ascending-sorted slice using
+// linear interpolation between order statistics (type-7 estimator).
+func quantileSorted(sorted []float64, q float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	pos := q * float64(n-1)
+	lo := int(math.Floor(pos))
+	if lo >= n-1 {
+		return sorted[n-1]
+	}
+	frac := pos - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[lo+1]*frac
+}
+
+// boundPair maps a confidence level to the quantile pair used for
+// LowerBound/UpperBound: the nearest emitted pair. P10/P90 form an 80%
+// interval, P25/P75 a 50% one; levels of 0.65 and above snap to P10/P90.
+func boundPair(confidence float64) (lower, upper string) {
+	if confidence < 0.65 {
+		return "p25", "p75"
+	}
+	return "p10", "p90"
+}
+
+// applyConformalBounds attaches empirical quantiles and bounds to
+// predictions. offset is the anchor gap (see anchorOffset): prediction i sits
+// offset+i+1 steps beyond the last training point, so it draws the quantiles
+// for that step.
+func applyConformalBounds(preds []Prediction, sq map[int]map[string]float64, cfg Config, offset int) {
+	lowerName, upperName := boundPair(cfg.ConfidenceLevel)
+	maxStep := 0
+	for h := range sq {
+		if h > maxStep {
+			maxStep = h
+		}
+	}
+	for i := range preds {
+		h := offset + i + 1
+		if h > maxStep {
+			h = maxStep
+		}
+		qs := sq[h]
+		if qs == nil {
+			continue
+		}
+		quantiles := make(map[string]float64, len(qs))
+		for name, off := range qs {
+			quantiles[name] = preds[i].Value + off
+		}
+		preds[i].Quantiles = quantiles
+		preds[i].LowerBound = quantiles[lowerName]
+		preds[i].UpperBound = quantiles[upperName]
+	}
+}
+
+// clipNonNegative floors prediction values, bounds, and quantiles at zero.
+// Applied when cfg.NonNegative marks the metric as a count/amount that
+// cannot go below zero (clicks, leads, cost, income).
+func clipNonNegative(preds []Prediction) {
+	for i := range preds {
+		if preds[i].Value < 0 {
+			preds[i].Value = 0
+		}
+		if preds[i].LowerBound < 0 {
+			preds[i].LowerBound = 0
+		}
+		if preds[i].UpperBound < 0 {
+			preds[i].UpperBound = 0
+		}
+		for name, v := range preds[i].Quantiles {
+			if v < 0 {
+				preds[i].Quantiles[name] = 0
+			}
+		}
+	}
+}

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -158,7 +158,9 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 		for _, m := range methods {
 			// Respect each method's minimum history: a fit the deployed
 			// model would never make must not feed residuals or weights.
-			if c < methodMinPoints(m) {
+			// (The view can be shorter than c after a level-shift
+			// truncation inside the prefix.)
+			if len(train) < methodMinPoints(m) {
 				continue
 			}
 			preds, _, err := methodForecast(m, train, testCfg)
@@ -199,13 +201,6 @@ func (e *rollingEval) methodPredictor(m Method) rowPredictor {
 	return func(r evalRow) (float64, bool) {
 		pred, ok := r.preds[m]
 		return pred, ok
-	}
-}
-
-// ensemblePredictor returns the rowPredictor for a weighted ensemble.
-func ensemblePredictor(weights map[Method]float64, members []Method) rowPredictor {
-	return func(r evalRow) (float64, bool) {
-		return ensembleCombine(r, weights, members)
 	}
 }
 
@@ -252,11 +247,15 @@ func (e *rollingEval) residualsByStep(predict rowPredictor) map[int][]float64 {
 const recencyDecay = 0.85
 
 // recencyRMSE returns each candidate's recency-weighted rolling RMSE (on
-// the model scale, where members are compared); candidates that produced
-// no rolling predictions are absent from the result.
-func (e *rollingEval) recencyRMSE(candidates []Method) map[Method]float64 {
+// the model scale, where members are compared) over the rows include
+// accepts (all rows when include is nil); candidates that produced no
+// rolling predictions on those rows are absent from the result.
+func (e *rollingEval) recencyRMSE(candidates []Method, include func(evalRow) bool) map[Method]float64 {
 	maxCut := 0
 	for _, r := range e.rows {
+		if include != nil && !include(r) {
+			continue
+		}
 		if r.cut > maxCut {
 			maxCut = r.cut
 		}
@@ -266,6 +265,9 @@ func (e *rollingEval) recencyRMSE(candidates []Method) map[Method]float64 {
 		sumW, sumSq := 0.0, 0.0
 		n := 0
 		for _, r := range e.rows {
+			if include != nil && !include(r) {
+				continue
+			}
 			pred, ok := r.preds[m]
 			if !ok {
 				continue

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -144,8 +144,10 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 
 		testCfg := cfg
 		testCfg.Horizon = steps
-		testCfg.SeasonalWeights = nil
 		testCfg.Anchor = time.Time{}
+
+		// This fold's seasonal profile, from its own prefix.
+		profile, _ := profileFor(s, cfg, c)
 
 		// Map each held-out point to its horizon step by calendar distance.
 		// Rows are created lazily so methods share the same row set.
@@ -164,7 +166,7 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 			if err != nil || len(preds) == 0 {
 				continue
 			}
-			applyProfile(preds, cfg)
+			applyProfile(preds, profile, cfg.LogTransform)
 			for i := c; i < len(s); i++ {
 				h, ok := stepFor(s[i].T)
 				if !ok || h > len(preds) {

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -77,10 +77,12 @@ func methodMinPoints(m Method) int {
 // evalRow is one (cut point, horizon step) observation from the rolling
 // backtest: the held-out actual and each method's prediction for it.
 type evalRow struct {
-	cut    int // training prefix length c the prediction was made from
-	step   int // 1-based horizon step
-	actual float64
-	preds  map[Method]float64
+	cut      int       // training prefix length c the prediction was made from
+	trainEnd time.Time // timestamp of the last training point
+	t        time.Time // timestamp of the held-out actual
+	step     int       // 1-based horizon step
+	actual   float64
+	preds    map[Method]float64
 }
 
 // rollingEval aggregates rolling-origin backtest results for one or more
@@ -171,10 +173,12 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 				idx, exists := rowIdx[h]
 				if !exists {
 					eval.rows = append(eval.rows, evalRow{
-						cut:    c,
-						step:   h,
-						actual: s[i].V,
-						preds:  map[Method]float64{},
+						cut:      c,
+						trainEnd: trainEnd,
+						t:        s[i].T,
+						step:     h,
+						actual:   s[i].V,
+						preds:    map[Method]float64{},
 					})
 					idx = len(eval.rows) - 1
 					rowIdx[h] = idx

--- a/go-cli/internal/forecast/backtest.go
+++ b/go-cli/internal/forecast/backtest.go
@@ -72,6 +72,19 @@ type evalRow struct {
 // methods evaluated on identical cuts.
 type rollingEval struct {
 	rows []evalRow
+	// invert maps stored values back to the original scale for reported
+	// error statistics when the series was fitted under a transform (log1p).
+	// Conformal residuals deliberately stay on the model scale — quantiles
+	// are computed there and inverted with the predictions.
+	invert func(float64) float64
+}
+
+// errDiff returns actual − predicted on the reporting scale.
+func (e *rollingEval) errDiff(actual, pred float64) float64 {
+	if e.invert != nil {
+		return e.invert(actual) - e.invert(pred)
+	}
+	return actual - pred
 }
 
 // runRollingBacktest refits each method on training prefixes s[:c] for cut
@@ -96,6 +109,9 @@ func runRollingBacktest(s Series, cfg Config, methods []Method) *rollingEval {
 	}
 
 	eval := &rollingEval{}
+	if cfg.LogTransform {
+		eval.invert = math.Expm1
+	}
 	for c := len(s) - 1; c >= lowestCut; c-- {
 		steps := len(s) - c
 		if steps > horizon {
@@ -161,7 +177,7 @@ func (e *rollingEval) errorStats(m Method) (mae, rmse float64, n int) {
 		if !ok {
 			continue
 		}
-		diff := r.actual - pred
+		diff := e.errDiff(r.actual, pred)
 		sumAbs += math.Abs(diff)
 		sumSq += diff * diff
 		n++
@@ -270,7 +286,7 @@ func (e *rollingEval) ensembleErrorStats(weights map[Method]float64, members []M
 		if !ok {
 			continue
 		}
-		diff := r.actual - pred
+		diff := e.errDiff(r.actual, pred)
 		sumAbs += math.Abs(diff)
 		sumSq += diff * diff
 		n++

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -1,0 +1,319 @@
+package forecast
+
+import (
+	"fmt"
+	"time"
+)
+
+// Coherent multi-metric forecasting via ratio decomposition.
+//
+// Forecasting totals independently can produce internally inconsistent
+// results (an income path and a cost path implying an ROI nothing supports).
+// RunCoherent instead forecasts drivers — clicks and the rates that link the
+// totals (conversion rate, average CPC, average payout), which are far more
+// stationary than the totals themselves — and composes the derived metrics
+// per timestep:
+//
+//	leads  = clicks × conv_rate
+//	cost   = clicks × avg_cpc
+//	income = leads × avg_payout
+//	net    = income − cost
+//
+// so the reported forecasts satisfy those identities exactly.
+
+// Metric keys accepted and returned by RunCoherent, matching the
+// reports/timeseries API field names.
+const (
+	MetricClicks = "total_clicks"
+	MetricLeads  = "total_leads"
+	MetricIncome = "total_income"
+	MetricCost   = "total_cost"
+	MetricNet    = "total_net"
+)
+
+// CompositionDirect and CompositionDerived label how each RunCoherent result
+// was produced (Result.Composition).
+const (
+	CompositionDirect  = "direct"
+	CompositionDerived = "derived"
+)
+
+// coherentSparseThreshold is the minimum fraction of clicks buckets a driver
+// rate must be defined on; below it the dependent metric falls back to
+// direct forecasting rather than composing from a rate estimated on scraps.
+const coherentSparseThreshold = 0.7
+
+// RunCoherent forecasts the core metrics coherently. The input map must hold
+// the four observed totals series under the MetricClicks/MetricLeads/
+// MetricIncome/MetricCost keys (values from the same report buckets);
+// driver rates are derived per bucket from those totals, so the composed
+// forecasts' identities hold against the series actually supplied.
+//
+// The returned map holds results for the four totals plus MetricNet. Each
+// result's Composition field reports "derived" (composed from drivers) or
+// "direct" (fallback when a driver rate is too sparse — e.g. conv_rate
+// undefined on many days). Derived results compose quantiles pairwise
+// (P50 from P50s; band endpoints combine conservatively, assuming
+// worst-case dependence between factors, so composed bands are valid but
+// can over-cover); their MAE/RMSE are zero since rolling errors are only
+// measured for directly fitted series. cfg.Metric, cfg.SeasonalWeights, and
+// cfg.NonNegative are ignored: metric-appropriate values are set per driver.
+func RunCoherent(series map[string]Series, cfg Config) (map[string]*Result, error) {
+	for _, key := range []string{MetricClicks, MetricLeads, MetricIncome, MetricCost} {
+		if len(series[key]) < 3 {
+			return nil, fmt.Errorf("coherent forecast needs at least 3 data points for %s, got %d", key, len(series[key]))
+		}
+	}
+
+	clicks := series[MetricClicks]
+	// Anchor every forecast at the clicks series' last bucket so all metrics
+	// share prediction timestamps even when a driver's last defined bucket
+	// is older (anchorOffset bridges the gap).
+	anchor := clicks[len(clicks)-1].T
+	if !cfg.Anchor.IsZero() && cfg.Anchor.After(anchor) {
+		anchor = cfg.Anchor
+	}
+
+	convRate, rateOK := deriveRate(series[MetricLeads], clicks)
+	avgCPC, cpcOK := deriveRate(series[MetricCost], clicks)
+	avgPayout, payoutOK := deriveRate(series[MetricIncome], series[MetricLeads])
+
+	out := map[string]*Result{}
+
+	clicksRes, err := runCoherentPart(clicks, cfg, MetricClicks, anchor)
+	if err != nil {
+		return nil, fmt.Errorf("forecasting %s: %w", MetricClicks, err)
+	}
+	clicksRes.Composition = CompositionDirect
+	out[MetricClicks] = clicksRes
+
+	// Leads: clicks × conv_rate, or direct when the rate is too sparse.
+	leadsRes, err := composeOrDirect(series[MetricLeads], cfg, MetricLeads, anchor, rateOK,
+		func() (*Result, error) {
+			rateRes, err := runCoherentPart(convRate, cfg, "conv_rate", anchor)
+			if err != nil {
+				return nil, err
+			}
+			return composeProduct(clicksRes, rateRes, MetricLeads, series[MetricLeads], cfg), nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("forecasting %s: %w", MetricLeads, err)
+	}
+	out[MetricLeads] = leadsRes
+
+	// Cost: clicks × avg_cpc.
+	costRes, err := composeOrDirect(series[MetricCost], cfg, MetricCost, anchor, cpcOK,
+		func() (*Result, error) {
+			cpcRes, err := runCoherentPart(avgCPC, cfg, "avg_cpc", anchor)
+			if err != nil {
+				return nil, err
+			}
+			return composeProduct(clicksRes, cpcRes, MetricCost, series[MetricCost], cfg), nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("forecasting %s: %w", MetricCost, err)
+	}
+	out[MetricCost] = costRes
+
+	// Income: leads result × avg_payout. Composing from the reported leads
+	// forecast (derived or direct) keeps income = leads × payout in the
+	// output either way; only a sparse payout forces income direct.
+	incomeRes, err := composeOrDirect(series[MetricIncome], cfg, MetricIncome, anchor, payoutOK,
+		func() (*Result, error) {
+			payoutRes, err := runCoherentPart(avgPayout, cfg, "avg_payout", anchor)
+			if err != nil {
+				return nil, err
+			}
+			return composeProduct(leadsRes, payoutRes, MetricIncome, series[MetricIncome], cfg), nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("forecasting %s: %w", MetricIncome, err)
+	}
+	out[MetricIncome] = incomeRes
+
+	// Net: always income − cost, so the identity holds whatever the
+	// components' composition.
+	out[MetricNet] = composeDifference(incomeRes, costRes, MetricNet, series[MetricIncome], series[MetricCost], cfg)
+
+	return out, nil
+}
+
+// deriveRate builds the per-bucket ratio numerator/denominator series,
+// keeping only buckets where the denominator is positive, and reports
+// whether the result is dense enough to compose from (defined on at least
+// coherentSparseThreshold of the denominator's buckets, minimum 3).
+func deriveRate(numerator, denominator Series) (Series, bool) {
+	byTime := make(map[time.Time]float64, len(numerator))
+	for _, p := range numerator {
+		byTime[p.T] = p.V
+	}
+	rate := make(Series, 0, len(denominator))
+	for _, p := range denominator {
+		num, ok := byTime[p.T]
+		if !ok || p.V <= 0 {
+			continue
+		}
+		rate = append(rate, Point{T: p.T, V: num / p.V})
+	}
+	if len(denominator) == 0 {
+		return rate, false
+	}
+	dense := len(rate) >= 3 &&
+		float64(len(rate)) >= coherentSparseThreshold*float64(len(denominator))
+	return rate, dense
+}
+
+// runCoherentPart forecasts one series with metric-appropriate settings:
+// all drivers and totals here are non-negative, and forecasts anchor at the
+// shared timestamp so compositions align per step.
+func runCoherentPart(s Series, cfg Config, metric string, anchor time.Time) (*Result, error) {
+	partCfg := cfg
+	partCfg.Metric = metric
+	partCfg.NonNegative = true
+	partCfg.SeasonalWeights = nil
+	partCfg.Anchor = anchor
+	in := make(Series, len(s))
+	copy(in, s)
+	return Run(in, partCfg)
+}
+
+// composeOrDirect returns the derived composition when the driver is dense
+// enough, and the direct forecast of the metric's own series otherwise.
+func composeOrDirect(observed Series, cfg Config, metric string, anchor time.Time, driverDense bool, compose func() (*Result, error)) (*Result, error) {
+	if driverDense {
+		res, err := compose()
+		if err == nil {
+			return res, nil
+		}
+		// A driver that fails to forecast (e.g. too few defined buckets
+		// after all) degrades to the direct path rather than failing the
+		// whole coherent run.
+	}
+	res, err := runCoherentPart(observed, cfg, metric, anchor)
+	if err != nil {
+		return nil, err
+	}
+	res.Composition = CompositionDirect
+	return res, nil
+}
+
+// composeProduct multiplies two forecasts per timestep: value×value,
+// P50×P50, and conservatively paired band endpoints (lower×lower,
+// upper×upper — exact under worst-case positive dependence since both
+// factors are non-negative). Quantiles compose only when both operands
+// carry complete sets. Trend statistics are recomputed from the composed
+// path against the observed derived series.
+func composeProduct(a, b *Result, metric string, observed Series, cfg Config) *Result {
+	n := len(a.Predictions)
+	if len(b.Predictions) < n {
+		n = len(b.Predictions)
+	}
+	preds := make([]Prediction, n)
+	for i := 0; i < n; i++ {
+		pa, pb := a.Predictions[i], b.Predictions[i]
+		preds[i] = Prediction{
+			T:          pa.T,
+			Value:      pa.Value * pb.Value,
+			LowerBound: pa.LowerBound * pb.LowerBound,
+			UpperBound: pa.UpperBound * pb.UpperBound,
+			Quantiles:  composeQuantiles(pa.Quantiles, pb.Quantiles, false),
+		}
+	}
+	return finishComposed(a, preds, metric, observed, cfg)
+}
+
+// composeDifference subtracts forecast b from forecast a per timestep with
+// conservative band pairing: lower = a.lower − b.upper, upper = a.upper −
+// b.lower. The result can be negative (net profit), so nothing is clipped.
+func composeDifference(a, b *Result, metric string, observedA, observedB Series, cfg Config) *Result {
+	n := len(a.Predictions)
+	if len(b.Predictions) < n {
+		n = len(b.Predictions)
+	}
+	preds := make([]Prediction, n)
+	for i := 0; i < n; i++ {
+		pa, pb := a.Predictions[i], b.Predictions[i]
+		preds[i] = Prediction{
+			T:          pa.T,
+			Value:      pa.Value - pb.Value,
+			LowerBound: pa.LowerBound - pb.UpperBound,
+			UpperBound: pa.UpperBound - pb.LowerBound,
+			Quantiles:  composeQuantiles(pa.Quantiles, pb.Quantiles, true),
+		}
+	}
+	observed := diffSeries(observedA, observedB)
+	return finishComposed(a, preds, metric, observed, cfg)
+}
+
+// composeQuantiles pairs two complete quantile sets: for products, level
+// with level (both operands non-negative keeps the order); for differences,
+// level with the mirrored level (p10 = a.p10 − b.p90 etc.), the conservative
+// combination. Returns nil unless both sets are complete.
+func composeQuantiles(qa, qb map[string]float64, difference bool) map[string]float64 {
+	if len(qa) == 0 || len(qb) == 0 {
+		return nil
+	}
+	mirror := map[string]string{"p10": "p90", "p25": "p75", "p50": "p50", "p75": "p25", "p90": "p10"}
+	out := make(map[string]float64, len(quantileLevels))
+	for _, lv := range quantileLevels {
+		va, okA := qa[lv.name]
+		other := lv.name
+		if difference {
+			other = mirror[lv.name]
+		}
+		vb, okB := qb[other]
+		if !okA || !okB {
+			return nil
+		}
+		if difference {
+			out[lv.name] = va - vb
+		} else {
+			out[lv.name] = va * vb
+		}
+	}
+	normalizeQuantileOrder(out)
+	return out
+}
+
+// finishComposed assembles a derived Result: trend statistics come from the
+// composed path (mean step-to-step change) relative to the observed series'
+// mean, and rolling error metrics are left zero — they are only measured
+// for directly fitted series.
+func finishComposed(template *Result, preds []Prediction, metric string, observed Series, cfg Config) *Result {
+	trend := 0.0
+	if len(preds) > 1 {
+		trend = (preds[len(preds)-1].Value - preds[0].Value) / float64(len(preds)-1)
+	}
+	trendPct := 0.0
+	if mean := seriesMean(observed); mean != 0 {
+		trendPct = (trend / mean) * 100
+	}
+	return &Result{
+		Method:      template.Method,
+		Metric:      metric,
+		Horizon:     template.Horizon,
+		Interval:    template.Interval,
+		Predictions: preds,
+		Trend:       trend,
+		TrendPct:    trendPct,
+		DataPoints:  len(observed),
+		Composition: CompositionDerived,
+	}
+}
+
+// diffSeries subtracts series b from series a on matching timestamps.
+func diffSeries(a, b Series) Series {
+	byTime := make(map[time.Time]float64, len(b))
+	for _, p := range b {
+		byTime[p.T] = p.V
+	}
+	out := make(Series, 0, len(a))
+	for _, p := range a {
+		vb, ok := byTime[p.T]
+		if !ok {
+			continue
+		}
+		out = append(out, Point{T: p.T, V: p.V - vb})
+	}
+	return out
+}

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -190,8 +190,9 @@ func runCoherentPart(s Series, cfg Config, metric string, anchor time.Time) (*Re
 	partCfg.Metric = metric
 	partCfg.NonNegative = true
 	partCfg.SeasonalWeights = nil
-	partCfg.HourlyWeights = nil
-	partCfg.MonthDayWeights = nil
+	partCfg.WeekdayProfile = false
+	partCfg.HourlyProfile = false
+	partCfg.MonthDayProfile = false
 	// Counts get the log1p treatment (multiplicative growth becomes
 	// additive); rates and per-unit amounts stay on their natural scale.
 	partCfg.LogTransform = metric == MetricClicks || metric == MetricLeads

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -171,6 +171,11 @@ func runCoherentPart(s Series, cfg Config, metric string, anchor time.Time) (*Re
 	partCfg.Metric = metric
 	partCfg.NonNegative = true
 	partCfg.SeasonalWeights = nil
+	partCfg.HourlyWeights = nil
+	partCfg.MonthDayWeights = nil
+	// Counts get the log1p treatment (multiplicative growth becomes
+	// additive); rates and per-unit amounts stay on their natural scale.
+	partCfg.LogTransform = metric == MetricClicks || metric == MetricLeads
 	partCfg.Anchor = anchor
 	in := make(Series, len(s))
 	copy(in, s)

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -2,6 +2,7 @@ package forecast
 
 import (
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -64,6 +65,17 @@ func RunCoherent(series map[string]Series, cfg Config) (map[string]*Result, erro
 			return nil, fmt.Errorf("coherent forecast needs at least 3 data points for %s, got %d", key, len(series[key]))
 		}
 	}
+
+	// Work on sorted copies: the anchor below reads the last bucket, and
+	// callers (unlike Run's own sort) are not required to pre-sort.
+	sorted := make(map[string]Series, 4)
+	for _, key := range []string{MetricClicks, MetricLeads, MetricIncome, MetricCost} {
+		cp := make(Series, len(series[key]))
+		copy(cp, series[key])
+		sort.Slice(cp, func(i, j int) bool { return cp[i].T.Before(cp[j].T) })
+		sorted[key] = cp
+	}
+	series = sorted
 
 	clicks := series[MetricClicks]
 	// Anchor every forecast at the clicks series' last bucket so all metrics
@@ -224,7 +236,7 @@ func composeProduct(a, b *Result, metric string, observed Series, cfg Config) *R
 			Quantiles:  composeQuantiles(pa.Quantiles, pb.Quantiles, false),
 		}
 	}
-	return finishComposed(a, preds, metric, observed, cfg)
+	return finishComposed(a, b, preds, metric, observed, cfg)
 }
 
 // composeDifference subtracts forecast b from forecast a per timestep with
@@ -247,7 +259,7 @@ func composeDifference(a, b *Result, metric string, observedA, observedB Series,
 		}
 	}
 	observed := diffSeries(observedA, observedB)
-	return finishComposed(a, preds, metric, observed, cfg)
+	return finishComposed(a, b, preds, metric, observed, cfg)
 }
 
 // composeQuantiles pairs two complete quantile sets: for products, level
@@ -258,7 +270,7 @@ func composeQuantiles(qa, qb map[string]float64, difference bool) map[string]flo
 	if len(qa) == 0 || len(qb) == 0 {
 		return nil
 	}
-	mirror := map[string]string{"p10": "p90", "p25": "p75", "p50": "p50", "p75": "p25", "p90": "p10"}
+	mirror := map[string]string{"p05": "p95", "p10": "p90", "p25": "p75", "p50": "p50", "p75": "p25", "p90": "p10", "p95": "p05"}
 	out := make(map[string]float64, len(quantileLevels))
 	for _, lv := range quantileLevels {
 		va, okA := qa[lv.name]
@@ -280,29 +292,39 @@ func composeQuantiles(qa, qb map[string]float64, difference bool) map[string]flo
 	return out
 }
 
-// finishComposed assembles a derived Result: trend statistics come from the
-// composed path (mean step-to-step change) relative to the observed series'
-// mean, and rolling error metrics are left zero — they are only measured
-// for directly fitted series.
-func finishComposed(template *Result, preds []Prediction, metric string, observed Series, cfg Config) *Result {
-	trend := 0.0
-	if len(preds) > 1 {
-		trend = (preds[len(preds)-1].Value - preds[0].Value) / float64(len(preds)-1)
-	}
+// finishComposed assembles a derived Result from its two operands: trend
+// statistics come from the composed path (mean step-to-step change)
+// relative to the observed series' mean; rolling error metrics are left
+// zero — they are only measured for directly fitted series. A level shift
+// detected in either operand is reported (the composition inherits it),
+// and BoundsSource is "mixed" when the operands' bounds disagree, since the
+// composed band then has no single nominal level.
+func finishComposed(a, b *Result, preds []Prediction, metric string, observed Series, cfg Config) *Result {
+	trend := predictionTrend(preds, observed)
 	trendPct := 0.0
 	if mean := seriesMean(observed); mean != 0 {
 		trendPct = (trend / mean) * 100
 	}
+	shiftAt := a.LevelShiftAt
+	if shiftAt == "" {
+		shiftAt = b.LevelShiftAt
+	}
+	source := a.BoundsSource
+	if a.BoundsSource != b.BoundsSource {
+		source = BoundsMixed
+	}
 	return &Result{
-		Method:      template.Method,
-		Metric:      metric,
-		Horizon:     template.Horizon,
-		Interval:    template.Interval,
-		Predictions: preds,
-		Trend:       trend,
-		TrendPct:    trendPct,
-		DataPoints:  len(observed),
-		Composition: CompositionDerived,
+		Method:       a.Method,
+		Metric:       metric,
+		Horizon:      a.Horizon,
+		Interval:     a.Interval,
+		Predictions:  preds,
+		Trend:        trend,
+		TrendPct:     trendPct,
+		DataPoints:   len(observed),
+		Composition:  CompositionDerived,
+		LevelShiftAt: shiftAt,
+		BoundsSource: source,
 	}
 }
 

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -2,6 +2,7 @@ package forecast
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"time"
 )
@@ -53,18 +54,19 @@ const coherentSparseThreshold = 0.7
 // The returned map holds results for the four totals plus MetricNet. Each
 // result's Composition field reports "derived" (composed from drivers) or
 // "direct" (fallback when a driver rate is too sparse — e.g. conv_rate
-// undefined on many days). Derived results compose quantiles pairwise
-// (P50 from P50s; band endpoints combine conservatively, assuming
-// worst-case dependence between factors, so composed bands are valid but
-// can over-cover); their MAE/RMSE are zero since rolling errors are only
-// measured for directly fitted series. cfg.Metric, cfg.SeasonalWeights, and
-// cfg.NonNegative are ignored: metric-appropriate values are set per driver.
+// undefined on many days). Derived results are backtested as compositions:
+// their bands, quantiles, and MAE/RMSE come from the composed forecast's
+// own rolling residuals against the observed derived series (see
+// finishComposed), so a derived p05-p95 band is calibrated the same way a
+// direct one is. cfg.Metric, cfg.SeasonalWeights, and cfg.NonNegative are
+// ignored: metric-appropriate values are set per driver.
 func RunCoherent(series map[string]Series, cfg Config) (map[string]*Result, error) {
 	for _, key := range []string{MetricClicks, MetricLeads, MetricIncome, MetricCost} {
 		if len(series[key]) < 3 {
 			return nil, fmt.Errorf("coherent forecast needs at least 3 data points for %s, got %d", key, len(series[key]))
 		}
 	}
+	cfg = withDefaults(cfg)
 
 	// Work on sorted copies: the anchor below reads the last bucket, and
 	// callers (unlike Run's own sort) are not required to pre-sort.
@@ -78,13 +80,18 @@ func RunCoherent(series map[string]Series, cfg Config) (map[string]*Result, erro
 	series = sorted
 
 	clicks := series[MetricClicks]
-	// Anchor every forecast at the clicks series' last bucket so all metrics
-	// share prediction timestamps even when a driver's last defined bucket
-	// is older (anchorOffset bridges the gap).
-	anchor := clicks[len(clicks)-1].T
-	if !cfg.Anchor.IsZero() && cfg.Anchor.After(anchor) {
-		anchor = cfg.Anchor
+	// Anchor every forecast at the latest bucket any input carries (or a
+	// later configured anchor) so all metrics share prediction timestamps
+	// and no forecast starts on a date another metric already observed —
+	// a rejected or missing clicks bucket must not hide the newest leads,
+	// cost, or income data. anchorOffset bridges each part's own gap.
+	anchor := cfg.Anchor
+	for _, key := range []string{MetricClicks, MetricLeads, MetricIncome, MetricCost} {
+		if last := series[key][len(series[key])-1].T; last.After(anchor) {
+			anchor = last
+		}
 	}
+	cfg.Anchor = anchor
 
 	convRate, rateOK := deriveRate(series[MetricLeads], clicks)
 	avgCPC, cpcOK := deriveRate(series[MetricCost], clicks)
@@ -214,12 +221,13 @@ func composeOrDirect(observed Series, cfg Config, metric string, anchor time.Tim
 	return res, nil
 }
 
-// composeProduct multiplies two forecasts per timestep: value×value,
-// P50×P50, and conservatively paired band endpoints (lower×lower,
-// upper×upper — exact under worst-case positive dependence since both
-// factors are non-negative). Quantiles compose only when both operands
-// carry complete sets. Trend statistics are recomputed from the composed
-// path against the observed derived series.
+// composeProduct multiplies two forecasts per timestep: value×value, and,
+// as the starting point finishComposed recalibrates from, P50×P50 with
+// conservatively paired band endpoints (lower×lower, upper×upper — valid
+// under worst-case positive dependence since both factors are
+// non-negative). Quantiles compose only when both operands carry complete
+// sets. Trend statistics are recomputed from the composed path against the
+// observed derived series.
 func composeProduct(a, b *Result, metric string, observed Series, cfg Config) *Result {
 	n := len(a.Predictions)
 	if len(b.Predictions) < n {
@@ -236,12 +244,14 @@ func composeProduct(a, b *Result, metric string, observed Series, cfg Config) *R
 			Quantiles:  composeQuantiles(pa.Quantiles, pb.Quantiles, false),
 		}
 	}
-	return finishComposed(a, b, preds, metric, observed, cfg)
+	return finishComposed(a, b, preds, metric, observed, cfg,
+		func(x, y float64) float64 { return x * y }, true)
 }
 
-// composeDifference subtracts forecast b from forecast a per timestep with
-// conservative band pairing: lower = a.lower − b.upper, upper = a.upper −
-// b.lower. The result can be negative (net profit), so nothing is clipped.
+// composeDifference subtracts forecast b from forecast a per timestep, with
+// conservative band pairing as the starting point: lower = a.lower −
+// b.upper, upper = a.upper − b.lower. The result can be negative (net
+// profit), so nothing is clipped.
 func composeDifference(a, b *Result, metric string, observedA, observedB Series, cfg Config) *Result {
 	n := len(a.Predictions)
 	if len(b.Predictions) < n {
@@ -259,7 +269,8 @@ func composeDifference(a, b *Result, metric string, observedA, observedB Series,
 		}
 	}
 	observed := diffSeries(observedA, observedB)
-	return finishComposed(a, b, preds, metric, observed, cfg)
+	return finishComposed(a, b, preds, metric, observed, cfg,
+		func(x, y float64) float64 { return x - y }, false)
 }
 
 // composeQuantiles pairs two complete quantile sets: for products, level
@@ -292,14 +303,24 @@ func composeQuantiles(qa, qb map[string]float64, difference bool) map[string]flo
 	return out
 }
 
-// finishComposed assembles a derived Result from its two operands: trend
-// statistics come from the composed path (mean step-to-step change)
-// relative to the observed series' mean; rolling error metrics are left
-// zero — they are only measured for directly fitted series. A level shift
-// detected in either operand is reported (the composition inherits it),
-// and BoundsSource is "mixed" when the operands' bounds disagree, since the
-// composed band then has no single nominal level.
-func finishComposed(a, b *Result, preds []Prediction, metric string, observed Series, cfg Config) *Result {
+// finishComposed assembles a derived Result from its two operands and
+// backtests the composition itself. Multiplying or subtracting the
+// operands' band endpoints does not yield a band of known coverage (two
+// marginal 90% intervals jointly cover as little as 80%, and their product
+// under worst-case pairing far more), so the composed point forecast is
+// re-evaluated on the operands' paired rolling predictions: wherever both
+// operands predicted the same target from the same training end, the
+// composed prediction is compared with the observed derived value, and the
+// resulting residuals by horizon step give the composed forecast its own
+// conformal quantiles, band, and MAE/RMSE — the same calibration a direct
+// forecast gets. When too few paired predictions exist, the conservative
+// pairing from the caller stands and BoundsSource says "composed".
+//
+// Trend statistics come from the composed path relative to the observed
+// series' mean; a level shift detected in either operand is reported (the
+// composition inherits it), and masked anomalies are the union of both
+// operands' so the excluded observations stay visible.
+func finishComposed(a, b *Result, preds []Prediction, metric string, observed Series, cfg Config, combine func(x, y float64) float64, nonNegative bool) *Result {
 	trend := predictionTrend(preds, observed)
 	trendPct := 0.0
 	if mean := seriesMean(observed); mean != 0 {
@@ -309,23 +330,108 @@ func finishComposed(a, b *Result, preds []Prediction, metric string, observed Se
 	if shiftAt == "" {
 		shiftAt = b.LevelShiftAt
 	}
-	source := a.BoundsSource
-	if a.BoundsSource != b.BoundsSource {
-		source = BoundsMixed
+
+	rolling, byStep, mae, rmse := composeRolling(a, b, observed, cfg.Interval, combine, nonNegative)
+	source := BoundsComposed
+	if totalResiduals(byStep) >= minTotalResiduals {
+		offset := 0
+		if len(observed) > 0 {
+			offset = anchorOffset(observed, cfg)
+		}
+		sq := stepQuantiles(byStep, offset+len(preds))
+		applyConformalBounds(preds, sq, cfg, offset)
+		if nonNegative {
+			ClipNonNegative(preds)
+		}
+		source = BoundsConformal
 	}
+
 	return &Result{
-		Method:       a.Method,
-		Metric:       metric,
-		Horizon:      a.Horizon,
-		Interval:     a.Interval,
-		Predictions:  preds,
-		Trend:        trend,
-		TrendPct:     trendPct,
-		DataPoints:   len(observed),
-		Composition:  CompositionDerived,
-		LevelShiftAt: shiftAt,
-		BoundsSource: source,
+		Method:          a.Method,
+		Metric:          metric,
+		Horizon:         a.Horizon,
+		Interval:        a.Interval,
+		Predictions:     preds,
+		Trend:           trend,
+		TrendPct:        trendPct,
+		MAE:             mae,
+		RMSE:            rmse,
+		DataPoints:      len(observed),
+		Composition:     CompositionDerived,
+		LevelShiftAt:    shiftAt,
+		AnomaliesMasked: unionSorted(a.AnomaliesMasked, b.AnomaliesMasked),
+		BoundsSource:    source,
+		rolling:         rolling,
 	}
+}
+
+// composeRolling pairs the operands' rolling-backtest predictions on shared
+// (training end, target) keys, composes them, and scores the compositions
+// against the observed derived series: it returns the composed rolling
+// predictions (so further compositions can be backtested too), residuals
+// bucketed by horizon step, and MAE/RMSE over the scored pairs (zero when
+// none exist). Pairs whose target has no observation are kept as rolling
+// predictions but not scored.
+func composeRolling(a, b *Result, observed Series, interval Interval, combine func(x, y float64) float64, nonNegative bool) (rolling map[rollingKey]float64, byStep map[int][]float64, mae, rmse float64) {
+	actualAt := make(map[time.Time]float64, len(observed))
+	for _, p := range observed {
+		actualAt[p.T] = p.V
+	}
+	rolling = make(map[rollingKey]float64, len(a.rolling))
+	byStep = map[int][]float64{}
+	sumAbs, sumSq := 0.0, 0.0
+	n := 0
+	for key, pa := range a.rolling {
+		pb, ok := b.rolling[key]
+		if !ok {
+			continue
+		}
+		pred := combine(pa, pb)
+		if nonNegative && pred < 0 {
+			pred = 0
+		}
+		rolling[key] = pred
+		actual, ok := actualAt[key.target]
+		if !ok {
+			continue
+		}
+		exact := intervalSteps(key.trainEnd, key.target, interval)
+		h := int(math.Round(exact))
+		if math.Abs(exact-float64(h)) > 0.01 || h < 1 {
+			continue
+		}
+		diff := actual - pred
+		byStep[h] = append(byStep[h], diff)
+		sumAbs += math.Abs(diff)
+		sumSq += diff * diff
+		n++
+	}
+	if n > 0 {
+		mae = sumAbs / float64(n)
+		rmse = math.Sqrt(sumSq / float64(n))
+	}
+	return rolling, byStep, mae, rmse
+}
+
+// unionSorted merges two timestamp lists without duplicates, in order (the
+// formatted timestamps sort chronologically).
+func unionSorted(a, b []string) []string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, list := range [][]string{a, b} {
+		for _, s := range list {
+			if _, dup := seen[s]; dup {
+				continue
+			}
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // diffSeries subtracts series b from series a on matching timestamps.

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -318,8 +318,12 @@ func composeQuantiles(qa, qb map[string]float64, difference bool) map[string]flo
 //
 // Trend statistics come from the composed path relative to the observed
 // series' mean; a level shift detected in either operand is reported (the
-// composition inherits it), and masked anomalies are the union of both
-// operands' so the excluded observations stay visible.
+// composition inherits it); masked anomalies are the union of both
+// operands' so the excluded observations stay visible; and DataPoints is
+// the fewest points either operand was actually fitted on (after masking,
+// truncation, and undefined rate buckets), since the observed derived
+// series itself is never fitted and the composition is only as informed as
+// its thinnest driver.
 func finishComposed(a, b *Result, preds []Prediction, metric string, observed Series, cfg Config, combine func(x, y float64) float64, nonNegative bool) *Result {
 	trend := predictionTrend(preds, observed)
 	trendPct := 0.0
@@ -356,7 +360,7 @@ func finishComposed(a, b *Result, preds []Prediction, metric string, observed Se
 		TrendPct:        trendPct,
 		MAE:             mae,
 		RMSE:            rmse,
-		DataPoints:      len(observed),
+		DataPoints:      minInt(a.DataPoints, b.DataPoints),
 		Composition:     CompositionDerived,
 		LevelShiftAt:    shiftAt,
 		AnomaliesMasked: unionSorted(a.AnomaliesMasked, b.AnomaliesMasked),
@@ -411,6 +415,13 @@ func composeRolling(a, b *Result, observed Series, interval Interval, combine fu
 		rmse = math.Sqrt(sumSq / float64(n))
 	}
 	return rolling, byStep, mae, rmse
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // unionSorted merges two timestamp lists without duplicates, in order (the

--- a/go-cli/internal/forecast/coherent.go
+++ b/go-cli/internal/forecast/coherent.go
@@ -337,12 +337,15 @@ func finishComposed(a, b *Result, preds []Prediction, metric string, observed Se
 	}
 
 	rolling, byStep, mae, rmse := composeRolling(a, b, observed, cfg.Interval, combine, nonNegative)
+	// The composition is only as current as its stalest driver: a payout
+	// rate undefined for the last few buckets makes the first composed
+	// prediction several steps ahead of that driver's data, so the band
+	// offset is measured from the earlier operand's training end, not from
+	// where the observed derived series happens to end.
+	trainEnd := earlierTrainEnd(a.trainEnd, b.trainEnd)
 	source := BoundsComposed
 	if totalResiduals(byStep) >= minTotalResiduals {
-		offset := 0
-		if len(observed) > 0 {
-			offset = anchorOffset(observed, cfg)
-		}
+		offset := composedOffset(trainEnd, cfg)
 		sq := stepQuantiles(byStep, offset+len(preds))
 		applyConformalBounds(preds, sq, cfg, offset)
 		if nonNegative {
@@ -367,7 +370,39 @@ func finishComposed(a, b *Result, preds []Prediction, metric string, observed Se
 		AnomaliesMasked: unionSorted(a.AnomaliesMasked, b.AnomaliesMasked),
 		BoundsSource:    source,
 		rolling:         rolling,
+		trainEnd:        trainEnd,
+		evaluated:       totalResiduals(byStep) > 0,
 	}
+}
+
+// earlierTrainEnd returns the earlier of two training ends, ignoring a
+// zero value.
+func earlierTrainEnd(a, b time.Time) time.Time {
+	switch {
+	case a.IsZero():
+		return b
+	case b.IsZero():
+		return a
+	case b.Before(a):
+		return b
+	default:
+		return a
+	}
+}
+
+// composedOffset returns how many whole interval steps the shared anchor
+// lies beyond the stalest operand's training end (0 when not ahead): the
+// composed forecast's first prediction is that many steps further out than
+// the data it was built from, so its residual pool is read from that step.
+func composedOffset(trainEnd time.Time, cfg Config) int {
+	if trainEnd.IsZero() || cfg.Anchor.IsZero() || !cfg.Anchor.After(trainEnd) {
+		return 0
+	}
+	steps := int(math.Round(intervalSteps(trainEnd, cfg.Anchor, cfg.Interval)))
+	if steps < 0 {
+		return 0
+	}
+	return steps
 }
 
 // composeRolling pairs the operands' rolling-backtest predictions on shared

--- a/go-cli/internal/forecast/coherent_test.go
+++ b/go-cli/internal/forecast/coherent_test.go
@@ -117,7 +117,7 @@ func TestRunCoherent_BoundsAndQuantilesOrdered(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	order := []string{"p10", "p25", "p50", "p75", "p90"}
+	order := []string{"p05", "p10", "p25", "p50", "p75", "p90", "p95"}
 	for key, res := range results {
 		for i, p := range res.Predictions {
 			if p.LowerBound > p.UpperBound {
@@ -260,11 +260,9 @@ func TestCoherentCompositionAccuracy(t *testing.T) {
 
 	wins, total := 0, 0
 	for _, sc := range scenarios {
+		rmse := rollingCompare(t, sc.series, []string{MetricLeads, MetricIncome})
 		for _, metric := range []string{MetricLeads, MetricIncome} {
-			composed, direct, n := rollingCompare(t, sc.series, metric)
-			if n == 0 {
-				t.Fatalf("%s/%s: no evaluations", sc.name, metric)
-			}
+			composed, direct := rmse[metric][0], rmse[metric][1]
 			total++
 			if composed <= direct*1.02 {
 				wins++
@@ -278,11 +276,14 @@ func TestCoherentCompositionAccuracy(t *testing.T) {
 }
 
 // rollingCompare measures rolling RMSE of the composed vs direct forecast of
-// one derived metric over held-out data.
-func rollingCompare(t *testing.T, series map[string]Series, metric string) (composedRMSE, directRMSE float64, n int) {
+// each requested derived metric over held-out data, running RunCoherent once
+// per cut for all of them. The result maps metric -> {composed, direct}.
+func rollingCompare(t *testing.T, series map[string]Series, metrics []string) map[string][2]float64 {
 	t.Helper()
-	full := series[metric]
-	sumSqC, sumSqD := 0.0, 0.0
+	sumSqC := map[string]float64{}
+	sumSqD := map[string]float64{}
+	n := 0
+	full := series[metrics[0]]
 	for c := 30; c < len(full); c += 4 {
 		steps := len(full) - c
 		if steps > 7 {
@@ -298,23 +299,29 @@ func rollingCompare(t *testing.T, series map[string]Series, metric string) (comp
 		if err != nil {
 			t.Fatalf("RunCoherent failed at cut %d: %v", c, err)
 		}
-		directIn := make(Series, c)
-		copy(directIn, full[:c])
-		directRes, err := Run(directIn, Config{Horizon: steps, Interval: IntervalDay, NonNegative: true})
-		if err != nil {
-			t.Fatalf("Run failed at cut %d: %v", c, err)
+		for _, metric := range metrics {
+			directIn := make(Series, c)
+			copy(directIn, series[metric][:c])
+			directRes, err := Run(directIn, Config{Horizon: steps, Interval: IntervalDay, NonNegative: true})
+			if err != nil {
+				t.Fatalf("Run failed at cut %d: %v", c, err)
+			}
+			for i := 0; i < steps; i++ {
+				actual := series[metric][c+i].V
+				dc := actual - results[metric].Predictions[i].Value
+				dd := actual - directRes.Predictions[i].Value
+				sumSqC[metric] += dc * dc
+				sumSqD[metric] += dd * dd
+			}
 		}
-		for i := 0; i < steps; i++ {
-			actual := full[c+i].V
-			dc := actual - results[metric].Predictions[i].Value
-			dd := actual - directRes.Predictions[i].Value
-			sumSqC += dc * dc
-			sumSqD += dd * dd
-			n++
-		}
+		n += steps
 	}
 	if n == 0 {
-		return 0, 0, 0
+		t.Fatal("no rolling evaluations")
 	}
-	return math.Sqrt(sumSqC / float64(n)), math.Sqrt(sumSqD / float64(n)), n
+	out := map[string][2]float64{}
+	for _, metric := range metrics {
+		out[metric] = [2]float64{math.Sqrt(sumSqC[metric] / float64(n)), math.Sqrt(sumSqD[metric] / float64(n))}
+	}
+	return out
 }

--- a/go-cli/internal/forecast/coherent_test.go
+++ b/go-cli/internal/forecast/coherent_test.go
@@ -533,6 +533,16 @@ func TestRunCoherent_ComposedInheritsAnomalies(t *testing.T) {
 	if len(want) != 2 {
 		t.Fatalf("clicks masked %v, want the two outage days", want)
 	}
+	// The masked clicks series (58 points) is the thinnest driver behind
+	// every composed metric, so none may claim more fitted points than it.
+	if got := results[MetricClicks].DataPoints; got != 58 {
+		t.Fatalf("clicks data points = %d, want 58 (two masked)", got)
+	}
+	for _, metric := range []string{MetricLeads, MetricCost, MetricIncome, MetricNet} {
+		if got := results[metric].DataPoints; got > 58 {
+			t.Errorf("%s: data_points_used = %d overstates the drivers' fitted history (clicks fitted 58)", metric, got)
+		}
+	}
 	for _, metric := range []string{MetricLeads, MetricCost, MetricIncome, MetricNet} {
 		got := results[metric].AnomaliesMasked
 		for _, ts := range want {

--- a/go-cli/internal/forecast/coherent_test.go
+++ b/go-cli/internal/forecast/coherent_test.go
@@ -260,30 +260,53 @@ func TestCoherentCompositionAccuracy(t *testing.T) {
 
 	wins, total := 0, 0
 	for _, sc := range scenarios {
-		rmse := rollingCompare(t, sc.series, []string{MetricLeads, MetricIncome})
+		scores := rollingCompare(t, sc.series, []string{MetricLeads, MetricIncome, MetricNet})
 		for _, metric := range []string{MetricLeads, MetricIncome} {
-			composed, direct := rmse[metric][0], rmse[metric][1]
+			sc0 := scores[metric]
 			total++
-			if composed <= direct*1.02 {
+			if sc0.composedRMSE <= sc0.directRMSE*1.02 {
 				wins++
 			}
-			t.Logf("%s/%s: composed rmse %.2f vs direct %.2f", sc.name, metric, composed, direct)
+			t.Logf("%s/%s: composed rmse %.2f (p05-p95 coverage %.1f%%) vs direct %.2f (coverage %.1f%%)",
+				sc.name, metric, sc0.composedRMSE, sc0.composedCoverage*100, sc0.directRMSE, sc0.directCoverage*100)
 		}
+		t.Logf("%s/%s: composed rmse %.2f (p05-p95 coverage %.1f%%) vs direct %.2f (coverage %.1f%%)",
+			sc.name, MetricNet, scores[MetricNet].composedRMSE, scores[MetricNet].composedCoverage*100,
+			scores[MetricNet].directRMSE, scores[MetricNet].directCoverage*100)
 	}
 	if wins*2 <= total {
 		t.Errorf("composition matched direct forecasting on only %d/%d cases, want a majority", wins, total)
 	}
 }
 
-// rollingCompare measures rolling RMSE of the composed vs direct forecast of
-// each requested derived metric over held-out data, running RunCoherent once
-// per cut for all of them. The result maps metric -> {composed, direct}.
-func rollingCompare(t *testing.T, series map[string]Series, metrics []string) map[string][2]float64 {
+// rollingScore holds rolling-backtest RMSE and default-band (p05-p95)
+// coverage for the composed and the direct forecast of one metric.
+type rollingScore struct {
+	composedRMSE, directRMSE         float64
+	composedCoverage, directCoverage float64
+}
+
+// rollingCompare measures rolling RMSE and band coverage of the composed vs
+// direct forecast of each requested derived metric over held-out data,
+// running RunCoherent once per cut for all of them. Net (income − cost) is
+// scored against the observed difference; its direct counterpart is a
+// signed forecast of that difference series.
+func rollingCompare(t *testing.T, series map[string]Series, metrics []string) map[string]rollingScore {
 	t.Helper()
 	sumSqC := map[string]float64{}
 	sumSqD := map[string]float64{}
+	inC := map[string]int{}
+	inD := map[string]int{}
 	n := 0
-	full := series[metrics[0]]
+	full := series[MetricClicks]
+	netSeries := diffSeries(series[MetricIncome], series[MetricCost])
+	observedSeries := func(metric string) Series {
+		if metric == MetricNet {
+			return netSeries
+		}
+		return series[metric]
+	}
+	observed := func(metric string, i int) float64 { return observedSeries(metric)[i].V }
 	for c := 30; c < len(full); c += 4 {
 		steps := len(full) - c
 		if steps > 7 {
@@ -301,17 +324,25 @@ func rollingCompare(t *testing.T, series map[string]Series, metrics []string) ma
 		}
 		for _, metric := range metrics {
 			directIn := make(Series, c)
-			copy(directIn, series[metric][:c])
-			directRes, err := Run(directIn, Config{Horizon: steps, Interval: IntervalDay, NonNegative: true})
+			copy(directIn, observedSeries(metric)[:c])
+			directRes, err := Run(directIn, Config{Horizon: steps, Interval: IntervalDay, NonNegative: metric != MetricNet})
 			if err != nil {
 				t.Fatalf("Run failed at cut %d: %v", c, err)
 			}
 			for i := 0; i < steps; i++ {
-				actual := series[metric][c+i].V
-				dc := actual - results[metric].Predictions[i].Value
-				dd := actual - directRes.Predictions[i].Value
+				actual := observed(metric, c+i)
+				pc := results[metric].Predictions[i]
+				dc := actual - pc.Value
 				sumSqC[metric] += dc * dc
+				if actual >= pc.LowerBound && actual <= pc.UpperBound {
+					inC[metric]++
+				}
+				pd := directRes.Predictions[i]
+				dd := actual - pd.Value
 				sumSqD[metric] += dd * dd
+				if actual >= pd.LowerBound && actual <= pd.UpperBound {
+					inD[metric]++
+				}
 			}
 		}
 		n += steps
@@ -319,9 +350,222 @@ func rollingCompare(t *testing.T, series map[string]Series, metrics []string) ma
 	if n == 0 {
 		t.Fatal("no rolling evaluations")
 	}
-	out := map[string][2]float64{}
+	out := map[string]rollingScore{}
 	for _, metric := range metrics {
-		out[metric] = [2]float64{math.Sqrt(sumSqC[metric] / float64(n)), math.Sqrt(sumSqD[metric] / float64(n))}
+		out[metric] = rollingScore{
+			composedRMSE:     math.Sqrt(sumSqC[metric] / float64(n)),
+			directRMSE:       math.Sqrt(sumSqD[metric] / float64(n)),
+			composedCoverage: float64(inC[metric]) / float64(n),
+			directCoverage:   float64(inD[metric]) / float64(n),
+		}
 	}
 	return out
+}
+
+// TestComposedBandsCalibrated enforces that derived metrics' bands are
+// calibrated like direct ones. Coverage is measured on the rolling suite
+// and averaged over seeds (a single 90-point series yields only ~15
+// effectively independent cuts). The primary claim is parity: a composed
+// p05-p95 band must not trail the direct forecast of the same metric,
+// since composition is backtested with the same machinery (both sit in
+// the low-to-mid 80s on a growing series, where pooled residuals lag the
+// error scale, and the low 90s on a flat one). The absolute window rules
+// out the 94–100% the worst-case endpoint pairing produced, needlessly
+// wide for alerting, as well as a real shortfall. Full-history results
+// must report conformal bounds, quantiles, and rolling errors.
+func TestComposedBandsCalibrated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping rolling-suite calibration in -short mode")
+	}
+	shapes := []struct {
+		name string
+		make func(rng *rand.Rand) map[string]Series
+	}{
+		{"trending", func(rng *rand.Rand) map[string]Series {
+			return makeCoherentSeries(90,
+				func(i int) float64 { return 200 + 6*float64(i) + rng.NormFloat64()*25 },
+				func(i int) float64 { return 0.10 + 0.02*rng.NormFloat64() },
+				func(i int) float64 { return 2.0 + 0.2*rng.NormFloat64() },
+				func(i int) float64 { return 50 + 4*rng.NormFloat64() })
+		}},
+		{"noisy_flat", func(rng *rand.Rand) map[string]Series {
+			return makeCoherentSeries(90,
+				func(i int) float64 { return 300 + rng.NormFloat64()*60 },
+				func(i int) float64 { return 0.08 + 0.015*rng.NormFloat64() },
+				func(i int) float64 { return 1.8 + 0.15*rng.NormFloat64() },
+				func(i int) float64 { return 45 + 3*rng.NormFloat64() })
+		}},
+	}
+	metrics := []string{MetricLeads, MetricCost, MetricIncome, MetricNet}
+	seeds := []int64{211, 212, 213}
+	for _, shape := range shapes {
+		sumC := map[string]float64{}
+		sumD := map[string]float64{}
+		for _, seed := range seeds {
+			scores := rollingCompare(t, shape.make(rand.New(rand.NewSource(seed))), metrics)
+			for _, m := range metrics {
+				sumC[m] += scores[m].composedCoverage
+				sumD[m] += scores[m].directCoverage
+			}
+		}
+		for _, m := range metrics {
+			cov := sumC[m] / float64(len(seeds))
+			direct := sumD[m] / float64(len(seeds))
+			t.Logf("%s/%s: composed p05-p95 coverage %.1f%% vs direct %.1f%% (mean of %d seeds)", shape.name, m, cov*100, direct*100, len(seeds))
+			if cov < direct-0.05 {
+				t.Errorf("%s/%s: composed coverage %.1f%% trails direct %.1f%%", shape.name, m, cov*100, direct*100)
+			}
+			if cov < 0.75 || cov > 0.975 {
+				t.Errorf("%s/%s: composed coverage %.1f%% is not calibrated to the 90%% band", shape.name, m, cov*100)
+			}
+		}
+
+		results, err := RunCoherent(shape.make(rand.New(rand.NewSource(seeds[0]))), Config{Horizon: 7, Interval: IntervalDay})
+		if err != nil {
+			t.Fatalf("%s: %v", shape.name, err)
+		}
+		for _, m := range metrics {
+			res := results[m]
+			if res.BoundsSource != BoundsConformal {
+				t.Errorf("%s/%s: bounds_source = %q, want conformal (recalibrated on composed residuals)", shape.name, m, res.BoundsSource)
+			}
+			if res.RMSE <= 0 || res.MAE <= 0 {
+				t.Errorf("%s/%s: derived result should carry rolling MAE/RMSE, got %.2f/%.2f", shape.name, m, res.MAE, res.RMSE)
+			}
+			for i, p := range res.Predictions {
+				if len(p.Quantiles) != len(quantileLevels) {
+					t.Errorf("%s/%s step %d: %d quantiles, want %d", shape.name, m, i, len(p.Quantiles), len(quantileLevels))
+				}
+			}
+		}
+	}
+}
+
+func TestRunCoherent_ShortHistoryKeepsComposedBounds(t *testing.T) {
+	// Ten points give at most two rolling cuts: too few paired residuals to
+	// recalibrate, so the conservative endpoint pairing stands and is
+	// labelled as such rather than as a calibrated band.
+	series := makeCoherentSeries(10,
+		func(i int) float64 { return 100 + 5*float64(i) },
+		constFn(0.1), constFn(2.0), constFn(50.0))
+	results, err := RunCoherent(series, Config{Horizon: 3, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, metric := range []string{MetricLeads, MetricCost, MetricIncome, MetricNet} {
+		res := results[metric]
+		if res.BoundsSource != BoundsComposed {
+			t.Errorf("%s: bounds_source = %q, want composed", metric, res.BoundsSource)
+		}
+		for i, p := range res.Predictions {
+			if p.LowerBound > p.Value+1e-9 || p.UpperBound < p.Value-1e-9 {
+				t.Errorf("%s step %d: value %.3f outside [%.3f, %.3f]", metric, i, p.Value, p.LowerBound, p.UpperBound)
+			}
+		}
+	}
+	// With the pairing kept, net's band is exactly the worst-corner
+	// combination of the income and cost bands.
+	for i := range results[MetricNet].Predictions {
+		income := results[MetricIncome].Predictions[i]
+		cost := results[MetricCost].Predictions[i]
+		net := results[MetricNet].Predictions[i]
+		if math.Abs(net.LowerBound-(income.LowerBound-cost.UpperBound)) > 1e-9 {
+			t.Errorf("step %d: net lower %.4f != income lower − cost upper %.4f", i, net.LowerBound, income.LowerBound-cost.UpperBound)
+		}
+	}
+}
+
+func TestRunCoherent_AnchorsAfterLatestInput(t *testing.T) {
+	// The clicks series is missing its newest bucket (rejected upstream)
+	// while leads, cost, and income carry it: forecasts must start after
+	// the latest observed bucket, not on a date the other metrics already
+	// have data for, and stay aligned across metrics.
+	series := makeCoherentSeries(40,
+		func(i int) float64 { return 100 + float64(i%3) },
+		constFn(0.1), constFn(2.0), constFn(50.0))
+	series[MetricClicks] = series[MetricClicks][:39]
+
+	results, err := RunCoherent(series, Config{Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	leads := series[MetricLeads]
+	wantFirst := leads[len(leads)-1].T.AddDate(0, 0, 1)
+	for key, res := range results {
+		if !res.Predictions[0].T.Equal(wantFirst) {
+			t.Errorf("%s: first prediction at %v, want %v (day after the latest input bucket)", key, res.Predictions[0].T, wantFirst)
+		}
+		if len(res.Predictions) != 5 {
+			t.Errorf("%s: %d predictions, want 5", key, len(res.Predictions))
+		}
+	}
+	// A configured anchor further ahead still wins.
+	later := wantFirst.AddDate(0, 0, 2)
+	results, err = RunCoherent(series, Config{Horizon: 5, Interval: IntervalDay, Anchor: later})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := results[MetricNet].Predictions[0].T; !got.Equal(later.AddDate(0, 0, 1)) {
+		t.Errorf("configured anchor ignored: first prediction at %v, want %v", got, later.AddDate(0, 0, 1))
+	}
+}
+
+func TestRunCoherent_ComposedInheritsAnomalies(t *testing.T) {
+	// A two-day tracking outage in clicks is masked for the clicks forecast;
+	// every metric composed from it must report the same masked dates, so
+	// an agent reading only total_leads still learns which observations
+	// were excluded.
+	rng := rand.New(rand.NewSource(31))
+	series := makeCoherentSeries(60,
+		func(i int) float64 {
+			if i == 40 || i == 41 {
+				return 0
+			}
+			return 500 + rng.NormFloat64()*20
+		},
+		constFn(0.1), constFn(2.0), constFn(50.0))
+
+	results, err := RunCoherent(series, Config{Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := results[MetricClicks].AnomaliesMasked
+	if len(want) != 2 {
+		t.Fatalf("clicks masked %v, want the two outage days", want)
+	}
+	for _, metric := range []string{MetricLeads, MetricCost, MetricIncome, MetricNet} {
+		got := results[metric].AnomaliesMasked
+		for _, ts := range want {
+			found := false
+			for _, g := range got {
+				if g == ts {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%s: masked anomalies %v missing %s inherited from clicks", metric, got, ts)
+			}
+		}
+		for i := 1; i < len(got); i++ {
+			if got[i] <= got[i-1] {
+				t.Errorf("%s: masked anomalies not sorted/deduplicated: %v", metric, got)
+			}
+		}
+	}
+}
+
+func TestUnionSorted(t *testing.T) {
+	got := unionSorted([]string{"2026-03-02", "2026-03-01"}, []string{"2026-03-02", "2026-02-28"})
+	want := []string{"2026-02-28", "2026-03-01", "2026-03-02"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+	if unionSorted(nil, nil) != nil {
+		t.Error("union of nothing should be nil (omitted from JSON)")
+	}
 }

--- a/go-cli/internal/forecast/coherent_test.go
+++ b/go-cli/internal/forecast/coherent_test.go
@@ -579,3 +579,60 @@ func TestUnionSorted(t *testing.T) {
 		t.Error("union of nothing should be nil (omitted from JSON)")
 	}
 }
+
+func TestComposedOffset_UsesStalestOperand(t *testing.T) {
+	day := func(d int) time.Time { return time.Date(2026, 3, d, 0, 0, 0, 0, time.UTC) }
+	if got := earlierTrainEnd(day(20), day(15)); !got.Equal(day(15)) {
+		t.Errorf("earlierTrainEnd = %v, want %v", got, day(15))
+	}
+	if got := earlierTrainEnd(time.Time{}, day(15)); !got.Equal(day(15)) {
+		t.Errorf("earlierTrainEnd with a zero operand = %v, want %v", got, day(15))
+	}
+	cfg := Config{Interval: IntervalDay, Anchor: day(20)}
+	if got := composedOffset(day(15), cfg); got != 5 {
+		t.Errorf("offset from a driver five days stale = %d, want 5", got)
+	}
+	if got := composedOffset(day(20), cfg); got != 0 {
+		t.Errorf("offset for a current driver = %d, want 0", got)
+	}
+	if got := composedOffset(day(15), Config{Interval: IntervalDay}); got != 0 {
+		t.Errorf("offset without an anchor = %d, want 0", got)
+	}
+}
+
+func TestRunCoherent_StaleDriverSetsCompositionTrainEnd(t *testing.T) {
+	// Leads drop to zero for the last six buckets, so avg_payout
+	// (income ÷ leads) is undefined there and its forecast runs six steps
+	// ahead of its data. Income, composed from it, must calibrate from that
+	// stale training end, not from where the observed income series ends.
+	rng := rand.New(rand.NewSource(31))
+	n := 60
+	series := makeCoherentSeries(n,
+		func(i int) float64 { return 300 + 30*rng.Float64() },
+		func(i int) float64 {
+			if i >= n-6 {
+				return 0
+			}
+			return 0.1 + 0.01*rng.Float64()
+		},
+		constFn(2.0), func(i int) float64 { return 50 + 5*rng.Float64() })
+
+	results, err := RunCoherent(series, Config{Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	income := results[MetricIncome]
+	if income.Composition != CompositionDerived {
+		t.Fatalf("income composition = %q, want derived", income.Composition)
+	}
+	wantEnd := series[MetricLeads][n-7].T // last bucket with leads > 0
+	if !income.trainEnd.Equal(wantEnd) {
+		t.Errorf("income trainEnd = %v, want the payout driver's %v", income.trainEnd, wantEnd)
+	}
+	if !results[MetricClicks].trainEnd.Equal(series[MetricClicks][n-1].T) {
+		t.Errorf("clicks trainEnd = %v, want the series end", results[MetricClicks].trainEnd)
+	}
+	if !income.Backtested() {
+		t.Error("composed income should report a backtest")
+	}
+}

--- a/go-cli/internal/forecast/coherent_test.go
+++ b/go-cli/internal/forecast/coherent_test.go
@@ -1,0 +1,320 @@
+package forecast
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// makeCoherentSeries builds aligned totals series from per-bucket clicks and
+// driver rates: leads = clicks*rate, cost = clicks*cpc, income = leads*payout.
+func makeCoherentSeries(n int, clicks func(i int) float64, rate, cpc, payout func(i int) float64) map[string]Series {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	out := map[string]Series{
+		MetricClicks: {}, MetricLeads: {}, MetricIncome: {}, MetricCost: {},
+	}
+	for i := 0; i < n; i++ {
+		t := base.AddDate(0, 0, i)
+		c := clicks(i)
+		l := c * rate(i)
+		out[MetricClicks] = append(out[MetricClicks], Point{T: t, V: c})
+		out[MetricLeads] = append(out[MetricLeads], Point{T: t, V: l})
+		out[MetricCost] = append(out[MetricCost], Point{T: t, V: c * cpc(i)})
+		out[MetricIncome] = append(out[MetricIncome], Point{T: t, V: l * payout(i)})
+	}
+	return out
+}
+
+func constFn(v float64) func(int) float64 { return func(int) float64 { return v } }
+
+func TestRunCoherent_ExactIdentitiesOnCleanData(t *testing.T) {
+	// Constant rates and linearly growing clicks: every driver forecast is
+	// exact, so the composed metrics must satisfy the identities exactly.
+	series := makeCoherentSeries(40,
+		func(i int) float64 { return 100 + 10*float64(i) },
+		constFn(0.1), constFn(2.0), constFn(50.0))
+
+	results, err := RunCoherent(series, Config{Horizon: 7, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, key := range []string{MetricClicks, MetricLeads, MetricIncome, MetricCost, MetricNet} {
+		if results[key] == nil {
+			t.Fatalf("missing result for %s", key)
+		}
+		if len(results[key].Predictions) != 7 {
+			t.Fatalf("%s: got %d predictions, want 7", key, len(results[key].Predictions))
+		}
+	}
+
+	for i := 0; i < 7; i++ {
+		clicks := results[MetricClicks].Predictions[i].Value
+		leads := results[MetricLeads].Predictions[i].Value
+		income := results[MetricIncome].Predictions[i].Value
+		cost := results[MetricCost].Predictions[i].Value
+		net := results[MetricNet].Predictions[i].Value
+
+		if math.Abs(leads-clicks*0.1) > 1e-6*clicks {
+			t.Errorf("step %d: leads %.6f != clicks*rate %.6f", i, leads, clicks*0.1)
+		}
+		if math.Abs(income-leads*50) > 1e-6*income {
+			t.Errorf("step %d: income %.6f != leads*payout %.6f", i, income, leads*50)
+		}
+		if math.Abs(cost-clicks*2) > 1e-6*cost {
+			t.Errorf("step %d: cost %.6f != clicks*cpc %.6f", i, cost, clicks*2)
+		}
+		if math.Abs(net-(income-cost)) > 1e-9*math.Abs(income) {
+			t.Errorf("step %d: net %.6f != income-cost %.6f", i, net, income-cost)
+		}
+	}
+}
+
+func TestRunCoherent_NetIdentityUnderNoise(t *testing.T) {
+	rng := rand.New(rand.NewSource(19))
+	series := makeCoherentSeries(60,
+		func(i int) float64 { return 200 + 40*rng.Float64() },
+		func(i int) float64 { return 0.08 + 0.04*rng.Float64() },
+		func(i int) float64 { return 1.5 + rng.Float64() },
+		func(i int) float64 { return 40 + 20*rng.Float64() })
+
+	results, err := RunCoherent(series, Config{Horizon: 10, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := range results[MetricNet].Predictions {
+		income := results[MetricIncome].Predictions[i].Value
+		cost := results[MetricCost].Predictions[i].Value
+		net := results[MetricNet].Predictions[i].Value
+		if math.Abs(net-(income-cost)) > 1e-9*(math.Abs(income)+math.Abs(cost)) {
+			t.Errorf("step %d: net %.9f != income-cost %.9f", i, net, income-cost)
+		}
+	}
+
+	// Derived compositions with dense drivers.
+	for _, key := range []string{MetricLeads, MetricIncome, MetricCost, MetricNet} {
+		if results[key].Composition != CompositionDerived {
+			t.Errorf("%s: composition = %q, want derived", key, results[key].Composition)
+		}
+	}
+	if results[MetricClicks].Composition != CompositionDirect {
+		t.Errorf("clicks composition = %q, want direct", results[MetricClicks].Composition)
+	}
+}
+
+func TestRunCoherent_BoundsAndQuantilesOrdered(t *testing.T) {
+	rng := rand.New(rand.NewSource(23))
+	series := makeCoherentSeries(60,
+		func(i int) float64 { return 150 + 2*float64(i) + 20*rng.Float64() },
+		func(i int) float64 { return 0.1 + 0.02*rng.Float64() },
+		func(i int) float64 { return 2 + 0.4*rng.Float64() },
+		func(i int) float64 { return 50 + 5*rng.Float64() })
+
+	results, err := RunCoherent(series, Config{Horizon: 7, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	order := []string{"p10", "p25", "p50", "p75", "p90"}
+	for key, res := range results {
+		for i, p := range res.Predictions {
+			if p.LowerBound > p.UpperBound {
+				t.Errorf("%s step %d: lower %.4f > upper %.4f", key, i, p.LowerBound, p.UpperBound)
+			}
+			if len(p.Quantiles) == 0 {
+				continue
+			}
+			for j := 1; j < len(order); j++ {
+				if p.Quantiles[order[j-1]] > p.Quantiles[order[j]]+1e-9 {
+					t.Errorf("%s step %d: %s > %s", key, i, order[j-1], order[j])
+				}
+			}
+		}
+	}
+}
+
+func TestRunCoherent_SparseDriverFallsBackToDirect(t *testing.T) {
+	// Clicks are zero on 40% of days, so conv_rate is defined on fewer than
+	// 70% of buckets: leads must fall back to direct forecasting. Income
+	// still composes (payout defined whenever leads > 0... also sparse here),
+	// and net always composes from the other two results.
+	rng := rand.New(rand.NewSource(29))
+	series := makeCoherentSeries(60,
+		func(i int) float64 {
+			if i%5 < 2 {
+				return 0
+			}
+			return 100 + 10*rng.Float64()
+		},
+		constFn(0.1), constFn(2.0), constFn(50.0))
+
+	results, err := RunCoherent(series, Config{Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := results[MetricLeads].Composition; got != CompositionDirect {
+		t.Errorf("leads composition = %q, want direct (sparse conv_rate)", got)
+	}
+	if got := results[MetricNet].Composition; got != CompositionDerived {
+		t.Errorf("net composition = %q, want derived", got)
+	}
+	// Net must still equal income − cost.
+	for i := range results[MetricNet].Predictions {
+		income := results[MetricIncome].Predictions[i].Value
+		cost := results[MetricCost].Predictions[i].Value
+		net := results[MetricNet].Predictions[i].Value
+		if math.Abs(net-(income-cost)) > 1e-9 {
+			t.Errorf("step %d: net %.9f != income-cost %.9f", i, net, income-cost)
+		}
+	}
+}
+
+func TestRunCoherent_MissingSeriesErrors(t *testing.T) {
+	series := makeCoherentSeries(20,
+		constFn(100), constFn(0.1), constFn(2), constFn(50))
+	delete(series, MetricIncome)
+	if _, err := RunCoherent(series, Config{Horizon: 5}); err == nil {
+		t.Fatal("expected error for missing income series")
+	}
+}
+
+func TestRunCoherent_TimestampsAligned(t *testing.T) {
+	// The last two buckets have zero clicks, so conv_rate's last defined
+	// bucket is older than the series end; predictions must still share
+	// timestamps across all metrics, starting after the last bucket.
+	series := makeCoherentSeries(40,
+		func(i int) float64 {
+			if i >= 38 {
+				return 0
+			}
+			return 100
+		},
+		constFn(0.1), constFn(2.0), constFn(50.0))
+
+	results, err := RunCoherent(series, Config{Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clicksSeries := series[MetricClicks]
+	wantFirst := clicksSeries[len(clicksSeries)-1].T.AddDate(0, 0, 1)
+	for key, res := range results {
+		if !res.Predictions[0].T.Equal(wantFirst) {
+			t.Errorf("%s: first prediction at %v, want %v", key, res.Predictions[0].T, wantFirst)
+		}
+		for i := range res.Predictions {
+			if !res.Predictions[i].T.Equal(results[MetricClicks].Predictions[i].T) {
+				t.Errorf("%s: prediction[%d] timestamp misaligned", key, i)
+			}
+		}
+	}
+}
+
+// TestCoherentCompositionAccuracy enforces the WS3 acceptance bar: rolling
+// backtest accuracy for leads and income via composition is at least as good
+// as direct forecasting on the majority of scenarios with stationary drivers.
+func TestCoherentCompositionAccuracy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping rolling-suite comparison in -short mode")
+	}
+	type scenario struct {
+		name   string
+		series map[string]Series
+	}
+	rng1 := rand.New(rand.NewSource(101))
+	rng2 := rand.New(rand.NewSource(102))
+	rng3 := rand.New(rand.NewSource(103))
+	rng4 := rand.New(rand.NewSource(104))
+	scenarios := []scenario{
+		{"trending_clicks_stable_rate", makeCoherentSeries(90,
+			func(i int) float64 { return 200 + 6*float64(i) + rng1.NormFloat64()*25 },
+			func(i int) float64 { return 0.10 + 0.02*rng1.NormFloat64() },
+			func(i int) float64 { return 2.0 + 0.2*rng1.NormFloat64() },
+			func(i int) float64 { return 50 + 4*rng1.NormFloat64() })},
+		{"noisy_clicks_stable_rate", makeCoherentSeries(90,
+			func(i int) float64 { return 300 + rng2.NormFloat64()*60 },
+			func(i int) float64 { return 0.08 + 0.015*rng2.NormFloat64() },
+			func(i int) float64 { return 1.8 + 0.15*rng2.NormFloat64() },
+			func(i int) float64 { return 45 + 3*rng2.NormFloat64() })},
+		{"weekly_clicks", makeCoherentSeries(90,
+			func(i int) float64 {
+				weekly := []float64{0.7, 1.1, 1.25, 1.2, 1.15, 1.0, 0.6}
+				return 250*weekly[i%7] + rng3.NormFloat64()*20
+			},
+			func(i int) float64 { return 0.12 + 0.02*rng3.NormFloat64() },
+			func(i int) float64 { return 2.2 + 0.2*rng3.NormFloat64() },
+			func(i int) float64 { return 55 + 4*rng3.NormFloat64() })},
+		{"plateau_clicks", makeCoherentSeries(90,
+			func(i int) float64 {
+				v := 400.0
+				if i < 45 {
+					v = 150 + (250.0/45.0)*float64(i)
+				}
+				return v + rng4.NormFloat64()*20
+			},
+			func(i int) float64 { return 0.09 + 0.015*rng4.NormFloat64() },
+			func(i int) float64 { return 2.0 + 0.15*rng4.NormFloat64() },
+			func(i int) float64 { return 48 + 4*rng4.NormFloat64() })},
+	}
+
+	wins, total := 0, 0
+	for _, sc := range scenarios {
+		for _, metric := range []string{MetricLeads, MetricIncome} {
+			composed, direct, n := rollingCompare(t, sc.series, metric)
+			if n == 0 {
+				t.Fatalf("%s/%s: no evaluations", sc.name, metric)
+			}
+			total++
+			if composed <= direct*1.02 {
+				wins++
+			}
+			t.Logf("%s/%s: composed rmse %.2f vs direct %.2f", sc.name, metric, composed, direct)
+		}
+	}
+	if wins*2 <= total {
+		t.Errorf("composition matched direct forecasting on only %d/%d cases, want a majority", wins, total)
+	}
+}
+
+// rollingCompare measures rolling RMSE of the composed vs direct forecast of
+// one derived metric over held-out data.
+func rollingCompare(t *testing.T, series map[string]Series, metric string) (composedRMSE, directRMSE float64, n int) {
+	t.Helper()
+	full := series[metric]
+	sumSqC, sumSqD := 0.0, 0.0
+	for c := 30; c < len(full); c += 4 {
+		steps := len(full) - c
+		if steps > 7 {
+			steps = 7
+		}
+		prefix := map[string]Series{}
+		for k, s := range series {
+			cp := make(Series, c)
+			copy(cp, s[:c])
+			prefix[k] = cp
+		}
+		results, err := RunCoherent(prefix, Config{Horizon: steps, Interval: IntervalDay})
+		if err != nil {
+			t.Fatalf("RunCoherent failed at cut %d: %v", c, err)
+		}
+		directIn := make(Series, c)
+		copy(directIn, full[:c])
+		directRes, err := Run(directIn, Config{Horizon: steps, Interval: IntervalDay, NonNegative: true})
+		if err != nil {
+			t.Fatalf("Run failed at cut %d: %v", c, err)
+		}
+		for i := 0; i < steps; i++ {
+			actual := full[c+i].V
+			dc := actual - results[metric].Predictions[i].Value
+			dd := actual - directRes.Predictions[i].Value
+			sumSqC += dc * dc
+			sumSqD += dd * dd
+			n++
+		}
+	}
+	if n == 0 {
+		return 0, 0, 0
+	}
+	return math.Sqrt(sumSqC / float64(n)), math.Sqrt(sumSqD / float64(n)), n
+}

--- a/go-cli/internal/forecast/conformal_test.go
+++ b/go-cli/internal/forecast/conformal_test.go
@@ -394,3 +394,43 @@ func TestRun_ConfidenceWidensBand(t *testing.T) {
 		t.Errorf("band widths not increasing with confidence: %v", widths)
 	}
 }
+
+func TestNonNegative_FoldsScoreTheClippedForecast(t *testing.T) {
+	// A series that declines linearly and then sits at zero: a linear fold
+	// projects below zero across the tail, but the emitted forecast is
+	// floored at zero. The rolling errors must describe that floored
+	// forecaster, so they are far smaller than the raw model's.
+	s := makeSeries(40, func(i int) float64 {
+		if v := 100 - 5*float64(i); v > 0 {
+			return v
+		}
+		return 0
+	})
+	cfg := Config{Method: MethodLinear, Horizon: 5, Interval: IntervalDay}
+	raw, err := Run(s, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg.NonNegative = true
+	clipped, err := Run(s, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !clipped.Backtested() || !raw.Backtested() {
+		t.Fatal("both runs should be backtested")
+	}
+	t.Logf("rolling mae: raw %.2f, clipped %.2f", raw.MAE, clipped.MAE)
+	if clipped.MAE >= raw.MAE {
+		t.Errorf("clipped forecaster mae %.2f should be below the raw model's %.2f", clipped.MAE, raw.MAE)
+	}
+	for i, p := range clipped.Predictions {
+		if p.Value != 0 || p.LowerBound != 0 {
+			t.Errorf("step %d: value %.2f lower %.2f, want 0 for a zero tail", i, p.Value, p.LowerBound)
+		}
+	}
+	for _, v := range clipped.rolling {
+		if v < 0 {
+			t.Fatalf("rolling prediction %.2f below zero for a non-negative metric", v)
+		}
+	}
+}

--- a/go-cli/internal/forecast/conformal_test.go
+++ b/go-cli/internal/forecast/conformal_test.go
@@ -1,0 +1,370 @@
+package forecast
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestQuantileSorted(t *testing.T) {
+	tests := []struct {
+		name   string
+		sorted []float64
+		q      float64
+		want   float64
+	}{
+		{"empty", nil, 0.5, 0},
+		{"single", []float64{7}, 0.1, 7},
+		{"median_even", []float64{1, 2, 3, 4}, 0.5, 2.5},
+		{"median_odd", []float64{1, 2, 3}, 0.5, 2},
+		{"p10_interp", []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100}, 0.10, 10},
+		{"min", []float64{1, 2, 3}, 0.0, 1},
+		{"max", []float64{1, 2, 3}, 1.0, 3},
+	}
+	for _, tc := range tests {
+		got := quantileSorted(tc.sorted, tc.q)
+		if math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("%s: quantileSorted(%v, %.2f) = %v, want %v", tc.name, tc.sorted, tc.q, got, tc.want)
+		}
+	}
+}
+
+func TestBoundPair(t *testing.T) {
+	tests := []struct {
+		conf         float64
+		lower, upper string
+	}{
+		{0.95, "p10", "p90"},
+		{0.80, "p10", "p90"},
+		{0.65, "p10", "p90"},
+		{0.50, "p25", "p75"},
+		{0.60, "p25", "p75"},
+	}
+	for _, tc := range tests {
+		lo, hi := boundPair(tc.conf)
+		if lo != tc.lower || hi != tc.upper {
+			t.Errorf("boundPair(%.2f) = %s/%s, want %s/%s", tc.conf, lo, hi, tc.lower, tc.upper)
+		}
+	}
+}
+
+func TestStepQuantiles_MergesThinBuckets(t *testing.T) {
+	// Step 1 has plenty of residuals; step 2 has only two extreme ones.
+	// Step 2's quantiles must be computed from the merged pool, not from
+	// the two extremes alone.
+	byStep := map[int][]float64{
+		1: {-4, -3, -2, -1, 0, 1, 2, 3, 4, 5},
+		2: {-100, 100},
+	}
+	sq := stepQuantiles(byStep, 2)
+	if sq == nil || sq[1] == nil || sq[2] == nil {
+		t.Fatal("expected quantiles for both steps")
+	}
+	// From the two extremes alone, p25 would be -50; the merged pool keeps
+	// it near the dense bucket's range.
+	if sq[2]["p25"] < -50 || sq[2]["p75"] > 50 {
+		t.Errorf("step-2 quantiles not merged with adjacent bucket: p25=%v p75=%v",
+			sq[2]["p25"], sq[2]["p75"])
+	}
+}
+
+func TestStepQuantiles_MonotoneWidening(t *testing.T) {
+	// Step 2's residuals are (spuriously) tighter than step 1's; the emitted
+	// intervals must not narrow with horizon.
+	byStep := map[int][]float64{
+		1: {-20, -15, -10, -5, 0, 5, 10, 15, 20, 25},
+		2: {-2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5},
+	}
+	sq := stepQuantiles(byStep, 3)
+	for h := 2; h <= 3; h++ {
+		if sq[h]["p10"] > sq[h-1]["p10"] {
+			t.Errorf("step %d p10 (%v) narrower than step %d (%v)", h, sq[h]["p10"], h-1, sq[h-1]["p10"])
+		}
+		if sq[h]["p90"] < sq[h-1]["p90"] {
+			t.Errorf("step %d p90 (%v) narrower than step %d (%v)", h, sq[h]["p90"], h-1, sq[h-1]["p90"])
+		}
+	}
+}
+
+func TestStepQuantiles_ExtendsBeyondObserved(t *testing.T) {
+	byStep := map[int][]float64{
+		1: {-3, -2, -1, 0, 1, 2, 3, 4},
+	}
+	sq := stepQuantiles(byStep, 5)
+	if sq[5] == nil {
+		t.Fatal("expected quantiles for steps beyond the observed range")
+	}
+	if sq[5]["p10"] != sq[1]["p10"] || sq[5]["p90"] != sq[1]["p90"] {
+		t.Errorf("far-step quantiles should reuse the farthest observed pool")
+	}
+}
+
+func TestRun_ConformalQuantilesOrdered(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	s := makeSeries(60, func(i int) float64 { return 100 + 2*float64(i) + rng.NormFloat64()*10 })
+
+	result, err := Run(s, Config{
+		Method:          MethodLinear,
+		Horizon:         7,
+		Interval:        IntervalDay,
+		ConfidenceLevel: 0.80,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	order := []string{"p10", "p25", "p50", "p75", "p90"}
+	for i, p := range result.Predictions {
+		if len(p.Quantiles) == 0 {
+			t.Fatalf("prediction[%d] missing quantiles", i)
+		}
+		for j := 1; j < len(order); j++ {
+			if p.Quantiles[order[j-1]] > p.Quantiles[order[j]] {
+				t.Errorf("prediction[%d]: %s (%v) > %s (%v)", i,
+					order[j-1], p.Quantiles[order[j-1]], order[j], p.Quantiles[order[j]])
+			}
+		}
+		if p.LowerBound != p.Quantiles["p10"] {
+			t.Errorf("prediction[%d]: LowerBound %v != p10 %v at 0.80 confidence", i, p.LowerBound, p.Quantiles["p10"])
+		}
+		if p.UpperBound != p.Quantiles["p90"] {
+			t.Errorf("prediction[%d]: UpperBound %v != p90 %v at 0.80 confidence", i, p.UpperBound, p.Quantiles["p90"])
+		}
+	}
+}
+
+func TestRun_ConfidenceMapsToQuantilePair(t *testing.T) {
+	rng := rand.New(rand.NewSource(9))
+	s := makeSeries(60, func(i int) float64 { return 100 + rng.NormFloat64()*10 })
+
+	result, err := Run(s, Config{
+		Method:          MethodSMA,
+		Horizon:         5,
+		Interval:        IntervalDay,
+		ConfidenceLevel: 0.50,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, p := range result.Predictions {
+		if p.LowerBound != p.Quantiles["p25"] || p.UpperBound != p.Quantiles["p75"] {
+			t.Errorf("prediction[%d]: bounds %v/%v, want p25/p75 %v/%v at 0.50 confidence",
+				i, p.LowerBound, p.UpperBound, p.Quantiles["p25"], p.Quantiles["p75"])
+		}
+	}
+}
+
+// conformalCoverage measures P10–P90 band coverage (and per-tail miss rates)
+// on held-out data via an outer rolling evaluation of Run itself.
+func conformalCoverage(t *testing.T, s Series, method Method) (coverage, lowMiss, highMiss float64) {
+	t.Helper()
+	covered, low, high, n := 0, 0, 0, 0
+	for c := 20; c < len(s); c += 2 {
+		steps := len(s) - c
+		if steps > 7 {
+			steps = 7
+		}
+		train := make(Series, c)
+		copy(train, s[:c])
+		res, err := Run(train, Config{
+			Method:          method,
+			Horizon:         steps,
+			Interval:        IntervalDay,
+			ConfidenceLevel: 0.80,
+		})
+		if err != nil {
+			t.Fatalf("Run failed at cut %d: %v", c, err)
+		}
+		for i := 0; i < steps && i < len(res.Predictions); i++ {
+			actual := s[c+i].V
+			p := res.Predictions[i]
+			switch {
+			case actual < p.LowerBound:
+				low++
+			case actual > p.UpperBound:
+				high++
+			default:
+				covered++
+			}
+			n++
+		}
+	}
+	if n == 0 {
+		t.Fatal("no held-out evaluations")
+	}
+	fn := float64(n)
+	return float64(covered) / fn, float64(low) / fn, float64(high) / fn
+}
+
+func TestRun_ConformalCoverage(t *testing.T) {
+	// Empirical coverage of the P10–P90 band must be 80% ± 10 points on
+	// uniform, Gaussian, and skewed noise. The old Gaussian bounds cannot
+	// meet the per-tail balance on skewed noise; conformal bounds can.
+	cases := []struct {
+		name  string
+		noise func(rng *rand.Rand) float64
+	}{
+		{"uniform", func(rng *rand.Rand) float64 { return (rng.Float64() - 0.5) * 40 }},
+		{"gaussian", func(rng *rand.Rand) float64 { return rng.NormFloat64() * 12 }},
+		{"skewed", func(rng *rand.Rand) float64 { return (rng.ExpFloat64() - 1) * 15 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(101))
+			s := makeSeries(100, func(i int) float64 { return 100 + tc.noise(rng) })
+			cov, low, high := conformalCoverage(t, s, MethodSMA)
+			if cov < 0.70 || cov > 0.90 {
+				t.Errorf("%s: coverage = %.1f%%, want 80%% ± 10", tc.name, cov*100)
+			}
+			// Each tail should miss roughly 10%; require both tails to be
+			// live (symmetric Gaussian bounds on skewed noise park one tail
+			// near zero).
+			if low < 0.02 || low > 0.20 {
+				t.Errorf("%s: lower-tail miss = %.1f%%, want ~10%% (2–20)", tc.name, low*100)
+			}
+			if high < 0.02 || high > 0.20 {
+				t.Errorf("%s: upper-tail miss = %.1f%%, want ~10%% (2–20)", tc.name, high*100)
+			}
+		})
+	}
+}
+
+func TestRun_NonNegativeClipsBounds(t *testing.T) {
+	// Steeply declining count series: unclipped forecasts and lower bounds
+	// go negative.
+	rng := rand.New(rand.NewSource(5))
+	s := makeSeries(40, func(i int) float64 {
+		v := 200 - 6*float64(i) + rng.NormFloat64()*10
+		if v < 0 {
+			v = 0
+		}
+		return v
+	})
+
+	result, err := Run(s, Config{
+		Method:      MethodLinear,
+		Horizon:     14,
+		Interval:    IntervalDay,
+		NonNegative: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, p := range result.Predictions {
+		if p.Value < 0 || p.LowerBound < 0 || p.UpperBound < 0 {
+			t.Errorf("prediction[%d]: negative output value=%v lower=%v upper=%v", i, p.Value, p.LowerBound, p.UpperBound)
+		}
+		for name, v := range p.Quantiles {
+			if v < 0 {
+				t.Errorf("prediction[%d]: negative quantile %s=%v", i, name, v)
+			}
+		}
+	}
+}
+
+func TestRun_ShortSeriesGaussianFallback(t *testing.T) {
+	// Too short for any rolling cut: bounds still present (Gaussian
+	// fallback), quantiles absent.
+	s := makeSeries(6, func(i int) float64 { return 10 + float64(i) })
+	result, err := Run(s, Config{Method: MethodLinear, Horizon: 3, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, p := range result.Predictions {
+		if p.LowerBound > p.Value || p.UpperBound < p.Value {
+			t.Errorf("prediction[%d]: fallback bounds not around value", i)
+		}
+		if len(p.Quantiles) != 0 {
+			t.Errorf("prediction[%d]: expected no quantiles for short series", i)
+		}
+	}
+}
+
+func TestRun_AutoSelectionDeterministic(t *testing.T) {
+	rng := rand.New(rand.NewSource(31))
+	s := makeSeries(50, func(i int) float64 { return 80 + 1.5*float64(i) + rng.NormFloat64()*20 })
+
+	var first Method
+	for run := 0; run < 3; run++ {
+		in := make(Series, len(s))
+		copy(in, s)
+		result, err := Run(in, Config{Method: MethodAuto, Horizon: 5, Interval: IntervalDay})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if run == 0 {
+			first = result.Method
+		} else if result.Method != first {
+			t.Fatalf("auto selection flipped: run 0 chose %s, run %d chose %s", first, run, result.Method)
+		}
+	}
+}
+
+func TestRun_RollingBacktestReportsErrors(t *testing.T) {
+	rng := rand.New(rand.NewSource(17))
+	s := makeSeries(60, func(i int) float64 { return 100 + 2*float64(i) + rng.NormFloat64()*8 })
+
+	result, err := Run(s, Config{Method: MethodLinear, Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.MAE <= 0 || result.RMSE <= 0 {
+		t.Errorf("expected positive rolling-backtest MAE/RMSE, got %v/%v", result.MAE, result.RMSE)
+	}
+	if result.RMSE < result.MAE {
+		t.Errorf("RMSE (%v) should be >= MAE (%v)", result.RMSE, result.MAE)
+	}
+}
+
+func TestScalePrediction_NegativeMultiplier(t *testing.T) {
+	p := Prediction{
+		Value:      100,
+		LowerBound: 80,
+		UpperBound: 120,
+		Quantiles: map[string]float64{
+			"p10": 80, "p25": 90, "p50": 100, "p75": 110, "p90": 120,
+		},
+	}
+	scalePrediction(&p, -1)
+	if p.LowerBound > p.UpperBound {
+		t.Errorf("bounds inverted after negative scale: %v > %v", p.LowerBound, p.UpperBound)
+	}
+	order := []string{"p10", "p25", "p50", "p75", "p90"}
+	for j := 1; j < len(order); j++ {
+		if p.Quantiles[order[j-1]] > p.Quantiles[order[j]] {
+			t.Errorf("quantiles out of order after negative scale: %s > %s", order[j-1], order[j])
+		}
+	}
+	if p.Quantiles["p10"] != -120 || p.Quantiles["p90"] != -80 {
+		t.Errorf("unexpected quantiles after scale: %v", p.Quantiles)
+	}
+}
+
+func TestRun_MaskedGapResidualAlignment(t *testing.T) {
+	// A series with a mid-history gap (as left by event masking): the rolling
+	// backtest must pair residuals by calendar step, not slice index, so
+	// conformal bounds stay tight on an exactly-linear gapped series.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var s Series
+	for day := 0; day < 50; day++ {
+		if day >= 20 && day < 27 {
+			continue
+		}
+		s = append(s, Point{T: base.AddDate(0, 0, day), V: 10 + 5*float64(day)})
+	}
+	result, err := Run(s, Config{Method: MethodLinear, Horizon: 3, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// A perfect linear series has ~zero residuals everywhere; misaligned
+	// pairing would show phantom errors of 5 units per skipped day.
+	if result.MAE > 0.01 {
+		t.Errorf("MAE = %v on exact linear gapped series, want ~0 (residual misalignment)", result.MAE)
+	}
+	for i, p := range result.Predictions {
+		if p.UpperBound-p.LowerBound > 1 {
+			t.Errorf("prediction[%d]: wide bounds (%v..%v) on exact series", i, p.LowerBound, p.UpperBound)
+		}
+	}
+}

--- a/go-cli/internal/forecast/conformal_test.go
+++ b/go-cli/internal/forecast/conformal_test.go
@@ -35,7 +35,10 @@ func TestBoundPair(t *testing.T) {
 		conf         float64
 		lower, upper string
 	}{
-		{0.95, "p10", "p90"},
+		{0.99, "p05", "p95"},
+		{0.95, "p05", "p95"},
+		{0.90, "p05", "p95"},
+		{0.85, "p05", "p95"},
 		{0.80, "p10", "p90"},
 		{0.65, "p10", "p90"},
 		{0.50, "p25", "p75"},
@@ -114,7 +117,7 @@ func TestRun_ConformalQuantilesOrdered(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	order := []string{"p10", "p25", "p50", "p75", "p90"}
+	order := []string{"p05", "p10", "p25", "p50", "p75", "p90", "p95"}
 	for i, p := range result.Predictions {
 		if len(p.Quantiles) == 0 {
 			t.Fatalf("prediction[%d] missing quantiles", i)
@@ -323,20 +326,20 @@ func TestScalePrediction_NegativeMultiplier(t *testing.T) {
 		LowerBound: 80,
 		UpperBound: 120,
 		Quantiles: map[string]float64{
-			"p10": 80, "p25": 90, "p50": 100, "p75": 110, "p90": 120,
+			"p05": 75, "p10": 80, "p25": 90, "p50": 100, "p75": 110, "p90": 120, "p95": 125,
 		},
 	}
 	scalePrediction(&p, -1)
 	if p.LowerBound > p.UpperBound {
 		t.Errorf("bounds inverted after negative scale: %v > %v", p.LowerBound, p.UpperBound)
 	}
-	order := []string{"p10", "p25", "p50", "p75", "p90"}
+	order := []string{"p05", "p10", "p25", "p50", "p75", "p90", "p95"}
 	for j := 1; j < len(order); j++ {
 		if p.Quantiles[order[j-1]] > p.Quantiles[order[j]] {
 			t.Errorf("quantiles out of order after negative scale: %s > %s", order[j-1], order[j])
 		}
 	}
-	if p.Quantiles["p10"] != -120 || p.Quantiles["p90"] != -80 {
+	if p.Quantiles["p05"] != -125 || p.Quantiles["p10"] != -120 || p.Quantiles["p90"] != -80 {
 		t.Errorf("unexpected quantiles after scale: %v", p.Quantiles)
 	}
 }
@@ -366,5 +369,28 @@ func TestRun_MaskedGapResidualAlignment(t *testing.T) {
 		if p.UpperBound-p.LowerBound > 1 {
 			t.Errorf("prediction[%d]: wide bounds (%v..%v) on exact series", i, p.LowerBound, p.UpperBound)
 		}
+	}
+}
+
+func TestRun_ConfidenceWidensBand(t *testing.T) {
+	// Higher confidence must widen the conformal band: 0.50 -> P25/P75,
+	// 0.80 -> P10/P90, 0.95 -> P05/P95 (the widest supported band).
+	rng := rand.New(rand.NewSource(9))
+	s := makeSeries(80, func(i int) float64 { return 100 + rng.NormFloat64()*10 })
+	widths := map[float64]float64{}
+	for _, c := range []float64{0.50, 0.80, 0.95} {
+		in := make(Series, len(s))
+		copy(in, s)
+		r, err := Run(in, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, ConfidenceLevel: c})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		widths[c] = r.Predictions[0].UpperBound - r.Predictions[0].LowerBound
+		if r.BoundsSource != BoundsConformal {
+			t.Errorf("bounds source = %q, want conformal", r.BoundsSource)
+		}
+	}
+	if !(widths[0.50] < widths[0.80] && widths[0.80] < widths[0.95]) {
+		t.Errorf("band widths not increasing with confidence: %v", widths)
 	}
 }

--- a/go-cli/internal/forecast/ensemble_test.go
+++ b/go-cli/internal/forecast/ensemble_test.go
@@ -1,0 +1,249 @@
+package forecast
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestDampedSum(t *testing.T) {
+	tests := []struct {
+		phi  float64
+		h    int
+		want float64
+	}{
+		{1.0, 1, 1},
+		{1.0, 5, 5},
+		{0.5, 1, 0.5},
+		{0.5, 2, 0.75},
+		{0.5, 3, 0.875},
+		{0.9, 2, 0.9 + 0.81},
+	}
+	for _, tc := range tests {
+		got := dampedSum(tc.phi, tc.h)
+		if math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("dampedSum(%v, %d) = %v, want %v", tc.phi, tc.h, got, tc.want)
+		}
+	}
+}
+
+func TestHoltWinters_DampedTrendPlateaus(t *testing.T) {
+	// A series that grows strongly then plateaus: the damped trend must not
+	// extrapolate the old growth forever. Acceptance: 30-step forecast stays
+	// within 2x the last observed level.
+	rng := rand.New(rand.NewSource(3))
+	s := makeSeries(60, func(i int) float64 {
+		v := 300.0
+		if i < 30 {
+			v = 100 + (200.0/30.0)*float64(i)
+		}
+		return v + rng.NormFloat64()*5
+	})
+	last := s[len(s)-1].V
+
+	result, err := Run(s, Config{Method: MethodHoltWinters, Horizon: 30, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, p := range result.Predictions {
+		if p.Value > 2*last {
+			t.Errorf("prediction[%d] = %.1f exceeds 2x last observed level (%.1f): runaway trend", i, p.Value, last)
+		}
+		if p.Value < 0 {
+			t.Errorf("prediction[%d] = %.1f went negative", i, p.Value)
+		}
+	}
+}
+
+func TestHoltWinters_UndampedStillAvailable(t *testing.T) {
+	// On a clean linear trend the optimizer should keep tracking it: 10 steps
+	// out must continue the line, not flatten (phi=1 stays in the grid).
+	s := makeSeries(40, func(i int) float64 { return 10 + 5*float64(i) })
+	result, err := Run(s, Config{Method: MethodHoltWinters, Horizon: 10, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Last observed = 10 + 5*39 = 205; 10 steps out should be ~255.
+	got := result.Predictions[9].Value
+	if math.Abs(got-255) > 10 {
+		t.Errorf("10-step forecast on clean trend = %.1f, want ~255", got)
+	}
+}
+
+func TestRun_EnsembleReportsWeights(t *testing.T) {
+	rng := rand.New(rand.NewSource(41))
+	s := makeSeries(60, func(i int) float64 { return 100 + 2*float64(i) + rng.NormFloat64()*10 })
+
+	result, err := Run(s, Config{Method: MethodEnsemble, Horizon: 7, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != MethodEnsemble {
+		t.Errorf("method = %q, want %q", result.Method, MethodEnsemble)
+	}
+	if len(result.Weights) == 0 {
+		t.Fatal("expected ensemble weights")
+	}
+	sum := 0.0
+	for name, w := range result.Weights {
+		if w <= 0 {
+			t.Errorf("weight[%s] = %v, want > 0", name, w)
+		}
+		sum += w
+	}
+	if math.Abs(sum-1) > 1e-9 {
+		t.Errorf("weights sum to %v, want 1", sum)
+	}
+}
+
+func TestRun_AutoIsEnsembleAlias(t *testing.T) {
+	rng := rand.New(rand.NewSource(43))
+	s := makeSeries(40, func(i int) float64 { return 50 + rng.NormFloat64()*5 })
+
+	result, err := Run(s, Config{Method: MethodAuto, Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != MethodEnsemble {
+		t.Errorf("auto resolved to %q, want %q", result.Method, MethodEnsemble)
+	}
+	if len(result.Weights) == 0 {
+		t.Error("expected ensemble weights for auto method")
+	}
+}
+
+func TestRun_EnsembleDropsNoisyMethods(t *testing.T) {
+	// On a strong clean trend, flat-line methods (SMA/WMA) trail far behind
+	// and their rolling RMSE exceeds twice the best; they must be dropped.
+	s := makeSeries(60, func(i int) float64 { return 10 + 10*float64(i) })
+
+	result, err := Run(s, Config{Method: MethodEnsemble, Horizon: 7, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, dropped := range []string{"sma", "wma"} {
+		if _, ok := result.Weights[dropped]; ok {
+			t.Errorf("expected %s to be dropped from ensemble on strong trend, weights = %v", dropped, result.Weights)
+		}
+	}
+}
+
+func TestRun_EnsembleShortSeriesFallsBack(t *testing.T) {
+	s := makeSeries(6, func(i int) float64 { return 10 + float64(i) })
+	result, err := Run(s, Config{Method: MethodEnsemble, Horizon: 3, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method == MethodEnsemble || result.Method == MethodAuto {
+		t.Errorf("expected fallback to a concrete single method, got %q", result.Method)
+	}
+	if len(result.Weights) != 0 {
+		t.Errorf("expected no weights on fallback, got %v", result.Weights)
+	}
+}
+
+func TestRun_EnsembleDeterministic(t *testing.T) {
+	rng := rand.New(rand.NewSource(47))
+	s := makeSeries(50, func(i int) float64 { return 80 + 1.5*float64(i) + rng.NormFloat64()*20 })
+
+	var firstPreds []Prediction
+	var firstWeights map[string]float64
+	for run := 0; run < 3; run++ {
+		in := make(Series, len(s))
+		copy(in, s)
+		result, err := Run(in, Config{Method: MethodEnsemble, Horizon: 7, Interval: IntervalDay})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if run == 0 {
+			firstPreds = result.Predictions
+			firstWeights = result.Weights
+			continue
+		}
+		for name, w := range result.Weights {
+			if firstWeights[name] != w {
+				t.Fatalf("weights differ between runs: %v vs %v", firstWeights, result.Weights)
+			}
+		}
+		for i := range result.Predictions {
+			if result.Predictions[i].Value != firstPreds[i].Value {
+				t.Fatalf("prediction[%d] differs between runs: %v vs %v", i, firstPreds[i].Value, result.Predictions[i].Value)
+			}
+		}
+	}
+}
+
+// rollingMeasureSelection mirrors rollingMeasure but, at every cut, forecasts
+// with the method the pre-ensemble winner-take-all auto selection (single
+// train/test split) would have chosen — the behavior the ensemble replaced.
+func rollingMeasureSelection(s Series, horizon int) (rmse float64, n int) {
+	sumSq := 0.0
+	for c := 9; c < len(s); c += 2 {
+		steps := len(s) - c
+		if steps > horizon {
+			steps = horizon
+		}
+		train := make(Series, c)
+		copy(train, s[:c])
+		cfg := Config{Horizon: steps, Interval: IntervalDay, ConfidenceLevel: 0.80}
+		cfg.Method = selectBestMethod(train, cfg)
+		res, err := Run(train, cfg)
+		if err != nil {
+			continue
+		}
+		for i := 0; i < steps && i < len(res.Predictions); i++ {
+			diff := s[c+i].V - res.Predictions[i].Value
+			sumSq += diff * diff
+			n++
+		}
+	}
+	if n == 0 {
+		return 0, 0
+	}
+	return math.Sqrt(sumSq / float64(n)), n
+}
+
+// TestEnsembleBeatsWinnerTakeAll enforces the WS2 acceptance bar: the
+// ensemble's rolling-backtest RMSE is at or below single-method selection on
+// at least 70% of the representative-series suite. The baseline is the
+// winner-take-all auto selection the ensemble replaced (choosing one method
+// per cut from a single train/test split); the hindsight-best single method
+// per series is logged for reference but is an oracle no ex-ante forecaster
+// is expected to beat everywhere.
+func TestEnsembleBeatsWinnerTakeAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping rolling-suite comparison in -short mode")
+	}
+	singles := []Method{MethodLinear, MethodSMA, MethodWMA, MethodHoltWinters}
+	series := suiteSeries()
+	names := []string{"trend_up", "trend_plateau", "weekly_seasonal", "noisy_flat",
+		"level_shift", "short", "skewed_noise", "mult_growth"}
+
+	wins := 0
+	for _, name := range names {
+		s := series[name]
+		ensRMSE, _, _, _, _, n := rollingMeasure(s, MethodEnsemble, 7)
+		if n == 0 {
+			t.Fatalf("%s: no rolling evaluations", name)
+		}
+		selRMSE, sn := rollingMeasureSelection(s, 7)
+		if sn == 0 {
+			t.Fatalf("%s: no selection evaluations", name)
+		}
+		oracle := math.MaxFloat64
+		for _, m := range singles {
+			rmse, _, _, _, _, mn := rollingMeasure(s, m, 7)
+			if mn > 0 && rmse < oracle {
+				oracle = rmse
+			}
+		}
+		if ensRMSE <= selRMSE*1.02 {
+			wins++
+		}
+		t.Logf("%s: ensemble %.2f vs winner-take-all %.2f (oracle best single %.2f)",
+			name, ensRMSE, selRMSE, oracle)
+	}
+	if wins < 6 { // 6 of 8 = 75%
+		t.Errorf("ensemble beat winner-take-all selection on only %d/8 series, want >= 6", wins)
+	}
+}

--- a/go-cli/internal/forecast/ensemble_test.go
+++ b/go-cli/internal/forecast/ensemble_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 )
 
 func TestDampedSum(t *testing.T) {
@@ -245,5 +246,43 @@ func TestEnsembleBeatsWinnerTakeAll(t *testing.T) {
 	}
 	if wins < 6 { // 6 of 8 = 75%
 		t.Errorf("ensemble beat winner-take-all selection on only %d/8 series, want >= 6", wins)
+	}
+}
+
+func TestNestedEnsemblePredictor_UsesOnlyPriorRows(t *testing.T) {
+	// Method A is exact on everything observed up to day 12 and useless
+	// afterwards; method B the reverse. Weights derived from all rows would
+	// favor B for the day-13 rows. Out-of-sample evaluation of the cut
+	// whose training ends on day 12 may only use rows observed by then, so
+	// it must weight A (B is pruned by the drop factor) and predict day 13
+	// with A alone. The earliest cut has no prior rows and falls back to
+	// equal weights.
+	day := func(d int) time.Time { return time.Date(2026, 1, d, 0, 0, 0, 0, time.UTC) }
+	row := func(cut, target int, actual, a, b float64) evalRow {
+		return evalRow{cut: cut, trainEnd: day(cut), t: day(target), step: target - cut, actual: actual,
+			preds: map[Method]float64{MethodLinear: a, MethodSMA: b}}
+	}
+	eval := &rollingEval{rows: []evalRow{
+		row(10, 11, 100, 100, 130), // A exact, B off by 30
+		row(10, 12, 100, 100, 130),
+		row(11, 12, 100, 100, 130),
+		row(11, 13, 200, 100, 200), // day 13: B exact, A off by 100
+		row(12, 13, 200, 100, 200),
+	}}
+	candidates := []Method{MethodLinear, MethodSMA}
+	predict := nestedEnsemblePredictor(eval, candidates)
+
+	got, ok := predict(eval.rows[4]) // cut 12 → day 13
+	if !ok || math.Abs(got-100) > 1e-9 {
+		t.Errorf("cut-12 prediction = %.3f (ok=%v), want 100: weights must come from rows observed by day 12 only", got, ok)
+	}
+	first, ok := predict(eval.rows[0]) // cut 10: no prior rows → equal weights
+	if !ok || math.Abs(first-115) > 1e-9 {
+		t.Errorf("earliest-cut prediction = %.3f (ok=%v), want 115 (equal weights)", first, ok)
+	}
+	// Sanity: full-data weights would indeed have leaned on B for day 13.
+	full := ensembleWeights(eval, candidates, nil)
+	if full[MethodSMA] <= full[MethodLinear] {
+		t.Errorf("full-data weights %v should favor B, otherwise this test proves nothing", full)
 	}
 }

--- a/go-cli/internal/forecast/events.go
+++ b/go-cli/internal/forecast/events.go
@@ -236,15 +236,18 @@ func ApplyEventAdjustments(predictions []Prediction, events []Event, impacts map
 	for i := range adjusted {
 		key := truncateToDay(adjusted[i].T).Format("2006-01-02")
 		if adj, ok := adjustments[key]; ok {
-			adjusted[i].Value *= adj.Multiplier
-			adjusted[i].LowerBound *= adj.Multiplier
-			adjusted[i].UpperBound *= adj.Multiplier
-			// Multiplicative adjustment can invert bounds when the multiplier
-			// is negative (e.g., learned from negative-profit actuals).
-			// Guarantee Lower ≤ Upper.
-			if adjusted[i].LowerBound > adjusted[i].UpperBound {
-				adjusted[i].LowerBound, adjusted[i].UpperBound = adjusted[i].UpperBound, adjusted[i].LowerBound
+			// scalePrediction guarantees Lower ≤ Upper and ordered quantiles
+			// even when the multiplier is negative (e.g., learned from
+			// negative-profit actuals). Copy the quantile map first so the
+			// input predictions stay unmodified.
+			if len(adjusted[i].Quantiles) > 0 {
+				qs := make(map[string]float64, len(adjusted[i].Quantiles))
+				for k, v := range adjusted[i].Quantiles {
+					qs[k] = v
+				}
+				adjusted[i].Quantiles = qs
 			}
+			scalePrediction(&adjusted[i], adj.Multiplier)
 		}
 	}
 

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -534,6 +534,7 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 	}
 	profile, _ := profileFor(series, cfg, len(series))
 	applyProfile(predictions, profile, cfg.LogTransform)
+	clipPointPredictions(predictions, cfg)
 
 	if eval == nil {
 		eval = runRollingBacktest(series, cfg, []Method{method})
@@ -603,6 +604,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 			continue
 		}
 		applyProfile(preds, profile, cfg.LogTransform)
+		clipPointPredictions(preds, cfg)
 		memberPreds[m] = preds
 		memberTrend[m] = tr
 		members = append(members, m)
@@ -810,6 +812,7 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 	}
 	profile, _ := profileFor(s, cfg, c)
 	applyProfile(preds, profile, cfg.LogTransform)
+	clipPointPredictions(preds, cfg)
 
 	sumSqModel, sumAbs, sumSq := 0.0, 0.0, 0.0
 	for _, p := range test {
@@ -1010,6 +1013,25 @@ func applyProfile(preds []Prediction, profile func(time.Time) float64, logScale 
 		}
 		if v := math.Expm1(preds[i].Value); v > 0 {
 			preds[i].Value = math.Log1p(v * w)
+		}
+	}
+}
+
+// clipPointPredictions floors point predictions at zero for non-negative
+// metrics. Zero is a fixed point of log1p, so the floor is the same on the
+// model scale. It runs on the deployed fit, every backtest fold, and the
+// holdout before residuals and bounds are computed, so the forecaster that
+// is calibrated is the clipped one the output shows: a fold projecting
+// below a zero tail scores the zero it would have emitted, not a negative
+// number nobody sees. Bounds and quantiles are floored separately at
+// output (ClipNonNegative).
+func clipPointPredictions(preds []Prediction, cfg Config) {
+	if !cfg.NonNegative {
+		return
+	}
+	for i := range preds {
+		if preds[i].Value < 0 {
+			preds[i].Value = 0
 		}
 	}
 }

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -124,10 +124,26 @@ type Result struct {
 
 	// rolling holds the deployed forecaster's rolling-backtest predictions
 	// on the reporting scale (transform inverted, zero-clipped like the
-	// output, no seasonal profile), keyed by the training window they were
-	// made from and the point they targeted. RunCoherent composes operands'
-	// entries to backtest derived metrics (see finishComposed).
+	// output, with the fold's own seasonal profile), keyed by the training
+	// window they were made from and the point they targeted. RunCoherent
+	// composes operands' entries to backtest derived metrics (see
+	// finishComposed).
 	rolling map[rollingKey]float64
+	// trainEnd is the timestamp of the last point the forecaster was
+	// fitted on (after masking and truncation); for a composed result, the
+	// earlier of its operands'. Predictions anchored later than this are
+	// that many steps further out, which the band offset accounts for.
+	trainEnd time.Time
+	// evaluated reports whether any held-out points scored the forecaster
+	// (rolling backtest or single holdout), so a zero MAE/RMSE can be told
+	// apart from "never measured".
+	evaluated bool
+}
+
+// Backtested reports whether MAE and RMSE were measured on held-out
+// points; when false they are unset, not zero error.
+func (r *Result) Backtested() bool {
+	return r.evaluated
 }
 
 // Bounds sources reported in Result.BoundsSource.
@@ -432,6 +448,8 @@ func Run(series Series, cfg Config) (*Result, error) {
 		SeasonalProfiles: profiles,
 		BoundsSource:     core.boundsSource,
 		rolling:          rolling,
+		trainEnd:         work[len(work)-1].T,
+		evaluated:        core.evaluated,
 	}, nil
 }
 
@@ -502,6 +520,8 @@ type forecastCore struct {
 	// forecaster's view of it (single method or weighted ensemble).
 	eval    *rollingEval
 	predict rowPredictor
+	// evaluated is true when mae/rmse were measured on held-out points.
+	evaluated bool
 }
 
 // computeSingle produces a single-method forecast with conformal bounds.
@@ -521,7 +541,7 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 	offset := anchorOffset(series, cfg)
 	predict := eval.methodPredictor(method)
 	byStep := eval.residualsByStep(predict)
-	mae, rmse, _ := eval.errorStats(predict)
+	mae, rmse, n := eval.errorStats(predict)
 	source := BoundsConformal
 	if totalResiduals(byStep) >= minTotalResiduals {
 		sq := stepQuantiles(byStep, offset+cfg.Horizon)
@@ -531,7 +551,7 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 		// bounds from a single-holdout residual estimate, and single-split
 		// accuracy metrics — one fit serves both.
 		var stddev float64
-		stddev, mae, rmse = holdoutEval(series, cfg, method)
+		stddev, mae, rmse, n = holdoutEval(series, cfg, method)
 		addBounds(predictions, stddev, cfg.ConfidenceLevel, offset)
 		source = BoundsGaussian
 	}
@@ -545,6 +565,7 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 		boundsSource: source,
 		eval:         eval,
 		predict:      predict,
+		evaluated:    n > 0,
 	}, nil
 }
 
@@ -611,7 +632,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 	offset := anchorOffset(series, cfg)
 	predict := nestedEnsemblePredictor(eval, candidates)
 	byStep := eval.residualsByStep(predict)
-	mae, rmse, _ := eval.errorStats(predict)
+	mae, rmse, n := eval.errorStats(predict)
 	source := BoundsConformal
 	if totalResiduals(byStep) >= minTotalResiduals {
 		sq := stepQuantiles(byStep, offset+cfg.Horizon)
@@ -637,6 +658,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 		boundsSource: source,
 		eval:         eval,
 		predict:      predict,
+		evaluated:    n > 0,
 	}, nil
 }
 
@@ -761,13 +783,13 @@ func seriesStdDev(s Series) float64 {
 // RMSE on the reporting scale. It is the fallback for series too short for
 // a rolling backtest; when even the single split is impossible it returns
 // the series' own standard deviation and zero errors.
-func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64) {
+func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64, n int) {
 	holdout := len(s) / 5
 	if holdout < 2 {
 		holdout = 2
 	}
 	if holdout > len(s)-3 {
-		return seriesStdDev(s), 0, 0
+		return seriesStdDev(s), 0, 0, 0
 	}
 
 	c := len(s) - holdout
@@ -784,12 +806,11 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 
 	preds, _, err := methodForecast(method, train, testCfg)
 	if err != nil || len(preds) == 0 {
-		return seriesStdDev(s), 0, 0
+		return seriesStdDev(s), 0, 0, 0
 	}
 	profile, _ := profileFor(s, cfg, c)
 	applyProfile(preds, profile, cfg.LogTransform)
 
-	n := 0
 	sumSqModel, sumAbs, sumSq := 0.0, 0.0, 0.0
 	for _, p := range test {
 		h, ok := stepIndex(trainEnd, p.T, cfg.Interval, len(preds))
@@ -809,10 +830,10 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 		n++
 	}
 	if n == 0 {
-		return seriesStdDev(s), 0, 0
+		return seriesStdDev(s), 0, 0, 0
 	}
 	fn := float64(n)
-	return math.Sqrt(sumSqModel / fn), sumAbs / fn, math.Sqrt(sumSq / fn)
+	return math.Sqrt(sumSqModel / fn), sumAbs / fn, math.Sqrt(sumSq / fn), n
 }
 
 // calendarSteps returns the number of whole interval steps from from to to,
@@ -917,7 +938,7 @@ func selectBestMethod(s Series, cfg Config) Method {
 	bestRMSE := math.MaxFloat64
 
 	for _, m := range autoCandidates(s) {
-		_, _, rmse := holdoutEval(s, cfg, m)
+		_, _, rmse, _ := holdoutEval(s, cfg, m)
 		// RMSE=0 means backtest couldn't run (too few points for holdout),
 		// not a perfect fit. Skip these candidates.
 		if rmse > 0 && rmse < bestRMSE {

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -96,6 +96,15 @@ type Result struct {
 	// (composed from driver forecasts) or "direct" (the metric's own series
 	// forecast directly). Empty for plain Run results.
 	Composition string `json:"composition,omitempty"`
+	// LevelShiftAt is the timestamp of the first observation after a
+	// detected level shift (offer paused, traffic source added). When set,
+	// pre-shift history was truncated or re-leveled before fitting.
+	LevelShiftAt string `json:"level_shift_at,omitempty"`
+	// SeasonalApplied reports whether any supplied seasonal profile
+	// actually adjusted the predictions: weekday and hourly weights are
+	// gated on detrended autocorrelation at the seasonal lag, so weights
+	// built from a series with no real weekly/daily structure are ignored.
+	SeasonalApplied bool `json:"seasonal_applied,omitempty"`
 }
 
 // SeasonalWeights maps day-of-week (time.Weekday) to a multiplier.
@@ -116,6 +125,21 @@ type Config struct {
 	// cost, income). Prediction values, bounds, and quantiles are clipped
 	// at zero.
 	NonNegative bool
+
+	// HourlyWeights maps hour-of-day (0-23) to a multiplier, for hourly
+	// forecasts. Like SeasonalWeights it is gated on detrended
+	// autocorrelation at the daily lag before being applied.
+	HourlyWeights map[int]float64
+
+	// MonthDayWeights maps day-of-month (1-31) to a multiplier — affiliate
+	// budgets and payouts often reset monthly. Applied without a gate: the
+	// profile is an explicit opt-in.
+	MonthDayWeights map[int]float64
+
+	// LogTransform fits count-like non-negative series on log1p scale and
+	// inverts on output, making multiplicative behavior additive and
+	// stabilizing variance. Ignored when the series has negative values.
+	LogTransform bool
 
 	// Anchor, when set, is the timestamp predictions step forward from
 	// instead of the series' last point. Used when training data has been
@@ -210,20 +234,65 @@ func Run(series Series, cfg Config) (*Result, error) {
 		method = MethodEnsemble
 	}
 
+	// The original-scale mean anchors the trend percentage regardless of
+	// transforms and truncation below.
+	originalMean := seriesMean(series)
+
+	// Optional log1p transform: fit multiplicative count series on log
+	// scale, invert on output. Skipped when negative values make the
+	// transform undefined.
+	work := series
+	logApplied := false
+	if cfg.LogTransform && seriesAllNonNegative(work) {
+		work = log1pSeries(work)
+		logApplied = true
+	} else {
+		cfg.LogTransform = false // downstream error stats stay untransformed
+	}
+
+	// Level-shift handling: fit on the current regime, not a blend of
+	// regimes. Post-shift history is used alone when long enough; otherwise
+	// older observations are re-leveled to the new regime.
+	levelShiftAt := ""
+	if idx, delta := detectLevelShift(work); idx > 0 {
+		levelShiftAt = formatShiftTime(work[idx].T, cfg.Interval)
+		work = applyLevelShift(work, idx, delta, cfg.Interval)
+	}
+
 	var core forecastCore
 	var err error
 	if method == MethodEnsemble {
-		core, err = computeEnsemble(series, cfg)
+		core, err = computeEnsemble(work, cfg)
 	} else {
-		core, err = computeSingle(series, cfg, method, nil)
+		core, err = computeSingle(work, cfg, method, nil)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	// Apply seasonal adjustment if weights are provided.
-	if len(cfg.SeasonalWeights) > 0 {
+	if logApplied {
+		invertLogPredictions(core.preds)
+		core.trend = predictionTrend(core.preds, series)
+	}
+
+	// Apply seasonal profiles. Weekday and hourly weights are gated on
+	// detrended autocorrelation at their lag so spurious profiles (built
+	// from noise) don't degrade the forecast; day-of-month weights are an
+	// explicit opt-in and apply as supplied.
+	seasonalApplied := false
+	if len(cfg.SeasonalWeights) > 0 &&
+		seasonalLagAutocorrelation(work, 7*24*time.Hour) >= seasonalGateThreshold {
 		core.preds = applySeasonalWeights(core.preds, cfg.SeasonalWeights)
+		seasonalApplied = true
+	}
+	if len(cfg.HourlyWeights) > 0 && cfg.Interval == IntervalHour &&
+		seasonalLagAutocorrelation(work, 24*time.Hour) >= seasonalGateThreshold {
+		core.preds = applyHourlyWeights(core.preds, cfg.HourlyWeights)
+		seasonalApplied = true
+	}
+	if len(cfg.MonthDayWeights) > 0 {
+		core.preds = applyMonthDayWeights(core.preds, cfg.MonthDayWeights)
+		seasonalApplied = true
 	}
 
 	if cfg.NonNegative {
@@ -232,26 +301,70 @@ func Run(series Series, cfg Config) (*Result, error) {
 
 	// Compute trend percentage.
 	trendPct := 0.0
-	if len(series) > 0 {
-		mean := seriesMean(series)
-		if mean != 0 {
-			trendPct = (core.trend / mean) * 100
-		}
+	if originalMean != 0 {
+		trendPct = (core.trend / originalMean) * 100
 	}
 
 	return &Result{
-		Method:      core.method,
-		Metric:      cfg.Metric,
-		Horizon:     cfg.Horizon,
-		Interval:    cfg.Interval,
-		Predictions: core.preds,
-		Trend:       core.trend,
-		TrendPct:    trendPct,
-		MAE:         core.mae,
-		RMSE:        core.rmse,
-		DataPoints:  len(series),
-		Weights:     core.weights,
+		Method:          core.method,
+		Metric:          cfg.Metric,
+		Horizon:         cfg.Horizon,
+		Interval:        cfg.Interval,
+		Predictions:     core.preds,
+		Trend:           core.trend,
+		TrendPct:        trendPct,
+		MAE:             core.mae,
+		RMSE:            core.rmse,
+		DataPoints:      len(series),
+		Weights:         core.weights,
+		LevelShiftAt:    levelShiftAt,
+		SeasonalApplied: seasonalApplied,
 	}, nil
+}
+
+// seriesAllNonNegative reports whether every value is >= 0.
+func seriesAllNonNegative(s Series) bool {
+	for _, p := range s {
+		if p.V < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// log1pSeries returns a copy of the series with values on log1p scale.
+func log1pSeries(s Series) Series {
+	out := make(Series, len(s))
+	for i, p := range s {
+		out[i] = Point{T: p.T, V: math.Log1p(p.V)}
+	}
+	return out
+}
+
+// invertLogPredictions maps predictions fitted on log1p scale back to the
+// original scale. expm1 is monotone, so bound and quantile order is kept.
+func invertLogPredictions(preds []Prediction) {
+	for i := range preds {
+		preds[i].Value = math.Expm1(preds[i].Value)
+		preds[i].LowerBound = math.Expm1(preds[i].LowerBound)
+		preds[i].UpperBound = math.Expm1(preds[i].UpperBound)
+		for name, v := range preds[i].Quantiles {
+			preds[i].Quantiles[name] = math.Expm1(v)
+		}
+	}
+}
+
+// predictionTrend estimates the per-period trend from the forecast path on
+// the original scale (used when the model's own trend lives in log space).
+func predictionTrend(preds []Prediction, original Series) float64 {
+	switch {
+	case len(preds) > 1:
+		return (preds[len(preds)-1].Value - preds[0].Value) / float64(len(preds)-1)
+	case len(preds) == 1 && len(original) > 0:
+		return preds[0].Value - original[len(original)-1].V
+	default:
+		return 0
+	}
 }
 
 // forecastCore is a computed forecast before the shared post-processing
@@ -603,7 +716,12 @@ func backtest(s Series, cfg Config, method Method) (mae, rmse float64) {
 	sumAbsErr := 0.0
 	sumSqErr := 0.0
 	for i := 0; i < n; i++ {
-		diff := test[i].V - preds[i].Value
+		actual, pred := test[i].V, preds[i].Value
+		if cfg.LogTransform {
+			// Values arrive on log1p scale; report errors on the original.
+			actual, pred = math.Expm1(actual), math.Expm1(pred)
+		}
+		diff := actual - pred
 		sumAbsErr += math.Abs(diff)
 		sumSqErr += diff * diff
 	}
@@ -684,6 +802,26 @@ func applySeasonalWeights(preds []Prediction, weights SeasonalWeights) []Predict
 	for i := range preds {
 		dow := preds[i].T.Weekday()
 		if w, ok := weights[dow]; ok {
+			scalePrediction(&preds[i], w)
+		}
+	}
+	return preds
+}
+
+// applyHourlyWeights adjusts prediction values by hour-of-day multipliers.
+func applyHourlyWeights(preds []Prediction, weights map[int]float64) []Prediction {
+	for i := range preds {
+		if w, ok := weights[preds[i].T.Hour()]; ok {
+			scalePrediction(&preds[i], w)
+		}
+	}
+	return preds
+}
+
+// applyMonthDayWeights adjusts prediction values by day-of-month multipliers.
+func applyMonthDayWeights(preds []Prediction, weights map[int]float64) []Prediction {
+	for i := range preds {
+		if w, ok := weights[preds[i].T.Day()]; ok {
 			scalePrediction(&preds[i], w)
 		}
 	}

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -57,11 +57,20 @@ type Point struct {
 type Series []Point
 
 // Prediction is a single forecasted value with confidence bounds.
+//
+// Bounds come from rolling-origin conformal prediction: empirical quantiles
+// of held-out residuals bucketed by horizon step. LowerBound/UpperBound carry
+// the quantile pair nearest the configured confidence level (P10/P90 for the
+// default levels — an 80% interval) and are asymmetric by nature. Quantiles
+// holds the full set ("p10", "p25", "p50", "p75", "p90"); it is empty when
+// the series is too short for a rolling backtest, in which case bounds fall
+// back to symmetric Gaussian estimates.
 type Prediction struct {
-	T          time.Time `json:"time"`
-	Value      float64   `json:"value"`
-	LowerBound float64   `json:"lower_bound"`
-	UpperBound float64   `json:"upper_bound"`
+	T          time.Time          `json:"time"`
+	Value      float64            `json:"value"`
+	LowerBound float64            `json:"lower_bound"`
+	UpperBound float64            `json:"upper_bound"`
+	Quantiles  map[string]float64 `json:"quantiles,omitempty"`
 }
 
 // Result holds the complete output of a forecast run.
@@ -91,6 +100,11 @@ type Config struct {
 	SMAWindow       int
 	SeasonalWeights SeasonalWeights
 	ConfidenceLevel float64 // 0.0-1.0, default 0.95
+
+	// NonNegative marks metrics that cannot go below zero (clicks, leads,
+	// cost, income). Prediction values, bounds, and quantiles are clipped
+	// at zero.
+	NonNegative bool
 
 	// Anchor, when set, is the timestamp predictions step forward from
 	// instead of the series' last point. Used when training data has been
@@ -180,28 +194,36 @@ func Run(series Series, cfg Config) (*Result, error) {
 	}
 
 	method := cfg.Method
+	var eval *rollingEval
 	if method == "" || method == MethodAuto {
-		method = selectBestMethod(series, cfg)
+		candidates := autoCandidates(series)
+		eval = runRollingBacktest(series, cfg, candidates)
+		method = selectByRollingRMSE(eval, candidates, series, cfg)
 	}
 
-	var predictions []Prediction
-	var trend float64
-	var err error
-
-	switch method {
-	case MethodLinear:
-		predictions, trend, err = linearForecast(series, cfg)
-	case MethodSMA:
-		predictions, trend, err = smaForecast(series, cfg)
-	case MethodWMA:
-		predictions, trend, err = wmaForecast(series, cfg)
-	case MethodHoltWinters:
-		predictions, trend, err = holtWintersForecast(series, cfg)
-	default:
-		return nil, fmt.Errorf("unknown method %q", method)
-	}
+	predictions, trend, err := methodForecast(method, series, cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	// Attach bounds via rolling-origin conformal prediction. When auto-
+	// selection already ran the rolling backtest, reuse it.
+	if eval == nil {
+		eval = runRollingBacktest(series, cfg, []Method{method})
+	}
+	offset := anchorOffset(series, cfg)
+	byStep := eval.residualsByStep(method)
+	mae, rmse := eval.errorStats(method)
+	if totalResiduals(byStep) >= minTotalResiduals {
+		sq := stepQuantiles(byStep, offset+cfg.Horizon)
+		applyConformalBounds(predictions, sq, cfg, offset)
+	} else {
+		// Series too short for a rolling backtest: symmetric Gaussian
+		// bounds from a single-holdout residual estimate, and single-split
+		// accuracy metrics.
+		stddev := residualStdDev(series, method, cfg)
+		addBounds(predictions, stddev, cfg.ConfidenceLevel, offset)
+		mae, rmse = backtest(series, cfg, method)
 	}
 
 	// Apply seasonal adjustment if weights are provided.
@@ -209,8 +231,9 @@ func Run(series Series, cfg Config) (*Result, error) {
 		predictions = applySeasonalWeights(predictions, cfg.SeasonalWeights)
 	}
 
-	// Compute accuracy metrics via leave-last-out backtest.
-	mae, rmse := backtest(series, cfg, method)
+	if cfg.NonNegative {
+		clipNonNegative(predictions)
+	}
 
 	// Compute trend percentage.
 	trendPct := 0.0
@@ -273,7 +296,8 @@ func seriesStdDev(s Series) float64 {
 	return math.Sqrt(sumSq / float64(len(s)))
 }
 
-// residualStdDev computes std dev of forecast residuals over the last holdout points.
+// residualStdDev computes std dev of forecast residuals over the last holdout
+// points. Fallback bound estimate for series too short for a rolling backtest.
 func residualStdDev(s Series, method Method, cfg Config) float64 {
 	holdout := len(s) / 5
 	if holdout < 2 {
@@ -291,20 +315,7 @@ func residualStdDev(s Series, method Method, cfg Config) float64 {
 	testCfg.SeasonalWeights = nil
 	testCfg.Anchor = time.Time{}
 
-	var preds []Prediction
-	var err error
-	switch method {
-	case MethodLinear:
-		preds, _, err = linearForecast(train, testCfg)
-	case MethodSMA:
-		preds, _, err = smaForecast(train, testCfg)
-	case MethodWMA:
-		preds, _, err = wmaForecast(train, testCfg)
-	case MethodHoltWinters:
-		preds, _, err = holtWintersForecast(train, testCfg)
-	default:
-		return seriesStdDev(s)
-	}
+	preds, _, err := methodForecast(method, train, testCfg)
 	if err != nil || len(preds) == 0 {
 		return seriesStdDev(s)
 	}
@@ -338,7 +349,8 @@ func zScore(confidence float64) float64 {
 	}
 }
 
-// addBounds applies confidence interval bounds to predictions. offset is the
+// addBounds applies symmetric Gaussian confidence bounds to predictions.
+// Fallback for series too short for conformal bounds. offset is the
 // number of steps the first prediction lies beyond the series' last point in
 // excess of one (see anchorOffset); it widens bounds across anchor gaps.
 func addBounds(preds []Prediction, stddev, confidence float64, offset int) {
@@ -383,7 +395,8 @@ func intervalSteps(from, to time.Time, interval Interval) float64 {
 	}
 }
 
-// backtest splits data into train/test and measures forecast accuracy.
+// backtest splits data into a single train/test split and measures forecast
+// accuracy. Fallback for series too short for a rolling backtest.
 func backtest(s Series, cfg Config, method Method) (mae, rmse float64) {
 	holdout := len(s) / 5
 	if holdout < 2 {
@@ -401,20 +414,7 @@ func backtest(s Series, cfg Config, method Method) (mae, rmse float64) {
 	testCfg.SeasonalWeights = nil
 	testCfg.Anchor = time.Time{}
 
-	var preds []Prediction
-	var err error
-	switch method {
-	case MethodLinear:
-		preds, _, err = linearForecast(train, testCfg)
-	case MethodSMA:
-		preds, _, err = smaForecast(train, testCfg)
-	case MethodWMA:
-		preds, _, err = wmaForecast(train, testCfg)
-	case MethodHoltWinters:
-		preds, _, err = holtWintersForecast(train, testCfg)
-	default:
-		return 0, 0
-	}
+	preds, _, err := methodForecast(method, train, testCfg)
 	if err != nil || len(preds) == 0 {
 		return 0, 0
 	}
@@ -437,17 +437,47 @@ func backtest(s Series, cfg Config, method Method) (mae, rmse float64) {
 	return mae, rmse
 }
 
-// selectBestMethod runs all methods via backtest and picks lowest RMSE.
-func selectBestMethod(s Series, cfg Config) Method {
+// autoCandidates lists the methods auto-selection considers for a series.
+// Holt-Winters needs enough history to stabilize its level/trend estimates.
+func autoCandidates(s Series) []Method {
 	candidates := []Method{MethodLinear, MethodSMA, MethodWMA}
 	if len(s) >= 14 {
 		candidates = append(candidates, MethodHoltWinters)
 	}
+	return candidates
+}
 
+// selectByRollingRMSE picks the candidate with the lowest rolling-backtest
+// RMSE. Averaging errors across many cut points makes the choice stable
+// run-to-run, unlike a single train/test split. When the series is too short
+// for any rolling cut, it falls back to the single-split selection.
+func selectByRollingRMSE(eval *rollingEval, candidates []Method, s Series, cfg Config) Method {
+	best := MethodLinear
+	bestRMSE := math.MaxFloat64
+	found := false
+	for _, m := range candidates {
+		_, rmse := eval.errorStats(m)
+		// RMSE=0 means the method produced no rolling predictions, not a
+		// perfect fit. Skip these candidates.
+		if rmse > 0 && rmse < bestRMSE {
+			bestRMSE = rmse
+			best = m
+			found = true
+		}
+	}
+	if !found {
+		return selectBestMethod(s, cfg)
+	}
+	return best
+}
+
+// selectBestMethod runs all methods via single-split backtest and picks the
+// lowest RMSE. Fallback for series too short for the rolling backtest.
+func selectBestMethod(s Series, cfg Config) Method {
 	best := MethodLinear
 	bestRMSE := math.MaxFloat64
 
-	for _, m := range candidates {
+	for _, m := range autoCandidates(s) {
 		_, rmse := backtest(s, cfg, m)
 		// RMSE=0 means backtest couldn't run (too few points for holdout),
 		// not a perfect fit. Skip these candidates.
@@ -460,17 +490,49 @@ func selectBestMethod(s Series, cfg Config) Method {
 	return best
 }
 
+// scalePrediction multiplies a prediction's value, bounds, and quantiles by
+// mult, restoring ordering afterwards: a negative multiplier inverts bound
+// and quantile order.
+func scalePrediction(p *Prediction, mult float64) {
+	p.Value *= mult
+	p.LowerBound *= mult
+	p.UpperBound *= mult
+	if p.LowerBound > p.UpperBound {
+		p.LowerBound, p.UpperBound = p.UpperBound, p.LowerBound
+	}
+	if len(p.Quantiles) == 0 {
+		return
+	}
+	for name := range p.Quantiles {
+		p.Quantiles[name] *= mult
+	}
+	normalizeQuantileOrder(p.Quantiles)
+}
+
+// normalizeQuantileOrder re-sorts quantile values so p10 ≤ p25 ≤ ... ≤ p90
+// after a transformation that may have inverted them. Only complete quantile
+// sets are reordered.
+func normalizeQuantileOrder(qs map[string]float64) {
+	vals := make([]float64, 0, len(quantileLevels))
+	for _, lv := range quantileLevels {
+		v, ok := qs[lv.name]
+		if !ok {
+			return
+		}
+		vals = append(vals, v)
+	}
+	sort.Float64s(vals)
+	for i, lv := range quantileLevels {
+		qs[lv.name] = vals[i]
+	}
+}
+
 // applySeasonalWeights adjusts prediction values by day-of-week multipliers.
 func applySeasonalWeights(preds []Prediction, weights SeasonalWeights) []Prediction {
 	for i := range preds {
 		dow := preds[i].T.Weekday()
 		if w, ok := weights[dow]; ok {
-			preds[i].Value *= w
-			preds[i].LowerBound *= w
-			preds[i].UpperBound *= w
-			if preds[i].LowerBound > preds[i].UpperBound {
-				preds[i].LowerBound, preds[i].UpperBound = preds[i].UpperBound, preds[i].LowerBound
-			}
+			scalePrediction(&preds[i], w)
 		}
 	}
 	return preds

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -151,11 +151,17 @@ type SeasonalWeights map[time.Weekday]float64
 
 // Config controls a forecast run.
 type Config struct {
-	Method          Method
-	Horizon         int
-	Interval        Interval
-	Metric          string
-	SMAWindow       int
+	Method    Method
+	Horizon   int
+	Interval  Interval
+	Metric    string
+	SMAWindow int
+	// SeasonalWeights supplies explicit day-of-week multipliers, applied as
+	// given (after the weekly gate) to the deployed fit and to every
+	// backtest fold alike. Supply weights estimated independently of the
+	// fitted history (a prior period, a business calendar): weights derived
+	// from the history itself would leak held-out values into the folds
+	// that score them — set WeekdayProfile for that instead.
 	SeasonalWeights SeasonalWeights
 	ConfidenceLevel float64 // 0.0-1.0, default 0.95
 
@@ -164,15 +170,20 @@ type Config struct {
 	// at zero.
 	NonNegative bool
 
-	// HourlyWeights maps hour-of-day (0-23) to a multiplier, for hourly
-	// forecasts. Like SeasonalWeights it is gated on detrended
-	// autocorrelation at the daily lag before being applied.
-	HourlyWeights map[int]float64
-
-	// MonthDayWeights maps day-of-month (1-31) to a multiplier — affiliate
-	// budgets and payouts often reset monthly. Applied without a gate: the
-	// profile is an explicit opt-in.
-	MonthDayWeights map[int]float64
+	// WeekdayProfile, HourlyProfile, and MonthDayProfile derive the
+	// corresponding multiplier profile from the training data itself,
+	// re-estimated (with shrinkage) from each training prefix — the
+	// deployed fit and every backtest fold — so bands and errors describe
+	// the profiled forecaster without leaking held-out points into their
+	// own multiplier. The weekday and hourly profiles are gated on
+	// detrended autocorrelation at their lag (measured on the same prefix);
+	// the day-of-month profile is an explicit opt-in with no gate.
+	// HourlyProfile applies to the hour interval only. Multiplicative
+	// profiles need non-negative data: a prefix with negative values gets
+	// none. WeekdayProfile is ignored when SeasonalWeights are supplied.
+	WeekdayProfile  bool
+	HourlyProfile   bool
+	MonthDayProfile bool
 
 	// LogTransform fits count-like non-negative series on log1p scale and
 	// inverts on output, making multiplicative behavior additive and
@@ -203,13 +214,6 @@ type Config struct {
 	// masked (e.g. event days removed) so predictions still start after
 	// the last real observation rather than inside masked history.
 	Anchor time.Time
-
-	// profile returns the seasonal multiplier for a prediction timestamp
-	// (weekday × hourly × day-of-month, over the profiles Run decided to
-	// apply). Set by Run, never by callers. It is applied to the deployed
-	// fit and inside every backtest fold before bounds are attached, so
-	// bands and errors describe the seasonally adjusted forecaster.
-	profile func(t time.Time) float64
 }
 
 // anchorTime returns the reference point predictions step forward from.
@@ -275,7 +279,6 @@ func withDefaults(cfg Config) Config {
 	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
 		cfg.ConfidenceLevel = 0.95
 	}
-	cfg.profile = nil
 	return cfg
 }
 
@@ -330,11 +333,6 @@ func Run(series Series, cfg Config) (*Result, error) {
 		}
 	}
 
-	// Seasonal gates measure the full (pre-truncation) history: a shift
-	// that leaves only a short recent window must not erase evidence of a
-	// weekly pattern the longer history carries.
-	gateSeries := work
-
 	// Level-shift handling: fit on the current regime, not a blend of
 	// regimes. Post-shift history is used alone when long enough; otherwise
 	// trainingView re-levels older observations to the new regime. Both the
@@ -356,40 +354,15 @@ func Run(series Series, cfg Config) (*Result, error) {
 		cfg.SMAWindow = defaultSMAWindow(len(work))
 	}
 
-	// Decide the seasonal profiles now, before fitting, so they scale the
-	// deployed fit and every backtest fold alike and the bands calibrate
-	// the forecaster that is actually emitted. Weekday and hourly weights
-	// are gated on detrended autocorrelation at their lag so spurious
-	// profiles (built from noise) don't degrade the forecast; when the
-	// history is too short to measure that lag there is no evidence against
-	// the profile and it applies as supplied. Day-of-month weights are an
-	// explicit opt-in and apply as supplied.
-	var profiles []string
-	var scalers []func(time.Time) float64
-	if len(cfg.SeasonalWeights) > 0 && seasonalGateAllows(gateSeries, 7*24*time.Hour) {
-		weekday := cfg.SeasonalWeights
-		scalers = append(scalers, func(t time.Time) float64 { return weekdayWeight(weekday, t.Weekday()) })
-		profiles = append(profiles, "weekday")
-	}
-	if len(cfg.HourlyWeights) > 0 && cfg.Interval == IntervalHour && seasonalGateAllows(gateSeries, 24*time.Hour) {
-		hourly := cfg.HourlyWeights
-		scalers = append(scalers, func(t time.Time) float64 { return slotWeight(hourly, t.Hour()) })
-		profiles = append(profiles, "hourly")
-	}
-	if len(cfg.MonthDayWeights) > 0 {
-		monthDay := cfg.MonthDayWeights
-		scalers = append(scalers, func(t time.Time) float64 { return slotWeight(monthDay, t.Day()) })
-		profiles = append(profiles, "monthday")
-	}
-	if len(scalers) > 0 {
-		cfg.profile = func(t time.Time) float64 {
-			f := 1.0
-			for _, scale := range scalers {
-				f *= scale(t)
-			}
-			return f
-		}
-	}
+	// Seasonal profiles are estimated from the training data by every fit
+	// (profileFor): the deployed fit here and each backtest fold on its own
+	// prefix, so the bands calibrate the profiled forecaster that is
+	// actually emitted. Weekday and hourly profiles are gated on detrended
+	// autocorrelation at their lag so spurious profiles (built from noise)
+	// don't degrade the forecast; when the history is too short to measure
+	// that lag there is no evidence against the profile and it applies.
+	// The names reported in meta are the deployed fit's.
+	_, profiles := profileFor(work, cfg, len(work))
 
 	var core forecastCore
 	var err error
@@ -539,7 +512,8 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 	if err != nil {
 		return forecastCore{}, err
 	}
-	applyProfile(predictions, cfg)
+	profile, _ := profileFor(series, cfg, len(series))
+	applyProfile(predictions, profile, cfg.LogTransform)
 
 	if eval == nil {
 		eval = runRollingBacktest(series, cfg, []Method{method})
@@ -594,6 +568,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 
 	// Fit each member on the full series. A member that fails to fit here
 	// (despite backtesting) is dropped and weights renormalize.
+	profile, _ := profileFor(series, cfg, len(series))
 	memberPreds := map[Method][]Prediction{}
 	memberTrend := map[Method]float64{}
 	members := make([]Method, 0, len(weights))
@@ -606,7 +581,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 			delete(weights, m)
 			continue
 		}
-		applyProfile(preds, cfg)
+		applyProfile(preds, profile, cfg.LogTransform)
 		memberPreds[m] = preds
 		memberTrend[m] = tr
 		members = append(members, m)
@@ -805,14 +780,14 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 	// reaches the farthest held-out point.
 	testCfg := cfg
 	testCfg.Horizon = calendarSteps(trainEnd, test[len(test)-1].T, cfg.Interval)
-	testCfg.SeasonalWeights = nil
 	testCfg.Anchor = time.Time{}
 
 	preds, _, err := methodForecast(method, train, testCfg)
 	if err != nil || len(preds) == 0 {
 		return seriesStdDev(s), 0, 0
 	}
-	applyProfile(preds, cfg)
+	profile, _ := profileFor(s, cfg, c)
+	applyProfile(preds, profile, cfg.LogTransform)
 
 	n := 0
 	sumSqModel, sumAbs, sumSq := 0.0, 0.0, 0.0
@@ -991,41 +966,24 @@ func normalizeQuantileOrder(qs map[string]float64) {
 	}
 }
 
-// weekdayWeight returns the multiplier a weekday profile defines for d, or
-// 1 when the day is absent.
-func weekdayWeight(weights SeasonalWeights, d time.Weekday) float64 {
-	if w, ok := weights[d]; ok {
-		return w
-	}
-	return 1
-}
-
-// slotWeight returns the multiplier an integer-slot profile defines for
-// slot, or 1 when the slot is absent.
-func slotWeight(weights map[int]float64, slot int) float64 {
-	if w, ok := weights[slot]; ok {
-		return w
-	}
-	return 1
-}
-
-// applyProfile scales point predictions by the seasonal profile for their
-// timestamps. A profile is multiplicative on the reporting scale, so under
-// the log1p transform it is applied through the transform (a model-scale
-// value whose reporting value is not positive is left alone: scaling it is
-// meaningless and the output clip zeroes it anyway). Bounds and quantiles
-// are attached afterwards, so they calibrate the adjusted forecaster; the
-// same call runs inside every backtest fold.
-func applyProfile(preds []Prediction, cfg Config) {
-	if cfg.profile == nil {
+// applyProfile scales point predictions by a seasonal profile (nil for
+// none) for their timestamps. A profile is multiplicative on the reporting
+// scale, so under the log1p transform it is applied through the transform
+// (a model-scale value whose reporting value is not positive is left alone:
+// scaling it is meaningless and the output clip zeroes it anyway). Bounds
+// and quantiles are attached afterwards, so they calibrate the adjusted
+// forecaster; the same call runs inside every backtest fold with that
+// fold's own profile.
+func applyProfile(preds []Prediction, profile func(time.Time) float64, logScale bool) {
+	if profile == nil {
 		return
 	}
 	for i := range preds {
-		w := cfg.profile(preds[i].T)
+		w := profile(preds[i].T)
 		if w == 1 {
 			continue
 		}
-		if !cfg.LogTransform {
+		if !logScale {
 			preds[i].Value *= w
 			continue
 		}
@@ -1033,4 +991,13 @@ func applyProfile(preds []Prediction, cfg Config) {
 			preds[i].Value = math.Log1p(v * w)
 		}
 	}
+}
+
+// expm1Series maps a log1p-scale series back to the reporting scale.
+func expm1Series(s Series) Series {
+	out := make(Series, len(s))
+	for i, p := range s {
+		out[i] = Point{T: p.T, V: math.Expm1(p.V)}
+	}
+	return out
 }

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -290,7 +290,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 	// must still start after them, so the anchor moves to the true end.
 	var anomalies []string
 	if cfg.NonNegative && !cfg.DisableAnomalyMask {
-		if idx := detectTransients(work, cfg.Interval, cfg.AnomalySigma, cfg.AnomalyCycles); len(idx) > 0 {
+		if idx := detectTransients(work, cfg.Interval, logApplied, cfg.AnomalySigma, cfg.AnomalyCycles); len(idx) > 0 {
 			for _, i := range idx {
 				anomalies = append(anomalies, formatShiftTime(work[i].T, cfg.Interval))
 			}

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -198,11 +198,6 @@ type Config struct {
 	AnomalySigma  float64
 	AnomalyCycles int
 
-	// relevel carries a detected level shift handled by re-leveling; every
-	// fit reads its training data through trainingView so backtest folds
-	// re-level from their own prefix only. Set by Run.
-	relevel *levelShift
-
 	// Anchor, when set, is the timestamp predictions step forward from
 	// instead of the series' last point. Used when training data has been
 	// masked (e.g. event days removed) so predictions still start after
@@ -273,7 +268,6 @@ func withDefaults(cfg Config) Config {
 	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
 		cfg.ConfidenceLevel = 0.95
 	}
-	cfg.relevel = nil
 	return cfg
 }
 
@@ -335,16 +329,16 @@ func Run(series Series, cfg Config) (*Result, error) {
 
 	// Level-shift handling: fit on the current regime, not a blend of
 	// regimes. Post-shift history is used alone when long enough; otherwise
-	// older observations are re-leveled to the new regime, per training
-	// prefix so backtest folds never see their held-out points.
+	// trainingView re-levels older observations to the new regime. Both the
+	// deployed fit and every backtest prefix run their own detection
+	// (trainingView), so this full-series pass only reports the shift and
+	// trims the data the run describes.
 	levelShiftAt := ""
 	if !cfg.DisableLevelShift {
 		if ls := detectLevelShift(work); ls != nil {
 			levelShiftAt = formatShiftTime(work[ls.idx].T, cfg.Interval)
 			if ls.truncates(len(work), cfg.Interval) {
 				work = work[ls.idx:]
-			} else {
-				cfg.relevel = ls
 			}
 		}
 	}
@@ -559,14 +553,17 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 // computeEnsemble produces the ensemble forecast: a weighted average of all
 // applicable methods' point forecasts, weighted and pruned by their
 // recency-discounted rolling-backtest RMSE (see ensembleWeights).
-// Conformal bounds are computed on the ensemble's own rolling
-// residuals, so the band reflects the combined forecaster that is actually
-// deployed. When the series is too short for any rolling cut, it falls back
-// to the best single method by single-split backtest.
+// Conformal bounds and error statistics come from the ensemble procedure's
+// own rolling residuals, evaluated out of sample: each backtest row is
+// predicted with weights derived only from rows observed before it (see
+// nestedEnsemblePredictor), so the band reflects the combined forecaster
+// that is actually deployed without letting a row's own actual shape the
+// weights that predict it. When the series is too short for any rolling
+// cut, it falls back to the best single method by single-split backtest.
 func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 	candidates := autoCandidates(series)
 	eval := runRollingBacktest(series, cfg, candidates)
-	weights := ensembleWeights(eval, candidates)
+	weights := ensembleWeights(eval, candidates, nil)
 	if len(weights) == 0 {
 		return computeSingle(series, cfg, selectBestMethod(series, cfg), eval)
 	}
@@ -609,9 +606,10 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 		trend += weights[m] * memberTrend[m]
 	}
 
-	// Conformal bounds on the ensemble's rolling residuals.
+	// Conformal bounds on the ensemble procedure's out-of-sample rolling
+	// residuals.
 	offset := anchorOffset(series, cfg)
-	predict := ensemblePredictor(weights, members)
+	predict := nestedEnsemblePredictor(eval, candidates)
 	byStep := eval.residualsByStep(predict)
 	mae, rmse, _ := eval.errorStats(predict)
 	source := BoundsConformal
@@ -651,11 +649,12 @@ const ensembleDropFactor = 1.15
 
 // ensembleWeights derives member weights from the recency-weighted
 // rolling-backtest RMSE: w ∝ 1/(rmse + ε)², dropping methods whose RMSE
-// exceeds ensembleDropFactor times the best. Returns nil when no candidate
-// produced rolling predictions.
-func ensembleWeights(eval *rollingEval, candidates []Method) map[Method]float64 {
+// exceeds ensembleDropFactor times the best. include, when non-nil,
+// restricts the rows the RMSE is measured on. Returns nil when no candidate
+// produced rolling predictions on those rows.
+func ensembleWeights(eval *rollingEval, candidates []Method, include func(evalRow) bool) map[Method]float64 {
 	const eps = 1e-9
-	rmses := eval.recencyRMSE(candidates)
+	rmses := eval.recencyRMSE(candidates, include)
 	if len(rmses) == 0 {
 		return nil
 	}
@@ -677,6 +676,35 @@ func ensembleWeights(eval *rollingEval, candidates []Method) map[Method]float64 
 		weights[m] = 1 / ((rmse + eps) * (rmse + eps))
 	}
 	return weights
+}
+
+// nestedEnsemblePredictor evaluates the ensemble procedure out of sample.
+// Deriving weights from the rolling rows and then scoring those same rows
+// with them would let each residual's own actual influence the weights that
+// produced it, flattering MAE/RMSE and narrowing the band below its
+// nominal coverage, most visibly when the pruning decision hinges on a few
+// rows. Instead a row from cut c is predicted with weights derived only
+// from rows whose targets were observed by that cut's training end, which
+// is what the procedure would have had at the time. The earliest cut, with
+// no history to weight from, uses equal weights over the members that
+// predicted it. Weights are cached per cut.
+func nestedEnsemblePredictor(e *rollingEval, candidates []Method) rowPredictor {
+	cache := map[int]map[Method]float64{}
+	return func(r evalRow) (float64, bool) {
+		w, ok := cache[r.cut]
+		if !ok {
+			trainEnd := r.trainEnd
+			w = ensembleWeights(e, candidates, func(o evalRow) bool { return !o.t.After(trainEnd) })
+			if len(w) == 0 {
+				w = make(map[Method]float64, len(candidates))
+				for _, m := range candidates {
+					w[m] = 1
+				}
+			}
+			cache[r.cut] = w
+		}
+		return ensembleCombine(r, w, candidates)
+	}
 }
 
 // normalizeWeights scales the members' weights to sum to 1.

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -92,6 +92,10 @@ type Result struct {
 	// Weights reports each member method's share of an ensemble forecast
 	// (summing to 1); empty for single-method runs.
 	Weights map[string]float64 `json:"weights,omitempty"`
+	// Composition reports how a RunCoherent result was produced: "derived"
+	// (composed from driver forecasts) or "direct" (the metric's own series
+	// forecast directly). Empty for plain Run results.
+	Composition string `json:"composition,omitempty"`
 }
 
 // SeasonalWeights maps day-of-week (time.Weekday) to a multiplier.

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -203,6 +203,13 @@ type Config struct {
 	// masked (e.g. event days removed) so predictions still start after
 	// the last real observation rather than inside masked history.
 	Anchor time.Time
+
+	// profile returns the seasonal multiplier for a prediction timestamp
+	// (weekday × hourly × day-of-month, over the profiles Run decided to
+	// apply). Set by Run, never by callers. It is applied to the deployed
+	// fit and inside every backtest fold before bounds are attached, so
+	// bands and errors describe the seasonally adjusted forecaster.
+	profile func(t time.Time) float64
 }
 
 // anchorTime returns the reference point predictions step forward from.
@@ -268,6 +275,7 @@ func withDefaults(cfg Config) Config {
 	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
 		cfg.ConfidenceLevel = 0.95
 	}
+	cfg.profile = nil
 	return cfg
 }
 
@@ -348,6 +356,41 @@ func Run(series Series, cfg Config) (*Result, error) {
 		cfg.SMAWindow = defaultSMAWindow(len(work))
 	}
 
+	// Decide the seasonal profiles now, before fitting, so they scale the
+	// deployed fit and every backtest fold alike and the bands calibrate
+	// the forecaster that is actually emitted. Weekday and hourly weights
+	// are gated on detrended autocorrelation at their lag so spurious
+	// profiles (built from noise) don't degrade the forecast; when the
+	// history is too short to measure that lag there is no evidence against
+	// the profile and it applies as supplied. Day-of-month weights are an
+	// explicit opt-in and apply as supplied.
+	var profiles []string
+	var scalers []func(time.Time) float64
+	if len(cfg.SeasonalWeights) > 0 && seasonalGateAllows(gateSeries, 7*24*time.Hour) {
+		weekday := cfg.SeasonalWeights
+		scalers = append(scalers, func(t time.Time) float64 { return weekdayWeight(weekday, t.Weekday()) })
+		profiles = append(profiles, "weekday")
+	}
+	if len(cfg.HourlyWeights) > 0 && cfg.Interval == IntervalHour && seasonalGateAllows(gateSeries, 24*time.Hour) {
+		hourly := cfg.HourlyWeights
+		scalers = append(scalers, func(t time.Time) float64 { return slotWeight(hourly, t.Hour()) })
+		profiles = append(profiles, "hourly")
+	}
+	if len(cfg.MonthDayWeights) > 0 {
+		monthDay := cfg.MonthDayWeights
+		scalers = append(scalers, func(t time.Time) float64 { return slotWeight(monthDay, t.Day()) })
+		profiles = append(profiles, "monthday")
+	}
+	if len(scalers) > 0 {
+		cfg.profile = func(t time.Time) float64 {
+			f := 1.0
+			for _, scale := range scalers {
+				f *= scale(t)
+			}
+			return f
+		}
+	}
+
 	var core forecastCore
 	var err error
 	if method == MethodEnsemble {
@@ -385,26 +428,6 @@ func Run(series Series, cfg Config) (*Result, error) {
 			}
 			rolling[rollingKey{trainEnd: r.trainEnd, target: r.t}] = pred
 		}
-	}
-
-	// Apply seasonal profiles. Weekday and hourly weights are gated on
-	// detrended autocorrelation at their lag so spurious profiles (built
-	// from noise) don't degrade the forecast; when the history is too short
-	// to measure that lag there is no evidence against the profile and it
-	// applies as supplied. Day-of-month weights are an explicit opt-in and
-	// apply as supplied.
-	var profiles []string
-	if len(cfg.SeasonalWeights) > 0 && seasonalGateAllows(gateSeries, 7*24*time.Hour) {
-		core.preds = applySeasonalWeights(core.preds, cfg.SeasonalWeights)
-		profiles = append(profiles, "weekday")
-	}
-	if len(cfg.HourlyWeights) > 0 && cfg.Interval == IntervalHour && seasonalGateAllows(gateSeries, 24*time.Hour) {
-		core.preds = applyHourlyWeights(core.preds, cfg.HourlyWeights)
-		profiles = append(profiles, "hourly")
-	}
-	if len(cfg.MonthDayWeights) > 0 {
-		core.preds = applyMonthDayWeights(core.preds, cfg.MonthDayWeights)
-		profiles = append(profiles, "monthday")
 	}
 
 	if cfg.NonNegative {
@@ -516,6 +539,7 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 	if err != nil {
 		return forecastCore{}, err
 	}
+	applyProfile(predictions, cfg)
 
 	if eval == nil {
 		eval = runRollingBacktest(series, cfg, []Method{method})
@@ -582,6 +606,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 			delete(weights, m)
 			continue
 		}
+		applyProfile(preds, cfg)
 		memberPreds[m] = preds
 		memberTrend[m] = tr
 		members = append(members, m)
@@ -772,10 +797,14 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 
 	c := len(s) - holdout
 	train := trainingView(s, cfg, c)
+	trainEnd := train[len(train)-1].T
 	test := s[c:]
 
+	// Held-out points are matched to prediction steps by calendar distance
+	// (masked gaps make it exceed the observation count), so the horizon
+	// reaches the farthest held-out point.
 	testCfg := cfg
-	testCfg.Horizon = holdout
+	testCfg.Horizon = calendarSteps(trainEnd, test[len(test)-1].T, cfg.Interval)
 	testCfg.SeasonalWeights = nil
 	testCfg.Anchor = time.Time{}
 
@@ -783,14 +812,16 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 	if err != nil || len(preds) == 0 {
 		return seriesStdDev(s), 0, 0
 	}
+	applyProfile(preds, cfg)
 
-	n := len(preds)
-	if n > len(test) {
-		n = len(test)
-	}
+	n := 0
 	sumSqModel, sumAbs, sumSq := 0.0, 0.0, 0.0
-	for i := 0; i < n; i++ {
-		actual, pred := test[i].V, preds[i].Value
+	for _, p := range test {
+		h, ok := stepIndex(trainEnd, p.T, cfg.Interval, len(preds))
+		if !ok {
+			continue
+		}
+		actual, pred := p.V, preds[h-1].Value
 		modelDiff := actual - pred
 		sumSqModel += modelDiff * modelDiff
 		if cfg.LogTransform {
@@ -800,9 +831,35 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 		diff := actual - pred
 		sumAbs += math.Abs(diff)
 		sumSq += diff * diff
+		n++
+	}
+	if n == 0 {
+		return seriesStdDev(s), 0, 0
 	}
 	fn := float64(n)
 	return math.Sqrt(sumSqModel / fn), sumAbs / fn, math.Sqrt(sumSq / fn)
+}
+
+// calendarSteps returns the number of whole interval steps from from to to,
+// at least 1.
+func calendarSteps(from, to time.Time, interval Interval) int {
+	steps := int(math.Round(intervalSteps(from, to, interval)))
+	if steps < 1 {
+		return 1
+	}
+	return steps
+}
+
+// stepIndex maps a held-out timestamp to its 1-based horizon step from
+// trainEnd; ok is false when it is not a whole step away or lies beyond
+// maxStep.
+func stepIndex(trainEnd, t time.Time, interval Interval, maxStep int) (int, bool) {
+	exact := intervalSteps(trainEnd, t, interval)
+	h := int(math.Round(exact))
+	if math.Abs(exact-float64(h)) > 0.01 || h < 1 || h > maxStep {
+		return 0, false
+	}
+	return h, true
 }
 
 // zScore returns the z-score for a given confidence level (two-tailed).
@@ -934,33 +991,46 @@ func normalizeQuantileOrder(qs map[string]float64) {
 	}
 }
 
-// applySeasonalWeights adjusts prediction values by day-of-week multipliers.
-func applySeasonalWeights(preds []Prediction, weights SeasonalWeights) []Prediction {
-	for i := range preds {
-		dow := preds[i].T.Weekday()
-		if w, ok := weights[dow]; ok {
-			scalePrediction(&preds[i], w)
-		}
+// weekdayWeight returns the multiplier a weekday profile defines for d, or
+// 1 when the day is absent.
+func weekdayWeight(weights SeasonalWeights, d time.Weekday) float64 {
+	if w, ok := weights[d]; ok {
+		return w
 	}
-	return preds
+	return 1
 }
 
-// applyHourlyWeights adjusts prediction values by hour-of-day multipliers.
-func applyHourlyWeights(preds []Prediction, weights map[int]float64) []Prediction {
-	for i := range preds {
-		if w, ok := weights[preds[i].T.Hour()]; ok {
-			scalePrediction(&preds[i], w)
-		}
+// slotWeight returns the multiplier an integer-slot profile defines for
+// slot, or 1 when the slot is absent.
+func slotWeight(weights map[int]float64, slot int) float64 {
+	if w, ok := weights[slot]; ok {
+		return w
 	}
-	return preds
+	return 1
 }
 
-// applyMonthDayWeights adjusts prediction values by day-of-month multipliers.
-func applyMonthDayWeights(preds []Prediction, weights map[int]float64) []Prediction {
+// applyProfile scales point predictions by the seasonal profile for their
+// timestamps. A profile is multiplicative on the reporting scale, so under
+// the log1p transform it is applied through the transform (a model-scale
+// value whose reporting value is not positive is left alone: scaling it is
+// meaningless and the output clip zeroes it anyway). Bounds and quantiles
+// are attached afterwards, so they calibrate the adjusted forecaster; the
+// same call runs inside every backtest fold.
+func applyProfile(preds []Prediction, cfg Config) {
+	if cfg.profile == nil {
+		return
+	}
 	for i := range preds {
-		if w, ok := weights[preds[i].T.Day()]; ok {
-			scalePrediction(&preds[i], w)
+		w := cfg.profile(preds[i].T)
+		if w == 1 {
+			continue
+		}
+		if !cfg.LogTransform {
+			preds[i].Value *= w
+			continue
+		}
+		if v := math.Expm1(preds[i].Value); v > 0 {
+			preds[i].Value = math.Log1p(v * w)
 		}
 	}
-	return preds
 }

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -64,11 +64,11 @@ type Series []Point
 //
 // Bounds come from rolling-origin conformal prediction: empirical quantiles
 // of held-out residuals bucketed by horizon step. LowerBound/UpperBound carry
-// the quantile pair nearest the configured confidence level (P10/P90 for the
-// default levels — an 80% interval) and are asymmetric by nature. Quantiles
-// holds the full set ("p10", "p25", "p50", "p75", "p90"); it is empty when
-// the series is too short for a rolling backtest, in which case bounds fall
-// back to symmetric Gaussian estimates.
+// the quantile pair nearest the configured confidence level (P05/P95 for the
+// 0.95 default — a 90% interval, see boundPair) and are asymmetric by
+// nature. Quantiles holds the full set ("p05" … "p95"); it is empty when the
+// series is too short for a rolling backtest, in which case bounds fall back
+// to symmetric Gaussian estimates.
 type Prediction struct {
 	T          time.Time          `json:"time"`
 	Value      float64            `json:"value"`
@@ -114,18 +114,36 @@ type Result struct {
 	SeasonalApplied  bool     `json:"seasonal_applied,omitempty"`
 	SeasonalProfiles []string `json:"seasonal_profiles,omitempty"`
 	// BoundsSource reports how bounds were produced: "conformal" (rolling
-	// residual quantiles), "gaussian" (short-series symmetric fallback), or
-	// for RunCoherent derived metrics "mixed" when the composed operands
-	// disagree (the band then has no single nominal level).
+	// residual quantiles — for RunCoherent derived metrics, residuals of the
+	// composed forecast itself), "gaussian" (short-series symmetric
+	// fallback), or "composed" (a derived metric whose operands had too few
+	// paired rolling predictions to recalibrate: its band pairs the
+	// operands' band endpoints at worst-case dependence, which is valid but
+	// carries no single nominal coverage).
 	BoundsSource string `json:"bounds_source,omitempty"`
+
+	// rolling holds the deployed forecaster's rolling-backtest predictions
+	// on the reporting scale (transform inverted, zero-clipped like the
+	// output, no seasonal profile), keyed by the training window they were
+	// made from and the point they targeted. RunCoherent composes operands'
+	// entries to backtest derived metrics (see finishComposed).
+	rolling map[rollingKey]float64
 }
 
 // Bounds sources reported in Result.BoundsSource.
 const (
 	BoundsConformal = "conformal"
 	BoundsGaussian  = "gaussian"
-	BoundsMixed     = "mixed"
+	BoundsComposed  = "composed"
 )
+
+// rollingKey identifies one rolling-backtest prediction by the last training
+// timestamp and the target timestamp. Timestamps are compared as map keys,
+// so operands must share the calendar the report buckets were parsed in
+// (they do: RunCoherent derives every series from the same buckets).
+type rollingKey struct {
+	trainEnd, target time.Time
+}
 
 // SeasonalWeights maps day-of-week (time.Weekday) to a multiplier.
 // A weight of 1.0 means average; 1.2 means 20% above average for that day.
@@ -242,6 +260,23 @@ func ValidIntervals() []string {
 	}
 }
 
+// withDefaults fills the Config fields Run and RunCoherent share defaults
+// for, so composed forecasts use the same horizon, interval, and band pair
+// as the parts they are built from.
+func withDefaults(cfg Config) Config {
+	if cfg.Horizon <= 0 {
+		cfg.Horizon = 7
+	}
+	if cfg.Interval == "" {
+		cfg.Interval = IntervalDay
+	}
+	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
+		cfg.ConfidenceLevel = 0.95
+	}
+	cfg.relevel = nil
+	return cfg
+}
+
 // Run executes a forecast on the given series with the provided configuration.
 func Run(series Series, cfg Config) (*Result, error) {
 	if len(series) < 3 {
@@ -253,16 +288,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 		return series[i].T.Before(series[j].T)
 	})
 
-	if cfg.Horizon <= 0 {
-		cfg.Horizon = 7
-	}
-	if cfg.Interval == "" {
-		cfg.Interval = IntervalDay
-	}
-	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
-		cfg.ConfidenceLevel = 0.95
-	}
-	cfg.relevel = nil
+	cfg = withDefaults(cfg)
 
 	method := cfg.Method
 	if method == "" || method == MethodAuto {
@@ -347,6 +373,26 @@ func Run(series Series, cfg Config) (*Result, error) {
 		core.trend = math.Expm1(core.trend) * core.preds[0].Value
 	}
 
+	// Keep the deployed forecaster's rolling predictions on the reporting
+	// scale so compositions of this result can be backtested too.
+	var rolling map[rollingKey]float64
+	if core.eval != nil && core.predict != nil {
+		rolling = make(map[rollingKey]float64, len(core.eval.rows))
+		for _, r := range core.eval.rows {
+			pred, ok := core.predict(r)
+			if !ok {
+				continue
+			}
+			if logApplied {
+				pred = math.Expm1(pred)
+			}
+			if cfg.NonNegative && pred < 0 {
+				pred = 0
+			}
+			rolling[rollingKey{trainEnd: r.trainEnd, target: r.t}] = pred
+		}
+	}
+
 	// Apply seasonal profiles. Weekday and hourly weights are gated on
 	// detrended autocorrelation at their lag so spurious profiles (built
 	// from noise) don't degrade the forecast; when the history is too short
@@ -395,6 +441,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 		SeasonalApplied:  len(profiles) > 0,
 		SeasonalProfiles: profiles,
 		BoundsSource:     core.boundsSource,
+		rolling:          rolling,
 	}, nil
 }
 
@@ -461,6 +508,10 @@ type forecastCore struct {
 	mae, rmse    float64
 	weights      map[string]float64 // ensemble only
 	boundsSource string
+	// eval and predict expose the rolling backtest and the deployed
+	// forecaster's view of it (single method or weighted ensemble).
+	eval    *rollingEval
+	predict rowPredictor
 }
 
 // computeSingle produces a single-method forecast with conformal bounds.
@@ -476,8 +527,9 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 		eval = runRollingBacktest(series, cfg, []Method{method})
 	}
 	offset := anchorOffset(series, cfg)
-	byStep := eval.residualsByStep(eval.methodPredictor(method))
-	mae, rmse, _ := eval.errorStats(eval.methodPredictor(method))
+	predict := eval.methodPredictor(method)
+	byStep := eval.residualsByStep(predict)
+	mae, rmse, _ := eval.errorStats(predict)
 	source := BoundsConformal
 	if totalResiduals(byStep) >= minTotalResiduals {
 		sq := stepQuantiles(byStep, offset+cfg.Horizon)
@@ -499,6 +551,8 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 		mae:          mae,
 		rmse:         rmse,
 		boundsSource: source,
+		eval:         eval,
+		predict:      predict,
 	}, nil
 }
 
@@ -583,6 +637,8 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 		rmse:         rmse,
 		weights:      named,
 		boundsSource: source,
+		eval:         eval,
+		predict:      predict,
 	}, nil
 }
 

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -34,7 +34,11 @@ const (
 	MethodSMA         Method = "sma"
 	MethodWMA         Method = "wma"
 	MethodHoltWinters Method = "holtwinters"
-	MethodAuto        Method = "auto"
+	// MethodEnsemble combines all applicable methods as a weighted average,
+	// weighted by inverse squared recency-discounted rolling-backtest RMSE
+	// (see ensembleWeights). MethodAuto is an alias for it.
+	MethodEnsemble Method = "ensemble"
+	MethodAuto     Method = "auto"
 )
 
 // Interval defines the time granularity of forecasted points.
@@ -85,6 +89,9 @@ type Result struct {
 	MAE         float64      `json:"mae"`
 	RMSE        float64      `json:"rmse"`
 	DataPoints  int          `json:"data_points_used"`
+	// Weights reports each member method's share of an ensemble forecast
+	// (summing to 1); empty for single-method runs.
+	Weights map[string]float64 `json:"weights,omitempty"`
 }
 
 // SeasonalWeights maps day-of-week (time.Weekday) to a multiplier.
@@ -155,6 +162,7 @@ func ValidMethods() []string {
 		string(MethodSMA),
 		string(MethodWMA),
 		string(MethodHoltWinters),
+		string(MethodEnsemble),
 		string(MethodAuto),
 	}
 }
@@ -194,26 +202,79 @@ func Run(series Series, cfg Config) (*Result, error) {
 	}
 
 	method := cfg.Method
-	var eval *rollingEval
 	if method == "" || method == MethodAuto {
-		candidates := autoCandidates(series)
-		eval = runRollingBacktest(series, cfg, candidates)
-		method = selectByRollingRMSE(eval, candidates, series, cfg)
+		method = MethodEnsemble
 	}
 
-	predictions, trend, err := methodForecast(method, series, cfg)
+	var core forecastCore
+	var err error
+	if method == MethodEnsemble {
+		core, err = computeEnsemble(series, cfg)
+	} else {
+		core, err = computeSingle(series, cfg, method, nil)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	// Attach bounds via rolling-origin conformal prediction. When auto-
-	// selection already ran the rolling backtest, reuse it.
+	// Apply seasonal adjustment if weights are provided.
+	if len(cfg.SeasonalWeights) > 0 {
+		core.preds = applySeasonalWeights(core.preds, cfg.SeasonalWeights)
+	}
+
+	if cfg.NonNegative {
+		clipNonNegative(core.preds)
+	}
+
+	// Compute trend percentage.
+	trendPct := 0.0
+	if len(series) > 0 {
+		mean := seriesMean(series)
+		if mean != 0 {
+			trendPct = (core.trend / mean) * 100
+		}
+	}
+
+	return &Result{
+		Method:      core.method,
+		Metric:      cfg.Metric,
+		Horizon:     cfg.Horizon,
+		Interval:    cfg.Interval,
+		Predictions: core.preds,
+		Trend:       core.trend,
+		TrendPct:    trendPct,
+		MAE:         core.mae,
+		RMSE:        core.rmse,
+		DataPoints:  len(series),
+		Weights:     core.weights,
+	}, nil
+}
+
+// forecastCore is a computed forecast before the shared post-processing
+// (seasonal adjustment, zero clipping, trend percentage) in Run.
+type forecastCore struct {
+	method    Method
+	preds     []Prediction
+	trend     float64
+	mae, rmse float64
+	weights   map[string]float64 // ensemble only
+}
+
+// computeSingle produces a single-method forecast with conformal bounds.
+// eval may carry a rolling backtest that already covers the method; pass nil
+// to have one run here.
+func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) (forecastCore, error) {
+	predictions, trend, err := methodForecast(method, series, cfg)
+	if err != nil {
+		return forecastCore{}, err
+	}
+
 	if eval == nil {
 		eval = runRollingBacktest(series, cfg, []Method{method})
 	}
 	offset := anchorOffset(series, cfg)
 	byStep := eval.residualsByStep(method)
-	mae, rmse := eval.errorStats(method)
+	mae, rmse, _ := eval.errorStats(method)
 	if totalResiduals(byStep) >= minTotalResiduals {
 		sq := stepQuantiles(byStep, offset+cfg.Horizon)
 		applyConformalBounds(predictions, sq, cfg, offset)
@@ -226,36 +287,147 @@ func Run(series Series, cfg Config) (*Result, error) {
 		mae, rmse = backtest(series, cfg, method)
 	}
 
-	// Apply seasonal adjustment if weights are provided.
-	if len(cfg.SeasonalWeights) > 0 {
-		predictions = applySeasonalWeights(predictions, cfg.SeasonalWeights)
+	return forecastCore{
+		method: method,
+		preds:  predictions,
+		trend:  trend,
+		mae:    mae,
+		rmse:   rmse,
+	}, nil
+}
+
+// computeEnsemble produces the ensemble forecast: a weighted average of all
+// applicable methods' point forecasts, weighted and pruned by their
+// recency-discounted rolling-backtest RMSE (see ensembleWeights).
+// Conformal bounds are computed on the ensemble's own rolling
+// residuals, so the band reflects the combined forecaster that is actually
+// deployed. When the series is too short for any rolling cut, it falls back
+// to the best single method by single-split backtest.
+func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
+	candidates := autoCandidates(series)
+	eval := runRollingBacktest(series, cfg, candidates)
+	weights := ensembleWeights(eval, candidates)
+	if len(weights) == 0 {
+		return computeSingle(series, cfg, selectBestMethod(series, cfg), eval)
 	}
 
-	if cfg.NonNegative {
-		clipNonNegative(predictions)
+	// Fit each member on the full series. A member that fails to fit here
+	// (despite backtesting) is dropped and weights renormalize.
+	memberPreds := map[Method][]Prediction{}
+	memberTrend := map[Method]float64{}
+	members := make([]Method, 0, len(weights))
+	for _, m := range candidates {
+		if _, ok := weights[m]; !ok {
+			continue
+		}
+		preds, tr, err := methodForecast(m, series, cfg)
+		if err != nil || len(preds) != cfg.Horizon {
+			delete(weights, m)
+			continue
+		}
+		memberPreds[m] = preds
+		memberTrend[m] = tr
+		members = append(members, m)
+	}
+	if len(members) == 0 {
+		return computeSingle(series, cfg, selectBestMethod(series, cfg), eval)
+	}
+	normalizeWeights(weights, members)
+
+	// Combine point forecasts and trends.
+	combined := make([]Prediction, cfg.Horizon)
+	for i := 0; i < cfg.Horizon; i++ {
+		combined[i].T = memberPreds[members[0]][i].T
+		v := 0.0
+		for _, m := range members {
+			v += weights[m] * memberPreds[m][i].Value
+		}
+		combined[i].Value = v
+	}
+	trend := 0.0
+	for _, m := range members {
+		trend += weights[m] * memberTrend[m]
 	}
 
-	// Compute trend percentage.
-	trendPct := 0.0
-	if len(series) > 0 {
-		mean := seriesMean(series)
-		if mean != 0 {
-			trendPct = (trend / mean) * 100
+	// Conformal bounds on the ensemble's rolling residuals.
+	offset := anchorOffset(series, cfg)
+	byStep := eval.ensembleResidualsByStep(weights, members)
+	mae, rmse := eval.ensembleErrorStats(weights, members)
+	if totalResiduals(byStep) >= minTotalResiduals {
+		sq := stepQuantiles(byStep, offset+cfg.Horizon)
+		applyConformalBounds(combined, sq, cfg, offset)
+	} else {
+		stddev := seriesStdDev(series)
+		addBounds(combined, stddev, cfg.ConfidenceLevel, offset)
+	}
+
+	named := make(map[string]float64, len(weights))
+	for _, m := range members {
+		named[string(m)] = weights[m]
+	}
+
+	return forecastCore{
+		method:  MethodEnsemble,
+		preds:   combined,
+		trend:   trend,
+		mae:     mae,
+		rmse:    rmse,
+		weights: named,
+	}, nil
+}
+
+// ensembleDropFactor excludes members whose recency-weighted rolling RMSE
+// exceeds this multiple of the best member's: a clearly-worse method only
+// adds noise to the mix. The tight factor keeps the ensemble concentrated on
+// near-best methods — a stabilized selection with hedging between equals —
+// which measured better out of sample than softer mixes.
+const ensembleDropFactor = 1.15
+
+// ensembleWeights derives member weights from the recency-weighted
+// rolling-backtest RMSE: w ∝ 1/(rmse + ε)², dropping methods whose RMSE
+// exceeds ensembleDropFactor times the best. Returns nil when no candidate
+// produced rolling predictions.
+func ensembleWeights(eval *rollingEval, candidates []Method) map[Method]float64 {
+	const eps = 1e-9
+	rmses := eval.recencyRMSE(candidates)
+	if len(rmses) == 0 {
+		return nil
+	}
+	best := math.MaxFloat64
+	for _, rmse := range rmses {
+		if rmse < best {
+			best = rmse
 		}
 	}
+	weights := map[Method]float64{}
+	for _, m := range candidates {
+		rmse, ok := rmses[m]
+		if !ok || rmse > ensembleDropFactor*best {
+			continue
+		}
+		// Inverse-MSE (Bates–Granger) weighting on the recency-discounted
+		// error, so the mix concentrates on methods that are accurate in the
+		// current regime.
+		weights[m] = 1 / ((rmse + eps) * (rmse + eps))
+	}
+	return weights
+}
 
-	return &Result{
-		Method:      method,
-		Metric:      cfg.Metric,
-		Horizon:     cfg.Horizon,
-		Interval:    cfg.Interval,
-		Predictions: predictions,
-		Trend:       trend,
-		TrendPct:    trendPct,
-		MAE:         mae,
-		RMSE:        rmse,
-		DataPoints:  len(series),
-	}, nil
+// normalizeWeights scales the members' weights to sum to 1.
+func normalizeWeights(weights map[Method]float64, members []Method) {
+	sum := 0.0
+	for _, m := range members {
+		sum += weights[m]
+	}
+	if sum <= 0 {
+		for _, m := range members {
+			weights[m] = 1 / float64(len(members))
+		}
+		return
+	}
+	for _, m := range members {
+		weights[m] /= sum
+	}
 }
 
 // defaultSMAWindow picks a reasonable SMA window based on series length.
@@ -445,30 +617,6 @@ func autoCandidates(s Series) []Method {
 		candidates = append(candidates, MethodHoltWinters)
 	}
 	return candidates
-}
-
-// selectByRollingRMSE picks the candidate with the lowest rolling-backtest
-// RMSE. Averaging errors across many cut points makes the choice stable
-// run-to-run, unlike a single train/test split. When the series is too short
-// for any rolling cut, it falls back to the single-split selection.
-func selectByRollingRMSE(eval *rollingEval, candidates []Method, s Series, cfg Config) Method {
-	best := MethodLinear
-	bestRMSE := math.MaxFloat64
-	found := false
-	for _, m := range candidates {
-		_, rmse := eval.errorStats(m)
-		// RMSE=0 means the method produced no rolling predictions, not a
-		// perfect fit. Skip these candidates.
-		if rmse > 0 && rmse < bestRMSE {
-			bestRMSE = rmse
-			best = m
-			found = true
-		}
-	}
-	if !found {
-		return selectBestMethod(s, cfg)
-	}
-	return best
 }
 
 // selectBestMethod runs all methods via single-split backtest and picks the

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -104,8 +104,23 @@ type Result struct {
 	// actually adjusted the predictions: weekday and hourly weights are
 	// gated on detrended autocorrelation at the seasonal lag, so weights
 	// built from a series with no real weekly/daily structure are ignored.
-	SeasonalApplied bool `json:"seasonal_applied,omitempty"`
+	// SeasonalProfiles names the profiles that applied ("weekday",
+	// "hourly", "monthday").
+	SeasonalApplied  bool     `json:"seasonal_applied,omitempty"`
+	SeasonalProfiles []string `json:"seasonal_profiles,omitempty"`
+	// BoundsSource reports how bounds were produced: "conformal" (rolling
+	// residual quantiles), "gaussian" (short-series symmetric fallback), or
+	// for RunCoherent derived metrics "mixed" when the composed operands
+	// disagree (the band then has no single nominal level).
+	BoundsSource string `json:"bounds_source,omitempty"`
 }
+
+// Bounds sources reported in Result.BoundsSource.
+const (
+	BoundsConformal = "conformal"
+	BoundsGaussian  = "gaussian"
+	BoundsMixed     = "mixed"
+)
 
 // SeasonalWeights maps day-of-week (time.Weekday) to a multiplier.
 // A weight of 1.0 means average; 1.2 means 20% above average for that day.
@@ -141,6 +156,16 @@ type Config struct {
 	// stabilizing variance. Ignored when the series has negative values.
 	LogTransform bool
 
+	// DisableLevelShift turns off level-shift detection, so the full
+	// history is always fitted as-is. Useful when the detector misreads a
+	// known transient (an untagged outage or promo) as a regime change.
+	DisableLevelShift bool
+
+	// relevel carries a detected level shift handled by re-leveling; every
+	// fit reads its training data through trainingView so backtest folds
+	// re-level from their own prefix only. Set by Run.
+	relevel *levelShift
+
 	// Anchor, when set, is the timestamp predictions step forward from
 	// instead of the series' last point. Used when training data has been
 	// masked (e.g. event days removed) so predictions still start after
@@ -159,7 +184,8 @@ func anchorTime(s Series, cfg Config) time.Time {
 // anchorOffset returns how many whole interval steps cfg.Anchor lies beyond
 // the series' last point (0 when Anchor is unset or not ahead). Trend models
 // must advance their projection by this many steps so values line up with
-// the anchored timestamps.
+// the anchored timestamps. Steps are counted on the calendar (whole months
+// for the month interval), since RunCoherent anchors at every interval.
 func anchorOffset(s Series, cfg Config) int {
 	if cfg.Anchor.IsZero() {
 		return 0
@@ -168,19 +194,11 @@ func anchorOffset(s Series, cfg Config) int {
 	if !cfg.Anchor.After(last) {
 		return 0
 	}
-	d := cfg.Anchor.Sub(last)
-	var step time.Duration
-	switch cfg.Interval {
-	case IntervalHour:
-		step = time.Hour
-	case IntervalWeek:
-		step = 7 * 24 * time.Hour
-	case IntervalMonth:
-		step = 30 * 24 * time.Hour // approximate; Anchor is only set for day interval
-	default:
-		step = 24 * time.Hour
+	steps := int(math.Round(intervalSteps(last, cfg.Anchor, cfg.Interval)))
+	if steps < 0 {
+		return 0
 	}
-	return int(d / step)
+	return steps
 }
 
 // ValidMethods returns all supported method names.
@@ -225,9 +243,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
 		cfg.ConfidenceLevel = 0.95
 	}
-	if cfg.SMAWindow <= 0 {
-		cfg.SMAWindow = defaultSMAWindow(len(series))
-	}
+	cfg.relevel = nil
 
 	method := cfg.Method
 	if method == "" || method == MethodAuto {
@@ -250,13 +266,30 @@ func Run(series Series, cfg Config) (*Result, error) {
 		cfg.LogTransform = false // downstream error stats stay untransformed
 	}
 
+	// Seasonal gates measure the full (pre-truncation) history: a shift
+	// that leaves only a short recent window must not erase evidence of a
+	// weekly pattern the longer history carries.
+	gateSeries := work
+
 	// Level-shift handling: fit on the current regime, not a blend of
 	// regimes. Post-shift history is used alone when long enough; otherwise
-	// older observations are re-leveled to the new regime.
+	// older observations are re-leveled to the new regime, per training
+	// prefix so backtest folds never see their held-out points.
 	levelShiftAt := ""
-	if idx, delta := detectLevelShift(work); idx > 0 {
-		levelShiftAt = formatShiftTime(work[idx].T, cfg.Interval)
-		work = applyLevelShift(work, idx, delta, cfg.Interval)
+	if !cfg.DisableLevelShift {
+		if ls := detectLevelShift(work); ls != nil {
+			levelShiftAt = formatShiftTime(work[ls.idx].T, cfg.Interval)
+			if ls.truncates(len(work), cfg.Interval) {
+				work = work[ls.idx:]
+			} else {
+				cfg.relevel = ls
+			}
+		}
+	}
+
+	// Window and data-point count describe the data actually modeled.
+	if cfg.SMAWindow <= 0 {
+		cfg.SMAWindow = defaultSMAWindow(len(work))
 	}
 
 	var core forecastCore
@@ -272,31 +305,34 @@ func Run(series Series, cfg Config) (*Result, error) {
 
 	if logApplied {
 		invertLogPredictions(core.preds)
-		core.trend = predictionTrend(core.preds, series)
+		// The model's trend is a per-period change on log scale, i.e. a
+		// multiplicative rate; express it as an absolute change at the
+		// first forecast level so every method keeps its own semantics.
+		core.trend = math.Expm1(core.trend) * core.preds[0].Value
 	}
 
 	// Apply seasonal profiles. Weekday and hourly weights are gated on
 	// detrended autocorrelation at their lag so spurious profiles (built
-	// from noise) don't degrade the forecast; day-of-month weights are an
-	// explicit opt-in and apply as supplied.
-	seasonalApplied := false
-	if len(cfg.SeasonalWeights) > 0 &&
-		seasonalLagAutocorrelation(work, 7*24*time.Hour) >= seasonalGateThreshold {
+	// from noise) don't degrade the forecast; when the history is too short
+	// to measure that lag there is no evidence against the profile and it
+	// applies as supplied. Day-of-month weights are an explicit opt-in and
+	// apply as supplied.
+	var profiles []string
+	if len(cfg.SeasonalWeights) > 0 && seasonalGateAllows(gateSeries, 7*24*time.Hour) {
 		core.preds = applySeasonalWeights(core.preds, cfg.SeasonalWeights)
-		seasonalApplied = true
+		profiles = append(profiles, "weekday")
 	}
-	if len(cfg.HourlyWeights) > 0 && cfg.Interval == IntervalHour &&
-		seasonalLagAutocorrelation(work, 24*time.Hour) >= seasonalGateThreshold {
+	if len(cfg.HourlyWeights) > 0 && cfg.Interval == IntervalHour && seasonalGateAllows(gateSeries, 24*time.Hour) {
 		core.preds = applyHourlyWeights(core.preds, cfg.HourlyWeights)
-		seasonalApplied = true
+		profiles = append(profiles, "hourly")
 	}
 	if len(cfg.MonthDayWeights) > 0 {
 		core.preds = applyMonthDayWeights(core.preds, cfg.MonthDayWeights)
-		seasonalApplied = true
+		profiles = append(profiles, "monthday")
 	}
 
 	if cfg.NonNegative {
-		clipNonNegative(core.preds)
+		ClipNonNegative(core.preds)
 	}
 
 	// Compute trend percentage.
@@ -306,20 +342,32 @@ func Run(series Series, cfg Config) (*Result, error) {
 	}
 
 	return &Result{
-		Method:          core.method,
-		Metric:          cfg.Metric,
-		Horizon:         cfg.Horizon,
-		Interval:        cfg.Interval,
-		Predictions:     core.preds,
-		Trend:           core.trend,
-		TrendPct:        trendPct,
-		MAE:             core.mae,
-		RMSE:            core.rmse,
-		DataPoints:      len(series),
-		Weights:         core.weights,
-		LevelShiftAt:    levelShiftAt,
-		SeasonalApplied: seasonalApplied,
+		Method:           core.method,
+		Metric:           cfg.Metric,
+		Horizon:          cfg.Horizon,
+		Interval:         cfg.Interval,
+		Predictions:      core.preds,
+		Trend:            core.trend,
+		TrendPct:         trendPct,
+		MAE:              core.mae,
+		RMSE:             core.rmse,
+		DataPoints:       len(work),
+		Weights:          core.weights,
+		Composition:      "",
+		LevelShiftAt:     levelShiftAt,
+		SeasonalApplied:  len(profiles) > 0,
+		SeasonalProfiles: profiles,
+		BoundsSource:     core.boundsSource,
 	}, nil
+}
+
+// seasonalGateAllows reports whether a seasonal profile at the given lag
+// may be applied: yes when the detrended autocorrelation at that lag clears
+// the threshold, and also when the history is too short to measure it (no
+// evidence against the profile).
+func seasonalGateAllows(s Series, lag time.Duration) bool {
+	ac, ok := seasonalLagAutocorrelation(s, lag)
+	return !ok || ac >= seasonalGateThreshold
 }
 
 // seriesAllNonNegative reports whether every value is >= 0.
@@ -354,8 +402,8 @@ func invertLogPredictions(preds []Prediction) {
 	}
 }
 
-// predictionTrend estimates the per-period trend from the forecast path on
-// the original scale (used when the model's own trend lives in log space).
+// predictionTrend estimates the per-period trend from a forecast path
+// (used for composed metrics, which have no model of their own).
 func predictionTrend(preds []Prediction, original Series) float64 {
 	switch {
 	case len(preds) > 1:
@@ -370,18 +418,19 @@ func predictionTrend(preds []Prediction, original Series) float64 {
 // forecastCore is a computed forecast before the shared post-processing
 // (seasonal adjustment, zero clipping, trend percentage) in Run.
 type forecastCore struct {
-	method    Method
-	preds     []Prediction
-	trend     float64
-	mae, rmse float64
-	weights   map[string]float64 // ensemble only
+	method       Method
+	preds        []Prediction
+	trend        float64
+	mae, rmse    float64
+	weights      map[string]float64 // ensemble only
+	boundsSource string
 }
 
 // computeSingle produces a single-method forecast with conformal bounds.
 // eval may carry a rolling backtest that already covers the method; pass nil
 // to have one run here.
 func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) (forecastCore, error) {
-	predictions, trend, err := methodForecast(method, series, cfg)
+	predictions, trend, err := methodForecast(method, trainingView(series, cfg, len(series)), cfg)
 	if err != nil {
 		return forecastCore{}, err
 	}
@@ -390,26 +439,29 @@ func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) 
 		eval = runRollingBacktest(series, cfg, []Method{method})
 	}
 	offset := anchorOffset(series, cfg)
-	byStep := eval.residualsByStep(method)
-	mae, rmse, _ := eval.errorStats(method)
+	byStep := eval.residualsByStep(eval.methodPredictor(method))
+	mae, rmse, _ := eval.errorStats(eval.methodPredictor(method))
+	source := BoundsConformal
 	if totalResiduals(byStep) >= minTotalResiduals {
 		sq := stepQuantiles(byStep, offset+cfg.Horizon)
 		applyConformalBounds(predictions, sq, cfg, offset)
 	} else {
 		// Series too short for a rolling backtest: symmetric Gaussian
 		// bounds from a single-holdout residual estimate, and single-split
-		// accuracy metrics.
-		stddev := residualStdDev(series, method, cfg)
+		// accuracy metrics — one fit serves both.
+		var stddev float64
+		stddev, mae, rmse = holdoutEval(series, cfg, method)
 		addBounds(predictions, stddev, cfg.ConfidenceLevel, offset)
-		mae, rmse = backtest(series, cfg, method)
+		source = BoundsGaussian
 	}
 
 	return forecastCore{
-		method: method,
-		preds:  predictions,
-		trend:  trend,
-		mae:    mae,
-		rmse:   rmse,
+		method:       method,
+		preds:        predictions,
+		trend:        trend,
+		mae:          mae,
+		rmse:         rmse,
+		boundsSource: source,
 	}, nil
 }
 
@@ -437,7 +489,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 		if _, ok := weights[m]; !ok {
 			continue
 		}
-		preds, tr, err := methodForecast(m, series, cfg)
+		preds, tr, err := methodForecast(m, trainingView(series, cfg, len(series)), cfg)
 		if err != nil || len(preds) != cfg.Horizon {
 			delete(weights, m)
 			continue
@@ -468,14 +520,17 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 
 	// Conformal bounds on the ensemble's rolling residuals.
 	offset := anchorOffset(series, cfg)
-	byStep := eval.ensembleResidualsByStep(weights, members)
-	mae, rmse := eval.ensembleErrorStats(weights, members)
+	predict := ensemblePredictor(weights, members)
+	byStep := eval.residualsByStep(predict)
+	mae, rmse, _ := eval.errorStats(predict)
+	source := BoundsConformal
 	if totalResiduals(byStep) >= minTotalResiduals {
 		sq := stepQuantiles(byStep, offset+cfg.Horizon)
 		applyConformalBounds(combined, sq, cfg, offset)
 	} else {
 		stddev := seriesStdDev(series)
 		addBounds(combined, stddev, cfg.ConfidenceLevel, offset)
+		source = BoundsGaussian
 	}
 
 	named := make(map[string]float64, len(weights))
@@ -484,12 +539,13 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 	}
 
 	return forecastCore{
-		method:  MethodEnsemble,
-		preds:   combined,
-		trend:   trend,
-		mae:     mae,
-		rmse:    rmse,
-		weights: named,
+		method:       MethodEnsemble,
+		preds:        combined,
+		trend:        trend,
+		mae:          mae,
+		rmse:         rmse,
+		weights:      named,
+		boundsSource: source,
 	}, nil
 }
 
@@ -559,45 +615,43 @@ func defaultSMAWindow(n int) int {
 	return w
 }
 
+// seriesValues extracts the values of a series.
+func seriesValues(s Series) []float64 {
+	out := make([]float64, len(s))
+	for i, p := range s {
+		out[i] = p.V
+	}
+	return out
+}
+
 // seriesMean returns the arithmetic mean of all values.
 func seriesMean(s Series) float64 {
-	if len(s) == 0 {
-		return 0
-	}
-	sum := 0.0
-	for _, p := range s {
-		sum += p.V
-	}
-	return sum / float64(len(s))
+	return mean(seriesValues(s))
 }
 
 // seriesStdDev returns the population standard deviation.
 func seriesStdDev(s Series) float64 {
-	if len(s) < 2 {
-		return 0
-	}
-	mean := seriesMean(s)
-	sumSq := 0.0
-	for _, p := range s {
-		diff := p.V - mean
-		sumSq += diff * diff
-	}
-	return math.Sqrt(sumSq / float64(len(s)))
+	return stddev(seriesValues(s))
 }
 
-// residualStdDev computes std dev of forecast residuals over the last holdout
-// points. Fallback bound estimate for series too short for a rolling backtest.
-func residualStdDev(s Series, method Method, cfg Config) float64 {
+// holdoutEval fits the method once on a single train/test split (the last
+// fifth of the series, minimum 2 points) and returns the residual standard
+// deviation on the model scale (for Gaussian fallback bounds) plus MAE and
+// RMSE on the reporting scale. It is the fallback for series too short for
+// a rolling backtest; when even the single split is impossible it returns
+// the series' own standard deviation and zero errors.
+func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64) {
 	holdout := len(s) / 5
 	if holdout < 2 {
 		holdout = 2
 	}
 	if holdout > len(s)-3 {
-		return seriesStdDev(s)
+		return seriesStdDev(s), 0, 0
 	}
 
-	train := s[:len(s)-holdout]
-	test := s[len(s)-holdout:]
+	c := len(s) - holdout
+	train := trainingView(s, cfg, c)
+	test := s[c:]
 
 	testCfg := cfg
 	testCfg.Horizon = holdout
@@ -606,19 +660,28 @@ func residualStdDev(s Series, method Method, cfg Config) float64 {
 
 	preds, _, err := methodForecast(method, train, testCfg)
 	if err != nil || len(preds) == 0 {
-		return seriesStdDev(s)
+		return seriesStdDev(s), 0, 0
 	}
 
 	n := len(preds)
 	if n > len(test) {
 		n = len(test)
 	}
-	sumSq := 0.0
+	sumSqModel, sumAbs, sumSq := 0.0, 0.0, 0.0
 	for i := 0; i < n; i++ {
-		diff := test[i].V - preds[i].Value
+		actual, pred := test[i].V, preds[i].Value
+		modelDiff := actual - pred
+		sumSqModel += modelDiff * modelDiff
+		if cfg.LogTransform {
+			// Values are on log1p scale; report errors on the original.
+			actual, pred = math.Expm1(actual), math.Expm1(pred)
+		}
+		diff := actual - pred
+		sumAbs += math.Abs(diff)
 		sumSq += diff * diff
 	}
-	return math.Sqrt(sumSq / float64(n))
+	fn := float64(n)
+	return math.Sqrt(sumSqModel / fn), sumAbs / fn, math.Sqrt(sumSq / fn)
 }
 
 // zScore returns the z-score for a given confidence level (two-tailed).
@@ -684,58 +747,11 @@ func intervalSteps(from, to time.Time, interval Interval) float64 {
 	}
 }
 
-// backtest splits data into a single train/test split and measures forecast
-// accuracy. Fallback for series too short for a rolling backtest.
-func backtest(s Series, cfg Config, method Method) (mae, rmse float64) {
-	holdout := len(s) / 5
-	if holdout < 2 {
-		holdout = 2
-	}
-	if holdout > len(s)-3 {
-		return 0, 0
-	}
-
-	train := s[:len(s)-holdout]
-	test := s[len(s)-holdout:]
-
-	testCfg := cfg
-	testCfg.Horizon = holdout
-	testCfg.SeasonalWeights = nil
-	testCfg.Anchor = time.Time{}
-
-	preds, _, err := methodForecast(method, train, testCfg)
-	if err != nil || len(preds) == 0 {
-		return 0, 0
-	}
-
-	n := len(preds)
-	if n > len(test) {
-		n = len(test)
-	}
-
-	sumAbsErr := 0.0
-	sumSqErr := 0.0
-	for i := 0; i < n; i++ {
-		actual, pred := test[i].V, preds[i].Value
-		if cfg.LogTransform {
-			// Values arrive on log1p scale; report errors on the original.
-			actual, pred = math.Expm1(actual), math.Expm1(pred)
-		}
-		diff := actual - pred
-		sumAbsErr += math.Abs(diff)
-		sumSqErr += diff * diff
-	}
-
-	mae = sumAbsErr / float64(n)
-	rmse = math.Sqrt(sumSqErr / float64(n))
-	return mae, rmse
-}
-
 // autoCandidates lists the methods auto-selection considers for a series.
 // Holt-Winters needs enough history to stabilize its level/trend estimates.
 func autoCandidates(s Series) []Method {
 	candidates := []Method{MethodLinear, MethodSMA, MethodWMA}
-	if len(s) >= 14 {
+	if len(s) >= holtWintersMinPoints {
 		candidates = append(candidates, MethodHoltWinters)
 	}
 	return candidates
@@ -748,7 +764,7 @@ func selectBestMethod(s Series, cfg Config) Method {
 	bestRMSE := math.MaxFloat64
 
 	for _, m := range autoCandidates(s) {
-		_, rmse := backtest(s, cfg, m)
+		_, _, rmse := holdoutEval(s, cfg, m)
 		// RMSE=0 means backtest couldn't run (too few points for holdout),
 		// not a perfect fit. Skip these candidates.
 		if rmse > 0 && rmse < bestRMSE {

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -230,6 +230,13 @@ type Config struct {
 	// masked (e.g. event days removed) so predictions still start after
 	// the last real observation rather than inside masked history.
 	Anchor time.Time
+
+	// excluded holds the timestamps Run's full-series transient detection
+	// masked. They are kept out of the residual pool (outages and spikes
+	// are not what the bands describe; the alerting layer judges them
+	// against the bands separately) — training data is masked per prefix
+	// by trainingView instead. Set by Run, never by callers.
+	excluded map[time.Time]bool
 }
 
 // anchorTime returns the reference point predictions step forward from.
@@ -295,6 +302,7 @@ func withDefaults(cfg Config) Config {
 	if cfg.ConfidenceLevel <= 0 || cfg.ConfidenceLevel >= 1 {
 		cfg.ConfidenceLevel = 0.95
 	}
+	cfg.excluded = nil
 	return cfg
 }
 
@@ -332,17 +340,23 @@ func Run(series Series, cfg Config) (*Result, error) {
 		cfg.LogTransform = false // downstream error stats stay untransformed
 	}
 
-	// Transient masking: short outlier runs are excluded from fitting and
-	// reported. When the series' last observations are masked, predictions
-	// must still start after them, so the anchor moves to the true end.
+	// Transient masking. Detection on the full series feeds the report
+	// (AnomaliesMasked), keeps the masked dates out of the residual pool
+	// (outages and spikes are not what the bands describe; the alerting
+	// layer judges those dates against the bands separately), and moves
+	// the anchor past a masked tail. Training data is masked per prefix
+	// instead (trainingView): the deployed fit and every backtest fold
+	// re-detect from their own history, so no fold trains on a prefix
+	// edited with knowledge of what came after it.
 	var anomalies []string
 	if cfg.NonNegative && !cfg.DisableAnomalyMask {
 		if idx := detectTransients(work, cfg.Interval, logApplied, cfg.AnomalySigma, cfg.AnomalyCycles); len(idx) > 0 {
+			cfg.excluded = make(map[time.Time]bool, len(idx))
 			for _, i := range idx {
 				anomalies = append(anomalies, formatShiftTime(work[i].T, cfg.Interval))
+				cfg.excluded[work[i].T] = true
 			}
 			last := work[len(work)-1].T
-			work = maskIndices(work, idx)
 			if cfg.Anchor.IsZero() || cfg.Anchor.Before(last) {
 				cfg.Anchor = last
 			}
@@ -353,21 +367,28 @@ func Run(series Series, cfg Config) (*Result, error) {
 	// regimes. Post-shift history is used alone when long enough; otherwise
 	// trainingView re-levels older observations to the new regime. Both the
 	// deployed fit and every backtest prefix run their own detection
-	// (trainingView), so this full-series pass only reports the shift and
-	// trims the data the run describes.
+	// (trainingView), so this full-series pass (on the masked series) only
+	// reports the shift and trims the evaluation window to the new regime.
 	levelShiftAt := ""
 	if !cfg.DisableLevelShift {
-		if ls := detectLevelShift(work); ls != nil {
-			levelShiftAt = formatShiftTime(work[ls.idx].T, cfg.Interval)
-			if ls.truncates(len(work), cfg.Interval) {
-				work = work[ls.idx:]
+		masked := withoutTimes(work, cfg.excluded)
+		if ls := detectLevelShift(masked); ls != nil {
+			levelShiftAt = formatShiftTime(masked[ls.idx].T, cfg.Interval)
+			if ls.truncates(len(masked), cfg.Interval) {
+				work = fromTime(work, masked[ls.idx].T)
 			}
 		}
 	}
 
-	// Window and data-point count describe the data actually modeled.
+	// The deployed training view (masked and level-shift handled from the
+	// full history): window and data-point count describe the data
+	// actually modeled.
+	deployed := trainingView(work, cfg, len(work))
+	if len(deployed) == 0 {
+		deployed = work
+	}
 	if cfg.SMAWindow <= 0 {
-		cfg.SMAWindow = defaultSMAWindow(len(work))
+		cfg.SMAWindow = defaultSMAWindow(len(deployed))
 	}
 
 	// Seasonal profiles are estimated from the training data by every fit
@@ -378,7 +399,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 	// don't degrade the forecast; when the history is too short to measure
 	// that lag there is no evidence against the profile and it applies.
 	// The names reported in meta are the deployed fit's.
-	_, profiles := profileFor(work, cfg, len(work))
+	_, profiles := profileFor(deployed, cfg)
 
 	var core forecastCore
 	var err error
@@ -439,7 +460,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 		TrendPct:         trendPct,
 		MAE:              core.mae,
 		RMSE:             core.rmse,
-		DataPoints:       len(work),
+		DataPoints:       len(deployed),
 		Weights:          core.weights,
 		Composition:      "",
 		LevelShiftAt:     levelShiftAt,
@@ -448,7 +469,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 		SeasonalProfiles: profiles,
 		BoundsSource:     core.boundsSource,
 		rolling:          rolling,
-		trainEnd:         work[len(work)-1].T,
+		trainEnd:         deployed[len(deployed)-1].T,
 		evaluated:        core.evaluated,
 	}, nil
 }
@@ -528,18 +549,24 @@ type forecastCore struct {
 // eval may carry a rolling backtest that already covers the method; pass nil
 // to have one run here.
 func computeSingle(series Series, cfg Config, method Method, eval *rollingEval) (forecastCore, error) {
-	predictions, trend, err := methodForecast(method, trainingView(series, cfg, len(series)), cfg)
+	train := trainingView(series, cfg, len(series))
+	if len(train) == 0 {
+		train = series
+	}
+	predictions, trend, err := methodForecast(method, train, cfg)
 	if err != nil {
 		return forecastCore{}, err
 	}
-	profile, _ := profileFor(series, cfg, len(series))
+	profile, _ := profileFor(train, cfg)
 	applyProfile(predictions, profile, cfg.LogTransform)
 	clipPointPredictions(predictions, cfg)
 
 	if eval == nil {
 		eval = runRollingBacktest(series, cfg, []Method{method})
 	}
-	offset := anchorOffset(series, cfg)
+	// Steps are counted from the fitted data's end: a masked tail puts
+	// the anchor several steps beyond it.
+	offset := anchorOffset(train, cfg)
 	predict := eval.methodPredictor(method)
 	byStep := eval.residualsByStep(predict)
 	mae, rmse, n := eval.errorStats(predict)
@@ -590,7 +617,11 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 
 	// Fit each member on the full series. A member that fails to fit here
 	// (despite backtesting) is dropped and weights renormalize.
-	profile, _ := profileFor(series, cfg, len(series))
+	train := trainingView(series, cfg, len(series))
+	if len(train) == 0 {
+		train = series
+	}
+	profile, _ := profileFor(train, cfg)
 	memberPreds := map[Method][]Prediction{}
 	memberTrend := map[Method]float64{}
 	members := make([]Method, 0, len(weights))
@@ -598,7 +629,7 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 		if _, ok := weights[m]; !ok {
 			continue
 		}
-		preds, tr, err := methodForecast(m, trainingView(series, cfg, len(series)), cfg)
+		preds, tr, err := methodForecast(m, train, cfg)
 		if err != nil || len(preds) != cfg.Horizon {
 			delete(weights, m)
 			continue
@@ -630,8 +661,8 @@ func computeEnsemble(series Series, cfg Config) (forecastCore, error) {
 	}
 
 	// Conformal bounds on the ensemble procedure's out-of-sample rolling
-	// residuals.
-	offset := anchorOffset(series, cfg)
+	// residuals; steps counted from the fitted data's end.
+	offset := anchorOffset(train, cfg)
 	predict := nestedEnsemblePredictor(eval, candidates)
 	byStep := eval.residualsByStep(predict)
 	mae, rmse, n := eval.errorStats(predict)
@@ -796,6 +827,9 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 
 	c := len(s) - holdout
 	train := trainingView(s, cfg, c)
+	if len(train) == 0 {
+		return seriesStdDev(s), 0, 0, 0
+	}
 	trainEnd := train[len(train)-1].T
 	test := s[c:]
 
@@ -810,12 +844,15 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 	if err != nil || len(preds) == 0 {
 		return seriesStdDev(s), 0, 0, 0
 	}
-	profile, _ := profileFor(s, cfg, c)
+	profile, _ := profileFor(train, cfg)
 	applyProfile(preds, profile, cfg.LogTransform)
 	clipPointPredictions(preds, cfg)
 
 	sumSqModel, sumAbs, sumSq := 0.0, 0.0, 0.0
 	for _, p := range test {
+		if cfg.excluded[p.T] {
+			continue
+		}
 		h, ok := stepIndex(trainEnd, p.T, cfg.Interval, len(preds))
 		if !ok {
 			continue
@@ -837,6 +874,32 @@ func holdoutEval(s Series, cfg Config, method Method) (stddev, mae, rmse float64
 	}
 	fn := float64(n)
 	return math.Sqrt(sumSqModel / fn), sumAbs / fn, math.Sqrt(sumSq / fn), n
+}
+
+// withoutTimes returns s without the points whose timestamps are in
+// excluded (s itself when excluded is empty).
+func withoutTimes(s Series, excluded map[time.Time]bool) Series {
+	if len(excluded) == 0 {
+		return s
+	}
+	out := make(Series, 0, len(s))
+	for _, p := range s {
+		if !excluded[p.T] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// fromTime returns the suffix of s starting at the first point at or after
+// t.
+func fromTime(s Series, t time.Time) Series {
+	for i, p := range s {
+		if !p.T.Before(t) {
+			return s[i:]
+		}
+	}
+	return s[len(s):]
 }
 
 // calendarSteps returns the number of whole interval steps from from to to,

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -100,6 +100,11 @@ type Result struct {
 	// detected level shift (offer paused, traffic source added). When set,
 	// pre-shift history was truncated or re-leveled before fitting.
 	LevelShiftAt string `json:"level_shift_at,omitempty"`
+	// AnomaliesMasked lists the timestamps of transient outliers (short
+	// runs abnormal for this series at that point of its cycle) that were
+	// excluded from fitting. The alerting layer should still compare the
+	// observed values on those dates against the bands.
+	AnomaliesMasked []string `json:"anomalies_masked,omitempty"`
 	// SeasonalApplied reports whether any supplied seasonal profile
 	// actually adjusted the predictions: weekday and hourly weights are
 	// gated on detrended autocorrelation at the seasonal lag, so weights
@@ -160,6 +165,12 @@ type Config struct {
 	// history is always fitted as-is. Useful when the detector misreads a
 	// known transient (an untagged outage or promo) as a regime change.
 	DisableLevelShift bool
+
+	// DisableAnomalyMask turns off transient masking (see anomaly.go), so
+	// short outlier runs — a tracking outage, an untagged spike — are fitted
+	// as data rather than looked through. Masking applies to NonNegative
+	// series only; signed metrics can legitimately swing.
+	DisableAnomalyMask bool
 
 	// relevel carries a detected level shift handled by re-leveling; every
 	// fit reads its training data through trainingView so backtest folds
@@ -266,6 +277,23 @@ func Run(series Series, cfg Config) (*Result, error) {
 		cfg.LogTransform = false // downstream error stats stay untransformed
 	}
 
+	// Transient masking: short outlier runs are excluded from fitting and
+	// reported. When the series' last observations are masked, predictions
+	// must still start after them, so the anchor moves to the true end.
+	var anomalies []string
+	if cfg.NonNegative && !cfg.DisableAnomalyMask {
+		if idx := detectTransients(work, cfg.Interval); len(idx) > 0 {
+			for _, i := range idx {
+				anomalies = append(anomalies, formatShiftTime(work[i].T, cfg.Interval))
+			}
+			last := work[len(work)-1].T
+			work = maskIndices(work, idx)
+			if cfg.Anchor.IsZero() || cfg.Anchor.Before(last) {
+				cfg.Anchor = last
+			}
+		}
+	}
+
 	// Seasonal gates measure the full (pre-truncation) history: a shift
 	// that leaves only a short recent window must not erase evidence of a
 	// weekly pattern the longer history carries.
@@ -355,6 +383,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 		Weights:          core.weights,
 		Composition:      "",
 		LevelShiftAt:     levelShiftAt,
+		AnomaliesMasked:  anomalies,
 		SeasonalApplied:  len(profiles) > 0,
 		SeasonalProfiles: profiles,
 		BoundsSource:     core.boundsSource,

--- a/go-cli/internal/forecast/forecast.go
+++ b/go-cli/internal/forecast/forecast.go
@@ -172,6 +172,14 @@ type Config struct {
 	// series only; signed metrics can legitimately swing.
 	DisableAnomalyMask bool
 
+	// AnomalySigma is the deviation, in robust sigma units, beyond which a
+	// point counts as a transient (default DefaultAnomalySigma); lower it
+	// to mask more aggressively, raise it to mask only extreme departures.
+	// AnomalyCycles is how many seasonal cycles on each side supply the
+	// same-weekday/hour reference values (default DefaultAnomalyCycles).
+	AnomalySigma  float64
+	AnomalyCycles int
+
 	// relevel carries a detected level shift handled by re-leveling; every
 	// fit reads its training data through trainingView so backtest folds
 	// re-level from their own prefix only. Set by Run.
@@ -282,7 +290,7 @@ func Run(series Series, cfg Config) (*Result, error) {
 	// must still start after them, so the anchor moves to the true end.
 	var anomalies []string
 	if cfg.NonNegative && !cfg.DisableAnomalyMask {
-		if idx := detectTransients(work, cfg.Interval); len(idx) > 0 {
+		if idx := detectTransients(work, cfg.Interval, cfg.AnomalySigma, cfg.AnomalyCycles); len(idx) > 0 {
 			for _, i := range idx {
 				anomalies = append(anomalies, formatShiftTime(work[i].T, cfg.Interval))
 			}

--- a/go-cli/internal/forecast/forecast_test.go
+++ b/go-cli/internal/forecast/forecast_test.go
@@ -414,8 +414,8 @@ func TestZScore(t *testing.T) {
 
 func TestValidMethods(t *testing.T) {
 	methods := ValidMethods()
-	if len(methods) != 5 {
-		t.Errorf("expected 5 valid methods, got %d", len(methods))
+	if len(methods) != 6 {
+		t.Errorf("expected 6 valid methods, got %d", len(methods))
 	}
 }
 

--- a/go-cli/internal/forecast/forecast_test.go
+++ b/go-cli/internal/forecast/forecast_test.go
@@ -2,6 +2,7 @@ package forecast
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 	"time"
 )
@@ -307,7 +308,17 @@ func TestRun_TrendPercentage(t *testing.T) {
 }
 
 func TestRun_SeasonalWeights(t *testing.T) {
-	s := makeSeries(14, func(i int) float64 { return 100 })
+	// A genuinely weekly series (Mondays high, Tuesdays low): the lag-7
+	// autocorrelation gate passes and supplied weights modulate predictions.
+	factors := map[time.Weekday]float64{time.Monday: 1.5, time.Tuesday: 0.8}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := makeSeries(28, func(i int) float64 {
+		f, ok := factors[base.AddDate(0, 0, i).Weekday()]
+		if !ok {
+			f = 1.0
+		}
+		return 100 * f
+	})
 
 	weights := SeasonalWeights{
 		time.Monday:  1.5,
@@ -323,15 +334,55 @@ func TestRun_SeasonalWeights(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if !result.SeasonalApplied {
+		t.Fatal("expected seasonal weights to be applied to a weekly series")
+	}
 
-	// Find which predictions fall on Monday/Tuesday and verify they were adjusted.
+	// The SMA base level is the window mean (~104); Monday/Tuesday
+	// predictions must be scaled by their weights relative to other days.
+	var flatVal float64
+	for _, p := range result.Predictions {
+		if _, weighted := factors[p.T.Weekday()]; !weighted {
+			flatVal = p.Value
+		}
+	}
+	if flatVal == 0 {
+		t.Fatal("no unweighted day in horizon")
+	}
 	for _, p := range result.Predictions {
 		dow := p.T.Weekday()
-		if dow == time.Monday && math.Abs(p.Value-150) > 5 {
-			t.Errorf("Monday prediction = %.2f, expected ~150 (100 * 1.5)", p.Value)
+		if dow == time.Monday && math.Abs(p.Value-1.5*flatVal) > 1 {
+			t.Errorf("Monday prediction = %.2f, expected ~%.2f (1.5x)", p.Value, 1.5*flatVal)
 		}
-		if dow == time.Tuesday && math.Abs(p.Value-80) > 5 {
-			t.Errorf("Tuesday prediction = %.2f, expected ~80 (100 * 0.8)", p.Value)
+		if dow == time.Tuesday && math.Abs(p.Value-0.8*flatVal) > 1 {
+			t.Errorf("Tuesday prediction = %.2f, expected ~%.2f (0.8x)", p.Value, 0.8*flatVal)
+		}
+	}
+}
+
+func TestRun_SeasonalWeightsGatedOnFlatSeries(t *testing.T) {
+	// Flat-noise series with no weekly structure: supplied weights must NOT
+	// be applied (the lag-7 autocorrelation gate rejects them).
+	rng := rand.New(rand.NewSource(61))
+	s := makeSeries(28, func(i int) float64 { return 100 + rng.NormFloat64()*10 })
+
+	result, err := Run(s, Config{
+		Method:          MethodSMA,
+		Horizon:         7,
+		Interval:        IntervalDay,
+		SeasonalWeights: SeasonalWeights{time.Monday: 1.5, time.Tuesday: 0.8},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SeasonalApplied {
+		t.Fatal("seasonal weights applied to a flat series with no weekly structure")
+	}
+	// All predictions share the flat SMA level — no day got scaled.
+	for i := 1; i < len(result.Predictions); i++ {
+		if math.Abs(result.Predictions[i].Value-result.Predictions[0].Value) > 0.01 {
+			t.Errorf("prediction[%d] = %.2f differs from [0] = %.2f: weights leaked through the gate",
+				i, result.Predictions[i].Value, result.Predictions[0].Value)
 		}
 	}
 }

--- a/go-cli/internal/forecast/holtwinters.go
+++ b/go-cli/internal/forecast/holtwinters.go
@@ -1,27 +1,34 @@
 package forecast
 
-// holtWintersForecast implements double exponential smoothing (Holt's method).
+// holtWintersForecast implements damped-trend double exponential smoothing
+// (Holt's method with Gardner–McKenzie damping).
 //
 // It models both level and trend, making it superior to SMA/WMA for series
-// with a clear directional trend. The smoothing parameters (alpha, beta) are
-// selected automatically via grid search over the training data to minimize
-// the sum of squared one-step-ahead forecast errors.
+// with a clear directional trend. The damping parameter phi shrinks the
+// trend's contribution geometrically with horizon, so a recent growth spurt
+// is not extrapolated forever; phi = 1 recovers the classic undamped method.
+// The smoothing parameters (alpha, beta, phi) are selected automatically via
+// grid search over the training data to minimize the sum of squared
+// one-step-ahead forecast errors.
 //
 // Model:
 //
-//	level(t) = alpha * y(t) + (1 - alpha) * (level(t-1) + trend(t-1))
-//	trend(t) = beta * (level(t) - level(t-1)) + (1 - beta) * trend(t-1)
-//	forecast(t+h) = level(t) + h * trend(t)
+//	level(t) = alpha * y(t) + (1 - alpha) * (level(t-1) + phi * trend(t-1))
+//	trend(t) = beta * (level(t) - level(t-1)) + (1 - beta) * phi * trend(t-1)
+//	forecast(t+h) = level(t) + (phi + phi^2 + ... + phi^h) * trend(t)
+//
+// The returned per-period trend is phi*trend — the first forecast step's
+// increment — which equals the raw trend when phi = 1.
 func holtWintersForecast(s Series, cfg Config) ([]Prediction, float64, error) {
-	alpha, beta := optimizeParams(s)
+	alpha, beta, phi := optimizeParams(s)
 
 	level, trend := initHoltWinters(s)
 
 	// Run the smoother over all observations.
 	for i := 1; i < len(s); i++ {
 		prevLevel := level
-		level = alpha*s[i].V + (1-alpha)*(level+trend)
-		trend = beta*(level-prevLevel) + (1-beta)*trend
+		level = alpha*s[i].V + (1-alpha)*(level+phi*trend)
+		trend = beta*(level-prevLevel) + (1-beta)*phi*trend
 	}
 
 	// Project forward. The anchor offset advances the projection so values
@@ -30,13 +37,28 @@ func holtWintersForecast(s Series, cfg Config) ([]Prediction, float64, error) {
 	offset := anchorOffset(s, cfg)
 	preds := make([]Prediction, cfg.Horizon)
 	for i := 0; i < cfg.Horizon; i++ {
-		h := float64(offset + i + 1)
-		val := level + h*trend
+		h := offset + i + 1
+		val := level + dampedSum(phi, h)*trend
 		t := nextTime(anchor, cfg.Interval, i+1)
 		preds[i] = Prediction{T: t, Value: val}
 	}
 
-	return preds, trend, nil
+	return preds, phi * trend, nil
+}
+
+// dampedSum returns phi + phi^2 + ... + phi^h, the damped multiplier applied
+// to the trend h steps out. It equals h when phi = 1.
+func dampedSum(phi float64, h int) float64 {
+	if phi == 1 {
+		return float64(h)
+	}
+	sum := 0.0
+	p := phi
+	for i := 0; i < h; i++ {
+		sum += p
+		p *= phi
+	}
+	return sum
 }
 
 // initHoltWinters sets the initial level and trend from the first few points.
@@ -53,41 +75,49 @@ func initHoltWinters(s Series) (level, trend float64) {
 	return level, trend
 }
 
-// optimizeParams performs a grid search over alpha and beta to minimize
+// phiGrid holds the candidate damping parameters; 1.0 preserves the classic
+// undamped behavior so the optimizer can still choose it.
+var phiGrid = []float64{0.85, 0.90, 0.95, 0.98, 1.0}
+
+// optimizeParams performs a grid search over alpha, beta, and phi to minimize
 // in-sample SSE (sum of squared one-step-ahead errors).
-func optimizeParams(s Series) (bestAlpha, bestBeta float64) {
+func optimizeParams(s Series) (bestAlpha, bestBeta, bestPhi float64) {
 	bestAlpha = 0.3
 	bestBeta = 0.1
+	bestPhi = 1.0
 	bestSSE := -1.0
 
 	for a := 0.05; a <= 0.95; a += 0.05 {
 		for b := 0.01; b <= 0.50; b += 0.05 {
-			sse := computeSSE(s, a, b)
-			if bestSSE < 0 || sse < bestSSE {
-				bestSSE = sse
-				bestAlpha = a
-				bestBeta = b
+			for _, p := range phiGrid {
+				sse := computeSSE(s, a, b, p)
+				if bestSSE < 0 || sse < bestSSE {
+					bestSSE = sse
+					bestAlpha = a
+					bestBeta = b
+					bestPhi = p
+				}
 			}
 		}
 	}
 
-	return bestAlpha, bestBeta
+	return bestAlpha, bestBeta, bestPhi
 }
 
 // computeSSE returns the sum of squared one-step-ahead forecast errors
 // for the given smoothing parameters.
-func computeSSE(s Series, alpha, beta float64) float64 {
+func computeSSE(s Series, alpha, beta, phi float64) float64 {
 	level, trend := initHoltWinters(s)
 
 	sse := 0.0
 	for i := 1; i < len(s); i++ {
-		forecast := level + trend
+		forecast := level + phi*trend
 		err := s[i].V - forecast
 		sse += err * err
 
 		prevLevel := level
-		level = alpha*s[i].V + (1-alpha)*(level+trend)
-		trend = beta*(level-prevLevel) + (1-beta)*trend
+		level = alpha*s[i].V + (1-alpha)*(level+phi*trend)
+		trend = beta*(level-prevLevel) + (1-beta)*phi*trend
 	}
 
 	return sse

--- a/go-cli/internal/forecast/holtwinters.go
+++ b/go-cli/internal/forecast/holtwinters.go
@@ -36,8 +36,6 @@ func holtWintersForecast(s Series, cfg Config) ([]Prediction, float64, error) {
 		preds[i] = Prediction{T: t, Value: val}
 	}
 
-	stddev := residualStdDev(s, MethodHoltWinters, cfg)
-	addBounds(preds, stddev, cfg.ConfidenceLevel, offset)
 	return preds, trend, nil
 }
 

--- a/go-cli/internal/forecast/levelshift.go
+++ b/go-cli/internal/forecast/levelshift.go
@@ -203,27 +203,35 @@ func (ls *levelShift) relevelPrefix(s Series, c int) Series {
 }
 
 // trainingView returns the series a model should be fitted on for a prefix
-// of length c, applying the same level-shift handling the deployed forecast
-// gets, detected on the prefix alone. A backtest fold therefore never knows
-// about a shift its own history could not yet reveal: a fold ending on the
-// first post-shift point trains on the unmodified prefix, exactly as the
+// of length c, applying the same data preparation the deployed forecast
+// gets, decided from the prefix alone: transient masking (short outlier
+// runs removed, for non-negative metrics unless disabled) and then
+// level-shift handling. A backtest fold therefore never trains on a
+// prefix edited with knowledge of what came after it — a fold ending on
+// the first post-shift point trains on the unmodified prefix, and a point
+// that only later data reveals as a transient stays in — exactly as the
 // deployed model would have at that time, so rolling residuals and
-// ensemble weights are not flattered around the regime change. A shift
-// whose post segment is long enough to model on its own truncates the
-// prefix; a shorter one re-levels the older history to the new regime.
+// ensemble weights are not flattered around outages or regime changes. A
+// shift whose post segment is long enough to model on its own truncates
+// the prefix; a shorter one re-levels the older history to the new regime.
 func trainingView(s Series, cfg Config, c int) Series {
 	prefix := s[:c]
-	if cfg.DisableLevelShift {
+	if cfg.NonNegative && !cfg.DisableAnomalyMask {
+		if idx := detectTransients(prefix, cfg.Interval, cfg.LogTransform, cfg.AnomalySigma, cfg.AnomalyCycles); len(idx) > 0 {
+			prefix = maskIndices(prefix, idx)
+		}
+	}
+	if cfg.DisableLevelShift || len(prefix) == 0 {
 		return prefix
 	}
 	ls := detectLevelShift(prefix)
 	if ls == nil {
 		return prefix
 	}
-	if ls.truncates(c, cfg.Interval) {
+	if ls.truncates(len(prefix), cfg.Interval) {
 		return prefix[ls.idx:]
 	}
-	return ls.relevelPrefix(s, c)
+	return ls.relevelPrefix(prefix, len(prefix))
 }
 
 // formatShiftTime renders a detected shift's timestamp for Result metadata.

--- a/go-cli/internal/forecast/levelshift.go
+++ b/go-cli/internal/forecast/levelshift.go
@@ -1,0 +1,224 @@
+package forecast
+
+import (
+	"math"
+	"time"
+)
+
+// Level-shift handling. A campaign pause, a new traffic source, or an offer
+// cap changes the series' level; fitting all history equally then splits the
+// difference between the old and new regimes.
+//
+// Detection is a CUSUM statistic on one-step residuals of a trailing-mean
+// baseline: a steady trend produces a roughly constant one-step residual
+// (which centering removes), while a level shift produces a burst of large
+// residuals that the CUSUM accumulates. Once a shift is confirmed, its
+// location is the two-segment mean split minimizing SSE, and its magnitude
+// is measured against the pre-shift segment's own linear fit extrapolated
+// forward (the counterfactual level). Run then either truncates the
+// pre-shift history (when the post-shift segment is long enough to model on
+// its own) or re-levels it to the new regime (when it is not, so the old
+// data's shape still helps without dragging the level).
+
+const (
+	// levelShiftMinPoints is the shortest series checked for level shifts:
+	// below it segment statistics are noise and a false detection rewrites
+	// most of the training data.
+	levelShiftMinPoints = 20
+	// levelShiftBaselineWindow is the trailing-mean window for one-step
+	// residuals.
+	levelShiftBaselineWindow = 7
+	// levelShiftMinSegment keeps the change point away from the series
+	// edges, where segment statistics are unstable.
+	levelShiftMinSegment = 4
+	// levelShiftCUSUMThreshold is the significance bound for the normalized
+	// CUSUM statistic max|S_j| / (σ√n). The classic 1.36 Kolmogorov bound
+	// assumes independent residuals; trailing-mean one-step residuals are
+	// autocorrelated and the shift burst inflates σ, so the bound is tuned
+	// empirically instead: flat noise, steady trends, and weekly patterns
+	// measure ≤ ~0.7 while genuine 3σ+ level shifts measure ≥ ~0.9. The
+	// magnitude gate below is the second line of defense.
+	levelShiftCUSUMThreshold = 0.9
+	// levelShiftSigmaMultiple is the minimum shift magnitude, in units of
+	// pre-shift residual noise, worth acting on: smaller shifts cost less
+	// than discarding or rewriting history does.
+	levelShiftSigmaMultiple = 3.0
+)
+
+// minPostShiftPoints returns how many post-shift observations are enough to
+// forecast from the new regime alone (two seasonal cycles for intervals
+// with a natural cycle).
+func minPostShiftPoints(interval Interval) int {
+	switch interval {
+	case IntervalHour:
+		return 48
+	case IntervalDay:
+		return 14
+	default:
+		return 8
+	}
+}
+
+// detectLevelShift scans for the strongest level change in the series.
+// It returns the index of the first post-shift observation and the level
+// delta (post-shift actuals minus the pre-shift fit's extrapolation), or
+// (-1, 0) when no shift passes both the CUSUM significance test and the
+// magnitude threshold.
+func detectLevelShift(s Series) (idx int, delta float64) {
+	n := len(s)
+	if n < levelShiftMinPoints {
+		return -1, 0
+	}
+
+	// One-step residuals against a trailing-mean baseline.
+	resid := make([]float64, 0, n-1)
+	for i := 1; i < n; i++ {
+		lo := i - levelShiftBaselineWindow
+		if lo < 0 {
+			lo = 0
+		}
+		sum := 0.0
+		for j := lo; j < i; j++ {
+			sum += s[j].V
+		}
+		resid = append(resid, s[i].V-sum/float64(i-lo))
+	}
+
+	sigmaR := stddev(resid)
+	if sigmaR <= 0 {
+		return -1, 0
+	}
+	m := mean(resid)
+	maxAbs, cum := 0.0, 0.0
+	for _, r := range resid {
+		cum += r - m
+		if a := math.Abs(cum); a > maxAbs {
+			maxAbs = a
+		}
+	}
+	if maxAbs/(sigmaR*math.Sqrt(float64(len(resid)))) < levelShiftCUSUMThreshold {
+		return -1, 0
+	}
+
+	// Locate the change point: the two-segment mean split minimizing SSE.
+	idx = bestMeanSplit(s)
+	if idx < levelShiftMinSegment || n-idx < 2 {
+		return -1, 0
+	}
+
+	// Magnitude: post-shift actuals vs the pre-shift segment's own linear
+	// fit extrapolated forward, gated against pre-shift noise.
+	pre := s[:idx]
+	slope, intercept := olsFit(pre)
+	base := pre[0].T
+	sum := 0.0
+	for i := idx; i < n; i++ {
+		sum += s[i].V - (intercept + slope*s[i].T.Sub(base).Hours())
+	}
+	delta = sum / float64(n-idx)
+
+	preResid := make([]float64, idx)
+	for i, p := range pre {
+		preResid[i] = p.V - (intercept + slope*p.T.Sub(base).Hours())
+	}
+	if sigmaPre := stddev(preResid); sigmaPre > 0 && math.Abs(delta) < levelShiftSigmaMultiple*sigmaPre {
+		return -1, 0
+	}
+	return idx, delta
+}
+
+// applyLevelShift returns the training series adjusted for a detected shift
+// at idx: the post-shift segment alone when it is long enough, otherwise a
+// copy with pre-shift values re-leveled by delta so the model sees a
+// shift-free series centered on the new regime. The input is not modified.
+func applyLevelShift(s Series, idx int, delta float64, interval Interval) Series {
+	if len(s)-idx >= minPostShiftPoints(interval) {
+		return s[idx:]
+	}
+	out := make(Series, len(s))
+	copy(out, s)
+	for i := 0; i < idx; i++ {
+		out[i].V += delta
+	}
+	return out
+}
+
+// formatShiftTime renders a detected shift's timestamp for Result metadata.
+func formatShiftTime(t time.Time, interval Interval) string {
+	if interval == IntervalHour {
+		return t.Format("2006-01-02 15:04")
+	}
+	return t.Format("2006-01-02")
+}
+
+// bestMeanSplit returns the split index minimizing the two-segment
+// sum of squared deviations from each segment's mean, using prefix sums.
+func bestMeanSplit(s Series) int {
+	n := len(s)
+	prefix := make([]float64, n+1)
+	prefixSq := make([]float64, n+1)
+	for i, p := range s {
+		prefix[i+1] = prefix[i] + p.V
+		prefixSq[i+1] = prefixSq[i] + p.V*p.V
+	}
+	sse := func(lo, hi int) float64 { // [lo, hi)
+		cnt := float64(hi - lo)
+		sum := prefix[hi] - prefix[lo]
+		sumSq := prefixSq[hi] - prefixSq[lo]
+		return sumSq - sum*sum/cnt
+	}
+	best, bestIdx := math.MaxFloat64, -1
+	for j := levelShiftMinSegment; j <= n-levelShiftMinSegment; j++ {
+		if total := sse(0, j) + sse(j, n); total < best {
+			best = total
+			bestIdx = j
+		}
+	}
+	return bestIdx
+}
+
+// olsFit returns the least-squares slope and intercept of the series
+// against calendar-hours since its first point.
+func olsFit(s Series) (slope, intercept float64) {
+	base := s[0].T
+	n := float64(len(s))
+	sumX, sumY, sumXY, sumXX := 0.0, 0.0, 0.0, 0.0
+	for _, p := range s {
+		x := p.T.Sub(base).Hours()
+		sumX += x
+		sumY += p.V
+		sumXY += x * p.V
+		sumXX += x * x
+	}
+	denom := n*sumXX - sumX*sumX
+	if math.Abs(denom) < 1e-12 {
+		return 0, sumY / n
+	}
+	slope = (n*sumXY - sumX*sumY) / denom
+	intercept = (sumY - slope*sumX) / n
+	return slope, intercept
+}
+
+func mean(v []float64) float64 {
+	if len(v) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, x := range v {
+		sum += x
+	}
+	return sum / float64(len(v))
+}
+
+func stddev(v []float64) float64 {
+	if len(v) < 2 {
+		return 0
+	}
+	m := mean(v)
+	sumSq := 0.0
+	for _, x := range v {
+		d := x - m
+		sumSq += d * d
+	}
+	return math.Sqrt(sumSq / float64(len(v)))
+}

--- a/go-cli/internal/forecast/levelshift.go
+++ b/go-cli/internal/forecast/levelshift.go
@@ -15,11 +15,13 @@ import (
 // residuals that the CUSUM accumulates. Once a shift is confirmed, its
 // location is the two-segment mean split minimizing SSE, and its magnitude
 // is measured against the pre-shift segment's own linear fit extrapolated
-// forward (the counterfactual level). Run then either truncates the
-// pre-shift history (when the post-shift segment is long enough to model on
-// its own) or re-levels it to the new regime (when it is not, so the old
-// data's shape still helps without dragging the level). Re-leveling is
-// applied per training prefix so backtest folds never see held-out data.
+// forward (the counterfactual level). The forecast is then fitted either
+// on the post-shift history alone (when that segment is long enough to
+// model on its own) or on all history re-leveled to the new regime (when
+// it is not, so the old data's shape still helps without dragging the
+// level). Detection and handling run per training prefix (trainingView),
+// so backtest folds neither see held-out data nor know of a shift before
+// their own history reveals it.
 
 const (
 	// levelShiftMinPoints is the shortest series checked for level shifts:
@@ -201,13 +203,27 @@ func (ls *levelShift) relevelPrefix(s Series, c int) Series {
 }
 
 // trainingView returns the series a model should be fitted on for a prefix
-// of length c: the prefix itself, or its re-leveled form when a level shift
-// is being handled by re-leveling (cfg.relevel).
+// of length c, applying the same level-shift handling the deployed forecast
+// gets, detected on the prefix alone. A backtest fold therefore never knows
+// about a shift its own history could not yet reveal: a fold ending on the
+// first post-shift point trains on the unmodified prefix, exactly as the
+// deployed model would have at that time, so rolling residuals and
+// ensemble weights are not flattered around the regime change. A shift
+// whose post segment is long enough to model on its own truncates the
+// prefix; a shorter one re-levels the older history to the new regime.
 func trainingView(s Series, cfg Config, c int) Series {
-	if cfg.relevel == nil {
-		return s[:c]
+	prefix := s[:c]
+	if cfg.DisableLevelShift {
+		return prefix
 	}
-	return cfg.relevel.relevelPrefix(s, c)
+	ls := detectLevelShift(prefix)
+	if ls == nil {
+		return prefix
+	}
+	if ls.truncates(c, cfg.Interval) {
+		return prefix[ls.idx:]
+	}
+	return ls.relevelPrefix(s, c)
 }
 
 // formatShiftTime renders a detected shift's timestamp for Result metadata.

--- a/go-cli/internal/forecast/levelshift.go
+++ b/go-cli/internal/forecast/levelshift.go
@@ -18,7 +18,8 @@ import (
 // forward (the counterfactual level). Run then either truncates the
 // pre-shift history (when the post-shift segment is long enough to model on
 // its own) or re-levels it to the new regime (when it is not, so the old
-// data's shape still helps without dragging the level).
+// data's shape still helps without dragging the level). Re-leveling is
+// applied per training prefix so backtest folds never see held-out data.
 
 const (
 	// levelShiftMinPoints is the shortest series checked for level shifts:
@@ -30,7 +31,7 @@ const (
 	levelShiftBaselineWindow = 7
 	// levelShiftMinSegment keeps the change point away from the series
 	// edges, where segment statistics are unstable.
-	levelShiftMinSegment = 4
+	levelShiftMinSegment = 5
 	// levelShiftCUSUMThreshold is the significance bound for the normalized
 	// CUSUM statistic max|S_j| / (σ√n). The classic 1.36 Kolmogorov bound
 	// assumes independent residuals; trailing-mean one-step residuals are
@@ -43,6 +44,14 @@ const (
 	// pre-shift residual noise, worth acting on: smaller shifts cost less
 	// than discarding or rewriting history does.
 	levelShiftSigmaMultiple = 3.0
+	// levelShiftPostSpreadMultiple bounds the post-shift segment's own
+	// spread relative to pre-shift noise; a transient burst (outage, promo
+	// spike) mixed with normal days blows past it.
+	levelShiftPostSpreadMultiple = 2.0
+	// levelShiftAgreeSigma is how far (in pre-shift sigmas) a post-shift
+	// point must sit beyond the old level to count as agreeing with the
+	// shift; a majority must agree.
+	levelShiftAgreeSigma = 1.5
 )
 
 // minPostShiftPoints returns how many post-shift observations are enough to
@@ -59,15 +68,25 @@ func minPostShiftPoints(interval Interval) int {
 	}
 }
 
+// levelShift describes a detected level change: idx is the first post-shift
+// observation, delta the level jump (post-shift actuals minus the pre-shift
+// linear fit extrapolated forward), and slope/intercept/base that pre-shift
+// fit, kept so the jump can be re-estimated from any prefix of the post-shift
+// data (see relevelPrefix).
+type levelShift struct {
+	idx              int
+	delta            float64
+	slope, intercept float64
+	base             time.Time
+}
+
 // detectLevelShift scans for the strongest level change in the series.
-// It returns the index of the first post-shift observation and the level
-// delta (post-shift actuals minus the pre-shift fit's extrapolation), or
-// (-1, 0) when no shift passes both the CUSUM significance test and the
-// magnitude threshold.
-func detectLevelShift(s Series) (idx int, delta float64) {
+// It returns nil when no shift passes the CUSUM significance test, the
+// magnitude threshold, and the post-segment consistency check.
+func detectLevelShift(s Series) *levelShift {
 	n := len(s)
 	if n < levelShiftMinPoints {
-		return -1, 0
+		return nil
 	}
 
 	// One-step residuals against a trailing-mean baseline.
@@ -86,7 +105,7 @@ func detectLevelShift(s Series) (idx int, delta float64) {
 
 	sigmaR := stddev(resid)
 	if sigmaR <= 0 {
-		return -1, 0
+		return nil
 	}
 	m := mean(resid)
 	maxAbs, cum := 0.0, 0.0
@@ -97,13 +116,13 @@ func detectLevelShift(s Series) (idx int, delta float64) {
 		}
 	}
 	if maxAbs/(sigmaR*math.Sqrt(float64(len(resid)))) < levelShiftCUSUMThreshold {
-		return -1, 0
+		return nil
 	}
 
 	// Locate the change point: the two-segment mean split minimizing SSE.
-	idx = bestMeanSplit(s)
-	if idx < levelShiftMinSegment || n-idx < 2 {
-		return -1, 0
+	idx := bestMeanSplit(s)
+	if idx < levelShiftMinSegment || n-idx < levelShiftMinSegment {
+		return nil
 	}
 
 	// Magnitude: post-shift actuals vs the pre-shift segment's own linear
@@ -111,36 +130,84 @@ func detectLevelShift(s Series) (idx int, delta float64) {
 	pre := s[:idx]
 	slope, intercept := olsFit(pre)
 	base := pre[0].T
-	sum := 0.0
+	postResid := make([]float64, 0, n-idx)
 	for i := idx; i < n; i++ {
-		sum += s[i].V - (intercept + slope*s[i].T.Sub(base).Hours())
+		postResid = append(postResid, s[i].V-(intercept+slope*s[i].T.Sub(base).Hours()))
 	}
-	delta = sum / float64(n-idx)
+	delta := mean(postResid)
 
 	preResid := make([]float64, idx)
 	for i, p := range pre {
 		preResid[i] = p.V - (intercept + slope*p.T.Sub(base).Hours())
 	}
-	if sigmaPre := stddev(preResid); sigmaPre > 0 && math.Abs(delta) < levelShiftSigmaMultiple*sigmaPre {
-		return -1, 0
+	// Noise floor: an exactly-fitted pre-segment (sigma 0) must still
+	// require a non-trivial jump, otherwise a clean trend "shifts" by 0.
+	sigmaPre := stddev(preResid)
+	if sigmaPre <= 0 {
+		sigmaPre = 1e-6 * (math.Abs(mean(seriesValues(pre))) + 1)
 	}
-	return idx, delta
+	if math.Abs(delta) < levelShiftSigmaMultiple*sigmaPre {
+		return nil
+	}
+
+	// Consistency: a genuine regime change moves the whole post segment,
+	// with noise comparable to before. A transient burst (a two-day tracking
+	// outage, a promo spike) at the end of history leaves the post segment
+	// internally inconsistent — its own spread dwarfs the pre-shift noise,
+	// or only a minority of its points actually sit beyond the old level —
+	// and must not rewrite the entire training history.
+	if stddev(postResid) > levelShiftPostSpreadMultiple*sigmaPre {
+		return nil
+	}
+	agree := 0
+	for _, r := range postResid {
+		if (delta > 0 && r > levelShiftAgreeSigma*sigmaPre) || (delta < 0 && r < -levelShiftAgreeSigma*sigmaPre) {
+			agree++
+		}
+	}
+	if agree*2 <= len(postResid) {
+		return nil
+	}
+
+	return &levelShift{idx: idx, delta: delta, slope: slope, intercept: intercept, base: base}
 }
 
-// applyLevelShift returns the training series adjusted for a detected shift
-// at idx: the post-shift segment alone when it is long enough, otherwise a
-// copy with pre-shift values re-leveled by delta so the model sees a
-// shift-free series centered on the new regime. The input is not modified.
-func applyLevelShift(s Series, idx int, delta float64, interval Interval) Series {
-	if len(s)-idx >= minPostShiftPoints(interval) {
-		return s[idx:]
+// truncates reports whether the post-shift segment is long enough to be
+// modeled on its own (so pre-shift history is dropped rather than re-leveled).
+func (ls *levelShift) truncates(n int, interval Interval) bool {
+	return n-ls.idx >= minPostShiftPoints(interval)
+}
+
+// relevelPrefix returns the first c points of s with pre-shift values
+// re-leveled to the new regime, using only the post-shift observations
+// inside the prefix to estimate the jump. A rolling-backtest cut therefore
+// never sees the actuals it holds out (no leakage); a prefix ending before
+// any post-shift point is returned unchanged. The input is not modified.
+func (ls *levelShift) relevelPrefix(s Series, c int) Series {
+	if ls == nil || c <= ls.idx {
+		return s[:c]
 	}
-	out := make(Series, len(s))
-	copy(out, s)
-	for i := 0; i < idx; i++ {
+	sum := 0.0
+	for i := ls.idx; i < c; i++ {
+		sum += s[i].V - (ls.intercept + ls.slope*s[i].T.Sub(ls.base).Hours())
+	}
+	delta := sum / float64(c-ls.idx)
+	out := make(Series, c)
+	copy(out, s[:c])
+	for i := 0; i < ls.idx; i++ {
 		out[i].V += delta
 	}
 	return out
+}
+
+// trainingView returns the series a model should be fitted on for a prefix
+// of length c: the prefix itself, or its re-leveled form when a level shift
+// is being handled by re-leveling (cfg.relevel).
+func trainingView(s Series, cfg Config, c int) Series {
+	if cfg.relevel == nil {
+		return s[:c]
+	}
+	return cfg.relevel.relevelPrefix(s, c)
 }
 
 // formatShiftTime renders a detected shift's timestamp for Result metadata.

--- a/go-cli/internal/forecast/linear.go
+++ b/go-cli/internal/forecast/linear.go
@@ -43,20 +43,9 @@ func linearForecast(s Series, cfg Config) ([]Prediction, float64, error) {
 	slope := (n*sumXY - sumX*sumY) / denominator
 	intercept := (sumY - slope*sumX) / n
 
-	// Compute residual standard deviation for confidence bounds.
-	sumResidSq := 0.0
-	for i, p := range s {
-		predicted := intercept + slope*xs[i]
-		diff := p.V - predicted
-		sumResidSq += diff * diff
-	}
-	residStd := 0.0
-	if n > 2 {
-		residStd = math.Sqrt(sumResidSq / (n - 2))
-	}
-
 	// Project forward. Each prediction's x derives from its own timestamp,
 	// so anchor gaps after masked trailing days are handled exactly.
+	// Bounds are attached by Run via conformal prediction.
 	anchor := anchorTime(s, cfg)
 	preds := make([]Prediction, cfg.Horizon)
 	for i := 0; i < cfg.Horizon; i++ {
@@ -65,7 +54,6 @@ func linearForecast(s Series, cfg Config) ([]Prediction, float64, error) {
 		preds[i] = Prediction{T: t, Value: val}
 	}
 
-	addBounds(preds, residStd, cfg.ConfidenceLevel, anchorOffset(s, cfg))
 	return preds, slope, nil
 }
 

--- a/go-cli/internal/forecast/moving_avg.go
+++ b/go-cli/internal/forecast/moving_avg.go
@@ -38,8 +38,6 @@ func smaForecast(s Series, cfg Config) ([]Prediction, float64, error) {
 		preds[i] = Prediction{T: t, Value: avg}
 	}
 
-	stddev := residualStdDev(s, MethodSMA, cfg)
-	addBounds(preds, stddev, cfg.ConfidenceLevel, anchorOffset(s, cfg))
 	return preds, trend, nil
 }
 
@@ -87,7 +85,5 @@ func wmaForecast(s Series, cfg Config) ([]Prediction, float64, error) {
 		preds[i] = Prediction{T: t, Value: wma}
 	}
 
-	stddev := residualStdDev(s, MethodWMA, cfg)
-	addBounds(preds, stddev, cfg.ConfidenceLevel, anchorOffset(s, cfg))
 	return preds, trend, nil
 }

--- a/go-cli/internal/forecast/seasonal.go
+++ b/go-cli/internal/forecast/seasonal.go
@@ -125,15 +125,20 @@ func WeekdayCounts(s Series) map[time.Weekday]int {
 
 // ShrinkWeekdayWeights returns a copy of weights with each multiplier
 // shrunk toward 1.0 by n/(n+k), where n is that weekday's sample count.
-// Days absent from counts are treated as unobserved (full shrinkage to 1.0
-// would leave the hint meaningless, so they keep no weight at all).
+// Weekdays with no observations (absent from counts, or counted zero) are
+// dropped: the history offers no evidence for them, and a fully shrunk 1.0
+// multiplier would be a no-op carried around as if it were a profile.
 func ShrinkWeekdayWeights(weights SeasonalWeights, counts map[time.Weekday]int) SeasonalWeights {
 	if len(weights) == 0 {
 		return weights
 	}
 	out := make(SeasonalWeights, len(weights))
 	for dow, w := range weights {
-		out[dow] = shrinkMultiplier(w, counts[dow])
+		n := counts[dow]
+		if n <= 0 {
+			continue
+		}
+		out[dow] = shrinkMultiplier(w, n)
 	}
 	return out
 }

--- a/go-cli/internal/forecast/seasonal.go
+++ b/go-cli/internal/forecast/seasonal.go
@@ -114,33 +114,89 @@ func shrinkMultiplier(raw float64, n int) float64 {
 	return 1 + (raw-1)*factor
 }
 
-// WeekdayCounts counts how many observations fall on each weekday.
-func WeekdayCounts(s Series) map[time.Weekday]int {
-	counts := map[time.Weekday]int{}
-	for _, p := range s {
-		counts[p.T.Weekday()]++
+// buildWeekdayWeights derives weekday multipliers from a series: each
+// weekday's mean over the overall mean, shrunk toward 1.0 by sample count
+// (see buildSlotWeights). Being a function of the training data alone, it
+// is re-estimated inside every backtest fold (see profileFor), which the
+// report-derived BuildWeekdayWeights cannot be.
+func buildWeekdayWeights(s Series) SeasonalWeights {
+	slots := buildSlotWeights(s, func(t time.Time) int { return int(t.Weekday()) })
+	if slots == nil {
+		return nil
 	}
-	return counts
-}
-
-// ShrinkWeekdayWeights returns a copy of weights with each multiplier
-// shrunk toward 1.0 by n/(n+k), where n is that weekday's sample count.
-// Weekdays with no observations (absent from counts, or counted zero) are
-// dropped: the history offers no evidence for them, and a fully shrunk 1.0
-// multiplier would be a no-op carried around as if it were a profile.
-func ShrinkWeekdayWeights(weights SeasonalWeights, counts map[time.Weekday]int) SeasonalWeights {
-	if len(weights) == 0 {
-		return weights
-	}
-	out := make(SeasonalWeights, len(weights))
-	for dow, w := range weights {
-		n := counts[dow]
-		if n <= 0 {
-			continue
-		}
-		out[dow] = shrinkMultiplier(w, n)
+	out := make(SeasonalWeights, len(slots))
+	for k, w := range slots {
+		out[time.Weekday(k)] = w
 	}
 	return out
+}
+
+// profileFor builds the seasonal multiplier the forecaster applies when it
+// is fitted on the first c points of s (the deployed fit passes len(s)),
+// from that prefix alone, and names the profiles that apply. Every
+// data-derived profile and every gate is re-estimated per prefix, so a
+// backtest fold never scales a held-out point by a multiplier that already
+// contains it, and bands and errors describe the profiled forecaster
+// honestly. Explicit SeasonalWeights are applied as supplied (after the
+// weekly gate). Values fitted under log1p are inverted first: profiles are
+// multiplicative on the reporting scale. Returns nil when nothing applies.
+func profileFor(s Series, cfg Config, c int) (func(time.Time) float64, []string) {
+	prefix := s[:c]
+	if cfg.LogTransform {
+		prefix = expm1Series(prefix)
+	}
+	var names []string
+	var scalers []func(time.Time) float64
+
+	weekday := cfg.SeasonalWeights
+	if len(weekday) == 0 && cfg.WeekdayProfile {
+		weekday = buildWeekdayWeights(prefix)
+	}
+	if len(weekday) > 0 && seasonalGateAllows(prefix, 7*24*time.Hour) {
+		w := weekday
+		scalers = append(scalers, func(t time.Time) float64 { return weekdayWeight(w, t.Weekday()) })
+		names = append(names, "weekday")
+	}
+	if cfg.HourlyProfile && cfg.Interval == IntervalHour && seasonalGateAllows(prefix, 24*time.Hour) {
+		if hourly := BuildHourlyWeights(prefix); len(hourly) > 0 {
+			scalers = append(scalers, func(t time.Time) float64 { return slotWeight(hourly, t.Hour()) })
+			names = append(names, "hourly")
+		}
+	}
+	if cfg.MonthDayProfile {
+		if monthDay := BuildMonthDayWeights(prefix); len(monthDay) > 0 {
+			scalers = append(scalers, func(t time.Time) float64 { return slotWeight(monthDay, t.Day()) })
+			names = append(names, "monthday")
+		}
+	}
+	if len(scalers) == 0 {
+		return nil, nil
+	}
+	return func(t time.Time) float64 {
+		f := 1.0
+		for _, scale := range scalers {
+			f *= scale(t)
+		}
+		return f
+	}, names
+}
+
+// weekdayWeight returns the multiplier a weekday profile defines for d, or
+// 1 when the day is absent.
+func weekdayWeight(weights SeasonalWeights, d time.Weekday) float64 {
+	if w, ok := weights[d]; ok {
+		return w
+	}
+	return 1
+}
+
+// slotWeight returns the multiplier an integer-slot profile defines for
+// slot, or 1 when the slot is absent.
+func slotWeight(weights map[int]float64, slot int) float64 {
+	if w, ok := weights[slot]; ok {
+		return w
+	}
+	return 1
 }
 
 // BuildHourlyWeights derives hour-of-day multipliers from an hourly series:

--- a/go-cli/internal/forecast/seasonal.go
+++ b/go-cli/internal/forecast/seasonal.go
@@ -1,7 +1,6 @@
 package forecast
 
 import (
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -141,8 +140,8 @@ func ShrinkWeekdayWeights(weights SeasonalWeights, counts map[time.Weekday]int) 
 
 // BuildHourlyWeights derives hour-of-day multipliers from an hourly series:
 // each hour's mean over the overall mean, shrunk toward 1.0 by sample count.
-// Returns nil when the series has no positive mean or covers fewer than two
-// distinct hours.
+// Returns nil when the series has negative values or no positive mean
+// (signed metrics get no profile) or covers fewer than two distinct hours.
 func BuildHourlyWeights(s Series) map[int]float64 {
 	return buildSlotWeights(s, func(t time.Time) int { return t.Hour() })
 }
@@ -164,6 +163,12 @@ func buildSlotWeights(s Series, slot func(time.Time) int) map[int]float64 {
 	counts := map[int]int{}
 	total := 0.0
 	for _, p := range s {
+		if p.V < 0 {
+			// Multiplicative profiles only make sense for non-negative
+			// series: a signed metric hovering near zero would produce
+			// negative or unbounded multipliers.
+			return nil
+		}
 		k := slot(p.T)
 		sums[k] += p.V
 		counts[k]++
@@ -173,7 +178,7 @@ func buildSlotWeights(s Series, slot func(time.Time) int) map[int]float64 {
 		return nil
 	}
 	mean := total / float64(len(s))
-	if mean == 0 {
+	if mean <= 0 {
 		return nil
 	}
 	weights := make(map[int]float64, len(sums))
@@ -193,30 +198,15 @@ const seasonalGateThreshold = 0.3
 // linearly detrended values: observations exactly `lag` apart are paired by
 // timestamp (so masked-day gaps don't misalign pairs), and the linear trend
 // is removed first so a trending series doesn't fake seasonal structure.
-// Returns 0 when there are too few pairs or no variance.
-func seasonalLagAutocorrelation(s Series, lag time.Duration) float64 {
+// ok is false when the history is too short to measure the lag (fewer than
+// 8 points or 4 pairs) or has no variance.
+func seasonalLagAutocorrelation(s Series, lag time.Duration) (ac float64, ok bool) {
 	if len(s) < 8 {
-		return 0
+		return 0, false
 	}
 
-	// Detrend: OLS on hours-since-start.
+	slope, intercept := olsFit(s)
 	base := s[0].T
-	n := float64(len(s))
-	sumX, sumY, sumXY, sumXX := 0.0, 0.0, 0.0, 0.0
-	for _, p := range s {
-		x := p.T.Sub(base).Hours()
-		sumX += x
-		sumY += p.V
-		sumXY += x * p.V
-		sumXX += x * x
-	}
-	denom := n*sumXX - sumX*sumX
-	slope, intercept := 0.0, sumY/n
-	if math.Abs(denom) > 1e-12 {
-		slope = (n*sumXY - sumX*sumY) / denom
-		intercept = (sumY - slope*sumX) / n
-	}
-
 	resid := make(map[time.Time]float64, len(s))
 	variance := 0.0
 	for _, p := range s {
@@ -224,9 +214,9 @@ func seasonalLagAutocorrelation(s Series, lag time.Duration) float64 {
 		resid[p.T] = e
 		variance += e * e
 	}
-	variance /= n
+	variance /= float64(len(s))
 	if variance <= 0 {
-		return 0
+		return 0, false
 	}
 
 	cov := 0.0
@@ -238,9 +228,9 @@ func seasonalLagAutocorrelation(s Series, lag time.Duration) float64 {
 		}
 	}
 	if pairs < 4 {
-		return 0
+		return 0, false
 	}
-	return (cov / float64(pairs)) / variance
+	return (cov / float64(pairs)) / variance, true
 }
 
 // extractFloat tries to pull a float64 from an interface{} value,

--- a/go-cli/internal/forecast/seasonal.go
+++ b/go-cli/internal/forecast/seasonal.go
@@ -1,6 +1,7 @@
 package forecast
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -101,6 +102,145 @@ func weekdayFromAPIIndex(idx int) (time.Weekday, bool) {
 		return 0, false
 	}
 	return time.Weekday((idx + 1) % 7), true
+}
+
+// seasonalShrinkK is the shrinkage constant for seasonal multipliers: a
+// profile slot with n samples keeps n/(n+k) of its deviation from 1.0, so
+// two Mondays of data no longer produce a 1.9x Monday multiplier.
+const seasonalShrinkK = 4.0
+
+// shrinkMultiplier pulls a raw multiplier toward 1.0 by n/(n+k).
+func shrinkMultiplier(raw float64, n int) float64 {
+	factor := float64(n) / (float64(n) + seasonalShrinkK)
+	return 1 + (raw-1)*factor
+}
+
+// WeekdayCounts counts how many observations fall on each weekday.
+func WeekdayCounts(s Series) map[time.Weekday]int {
+	counts := map[time.Weekday]int{}
+	for _, p := range s {
+		counts[p.T.Weekday()]++
+	}
+	return counts
+}
+
+// ShrinkWeekdayWeights returns a copy of weights with each multiplier
+// shrunk toward 1.0 by n/(n+k), where n is that weekday's sample count.
+// Days absent from counts are treated as unobserved (full shrinkage to 1.0
+// would leave the hint meaningless, so they keep no weight at all).
+func ShrinkWeekdayWeights(weights SeasonalWeights, counts map[time.Weekday]int) SeasonalWeights {
+	if len(weights) == 0 {
+		return weights
+	}
+	out := make(SeasonalWeights, len(weights))
+	for dow, w := range weights {
+		out[dow] = shrinkMultiplier(w, counts[dow])
+	}
+	return out
+}
+
+// BuildHourlyWeights derives hour-of-day multipliers from an hourly series:
+// each hour's mean over the overall mean, shrunk toward 1.0 by sample count.
+// Returns nil when the series has no positive mean or covers fewer than two
+// distinct hours.
+func BuildHourlyWeights(s Series) map[int]float64 {
+	return buildSlotWeights(s, func(t time.Time) int { return t.Hour() })
+}
+
+// BuildMonthDayWeights derives day-of-month multipliers (1–31) from a daily
+// series — affiliate budgets and payouts often reset monthly. Same
+// multiplier-table pattern and shrinkage as the other profiles.
+func BuildMonthDayWeights(s Series) map[int]float64 {
+	return buildSlotWeights(s, func(t time.Time) int { return t.Day() })
+}
+
+// buildSlotWeights groups observations into integer slots, computes each
+// slot's mean over the overall mean, and shrinks by sample count.
+func buildSlotWeights(s Series, slot func(time.Time) int) map[int]float64 {
+	if len(s) == 0 {
+		return nil
+	}
+	sums := map[int]float64{}
+	counts := map[int]int{}
+	total := 0.0
+	for _, p := range s {
+		k := slot(p.T)
+		sums[k] += p.V
+		counts[k]++
+		total += p.V
+	}
+	if len(counts) < 2 {
+		return nil
+	}
+	mean := total / float64(len(s))
+	if mean == 0 {
+		return nil
+	}
+	weights := make(map[int]float64, len(sums))
+	for k, sum := range sums {
+		raw := (sum / float64(counts[k])) / mean
+		weights[k] = shrinkMultiplier(raw, counts[k])
+	}
+	return weights
+}
+
+// seasonalGateThreshold is the minimum detrended autocorrelation at the
+// seasonal lag for profile weights to be applied; below it the apparent
+// seasonality is noise and adjusting would only add error.
+const seasonalGateThreshold = 0.3
+
+// seasonalLagAutocorrelation measures autocorrelation at a calendar lag on
+// linearly detrended values: observations exactly `lag` apart are paired by
+// timestamp (so masked-day gaps don't misalign pairs), and the linear trend
+// is removed first so a trending series doesn't fake seasonal structure.
+// Returns 0 when there are too few pairs or no variance.
+func seasonalLagAutocorrelation(s Series, lag time.Duration) float64 {
+	if len(s) < 8 {
+		return 0
+	}
+
+	// Detrend: OLS on hours-since-start.
+	base := s[0].T
+	n := float64(len(s))
+	sumX, sumY, sumXY, sumXX := 0.0, 0.0, 0.0, 0.0
+	for _, p := range s {
+		x := p.T.Sub(base).Hours()
+		sumX += x
+		sumY += p.V
+		sumXY += x * p.V
+		sumXX += x * x
+	}
+	denom := n*sumXX - sumX*sumX
+	slope, intercept := 0.0, sumY/n
+	if math.Abs(denom) > 1e-12 {
+		slope = (n*sumXY - sumX*sumY) / denom
+		intercept = (sumY - slope*sumX) / n
+	}
+
+	resid := make(map[time.Time]float64, len(s))
+	variance := 0.0
+	for _, p := range s {
+		e := p.V - (intercept + slope*p.T.Sub(base).Hours())
+		resid[p.T] = e
+		variance += e * e
+	}
+	variance /= n
+	if variance <= 0 {
+		return 0
+	}
+
+	cov := 0.0
+	pairs := 0
+	for _, p := range s {
+		if other, ok := resid[p.T.Add(lag)]; ok {
+			cov += resid[p.T] * other
+			pairs++
+		}
+	}
+	if pairs < 4 {
+		return 0
+	}
+	return (cov / float64(pairs)) / variance
 }
 
 // extractFloat tries to pull a float64 from an interface{} value,

--- a/go-cli/internal/forecast/seasonal.go
+++ b/go-cli/internal/forecast/seasonal.go
@@ -132,16 +132,17 @@ func buildWeekdayWeights(s Series) SeasonalWeights {
 }
 
 // profileFor builds the seasonal multiplier the forecaster applies when it
-// is fitted on the first c points of s (the deployed fit passes len(s)),
-// from that prefix alone, and names the profiles that apply. Every
-// data-derived profile and every gate is re-estimated per prefix, so a
-// backtest fold never scales a held-out point by a multiplier that already
-// contains it, and bands and errors describe the profiled forecaster
-// honestly. Explicit SeasonalWeights are applied as supplied (after the
-// weekly gate). Values fitted under log1p are inverted first: profiles are
-// multiplicative on the reporting scale. Returns nil when nothing applies.
-func profileFor(s Series, cfg Config, c int) (func(time.Time) float64, []string) {
-	prefix := s[:c]
+// is fitted on the training view train (a backtest prefix, or the deployed
+// fit's full history), from that data alone, and names the profiles that
+// apply. Every data-derived profile and every gate is re-estimated per
+// training view, so a backtest fold never scales a held-out point by a
+// multiplier that already contains it, and bands and errors describe the
+// profiled forecaster honestly. Explicit SeasonalWeights are applied as
+// supplied (after the weekly gate). Values fitted under log1p are inverted
+// first: profiles are multiplicative on the reporting scale. Returns nil
+// when nothing applies.
+func profileFor(train Series, cfg Config) (func(time.Time) float64, []string) {
+	prefix := train
 	if cfg.LogTransform {
 		prefix = expm1Series(prefix)
 	}

--- a/go-cli/internal/forecast/suite_measure_test.go
+++ b/go-cli/internal/forecast/suite_measure_test.go
@@ -7,7 +7,7 @@ package forecast
 //
 // It reports, per series and method, the rolling-backtest RMSE/MAE of Run()'s
 // point forecasts and the empirical coverage of the [LowerBound, UpperBound]
-// band (nominal 80% once conformal bounds land). Used to produce the
+// band (nominal 80% at ConfidenceLevel 0.80). Used to produce the
 // before/after numbers quoted in commit messages; skipped by default so CI
 // stays fast.
 
@@ -17,7 +17,6 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-	"time"
 )
 
 var measureFlag = flag.Bool("measure", false, "run the accuracy measurement suite")
@@ -26,14 +25,7 @@ var measureFlag = flag.Bool("measure", false, "run the accuracy measurement suit
 // seasonal, noisy flat, level shift, short, skewed noise, multiplicative.
 // All generators are deterministic (fixed seeds).
 func suiteSeries() map[string]Series {
-	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	mk := func(n int, fn func(i int) float64) Series {
-		s := make(Series, n)
-		for i := 0; i < n; i++ {
-			s[i] = Point{T: base.AddDate(0, 0, i), V: fn(i)}
-		}
-		return s
-	}
+	mk := makeSeries
 
 	weekly := []float64{0.7, 1.1, 1.25, 1.2, 1.15, 1.0, 0.6} // Mon..Sun-ish shape
 

--- a/go-cli/internal/forecast/suite_measure_test.go
+++ b/go-cli/internal/forecast/suite_measure_test.go
@@ -1,0 +1,160 @@
+package forecast
+
+// Rolling-origin accuracy measurement over a representative-series suite.
+// Run with:
+//
+//	go test ./internal/forecast/ -run TestMeasureSuite -v -measure
+//
+// It reports, per series and method, the rolling-backtest RMSE/MAE of Run()'s
+// point forecasts and the empirical coverage of the [LowerBound, UpperBound]
+// band (nominal 80% once conformal bounds land). Used to produce the
+// before/after numbers quoted in commit messages; skipped by default so CI
+// stays fast.
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+var measureFlag = flag.Bool("measure", false, "run the accuracy measurement suite")
+
+// suiteSeries returns the representative test series: trend, plateau, weekly
+// seasonal, noisy flat, level shift, short, skewed noise, multiplicative.
+// All generators are deterministic (fixed seeds).
+func suiteSeries() map[string]Series {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mk := func(n int, fn func(i int) float64) Series {
+		s := make(Series, n)
+		for i := 0; i < n; i++ {
+			s[i] = Point{T: base.AddDate(0, 0, i), V: fn(i)}
+		}
+		return s
+	}
+
+	weekly := []float64{0.7, 1.1, 1.25, 1.2, 1.15, 1.0, 0.6} // Mon..Sun-ish shape
+
+	out := map[string]Series{}
+
+	rng := rand.New(rand.NewSource(11))
+	out["trend_up"] = mk(90, func(i int) float64 {
+		return 100 + 3*float64(i) + rng.NormFloat64()*8
+	})
+
+	rng2 := rand.New(rand.NewSource(22))
+	out["trend_plateau"] = mk(90, func(i int) float64 {
+		v := 300.0
+		if i < 45 {
+			v = 100 + (200.0/45.0)*float64(i)
+		}
+		return v + rng2.NormFloat64()*6
+	})
+
+	rng3 := rand.New(rand.NewSource(33))
+	out["weekly_seasonal"] = mk(90, func(i int) float64 {
+		return 100*weekly[i%7] + rng3.NormFloat64()*5
+	})
+
+	rng4 := rand.New(rand.NewSource(44))
+	out["noisy_flat"] = mk(90, func(i int) float64 {
+		return 100 + rng4.NormFloat64()*15
+	})
+
+	rng5 := rand.New(rand.NewSource(55))
+	out["level_shift"] = mk(90, func(i int) float64 {
+		lvl := 100.0
+		if i >= 45 {
+			lvl = 170
+		}
+		return lvl + rng5.NormFloat64()*8
+	})
+
+	rng6 := rand.New(rand.NewSource(66))
+	out["short"] = mk(12, func(i int) float64 {
+		return 50 + 2*float64(i) + rng6.NormFloat64()*4
+	})
+
+	// Skewed (exponential) noise around a flat level: mean-zero but asymmetric.
+	rng7 := rand.New(rand.NewSource(77))
+	out["skewed_noise"] = mk(90, func(i int) float64 {
+		return 100 + (rng7.ExpFloat64()-1)*20
+	})
+
+	rng8 := rand.New(rand.NewSource(88))
+	out["mult_growth"] = mk(90, func(i int) float64 {
+		v := 40 * math.Pow(1.02, float64(i))
+		return v * (1 + rng8.NormFloat64()*0.06)
+	})
+
+	return out
+}
+
+// rollingMeasure runs Run() at multiple cut points and aggregates point-error
+// and band-coverage stats against the held-out tail. lowMiss/highMiss are the
+// per-tail escape rates (each nominally 10% for an 80% band).
+func rollingMeasure(s Series, method Method, horizon int) (rmse, mae, coverage, lowMiss, highMiss float64, n int) {
+	minTrain := 9
+	sumSq, sumAbs := 0.0, 0.0
+	covered, low, high := 0, 0, 0
+
+	for c := minTrain; c < len(s); c += 2 {
+		steps := len(s) - c
+		if steps > horizon {
+			steps = horizon
+		}
+		train := make(Series, c)
+		copy(train, s[:c])
+		res, err := Run(train, Config{
+			Method:          method,
+			Horizon:         steps,
+			Interval:        IntervalDay,
+			ConfidenceLevel: 0.80,
+		})
+		if err != nil {
+			continue
+		}
+		for i := 0; i < steps && i < len(res.Predictions); i++ {
+			actual := s[c+i].V
+			p := res.Predictions[i]
+			diff := actual - p.Value
+			sumSq += diff * diff
+			sumAbs += math.Abs(diff)
+			switch {
+			case actual < p.LowerBound:
+				low++
+			case actual > p.UpperBound:
+				high++
+			default:
+				covered++
+			}
+			n++
+		}
+	}
+	if n == 0 {
+		return 0, 0, 0, 0, 0, 0
+	}
+	fn := float64(n)
+	return math.Sqrt(sumSq / fn), sumAbs / fn, float64(covered) / fn, float64(low) / fn, float64(high) / fn, n
+}
+
+func TestMeasureSuite(t *testing.T) {
+	if !*measureFlag {
+		t.Skip("measurement suite disabled; pass -measure to run")
+	}
+	methods := []Method{MethodAuto, MethodLinear, MethodSMA, MethodWMA, MethodHoltWinters}
+	series := suiteSeries()
+	names := []string{"trend_up", "trend_plateau", "weekly_seasonal", "noisy_flat",
+		"level_shift", "short", "skewed_noise", "mult_growth"}
+
+	for _, name := range names {
+		s := series[name]
+		for _, m := range methods {
+			rmse, mae, cov, low, high, n := rollingMeasure(s, m, 7)
+			fmt.Printf("%-16s %-12s rmse=%8.2f mae=%8.2f cover80=%5.1f%% lowMiss=%4.1f%% highMiss=%4.1f%% n=%d\n",
+				name, m, rmse, mae, cov*100, low*100, high*100, n)
+		}
+	}
+}

--- a/go-cli/internal/forecast/transient_suite_test.go
+++ b/go-cli/internal/forecast/transient_suite_test.go
@@ -1,0 +1,194 @@
+package forecast
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// transientSuite returns representative series that contain transients or
+// patterns that look like transients but are not: sparse tracking outages,
+// one-off spikes, a business closed on Sundays, and a low-volume tracker.
+// Deterministic (fixed seeds).
+func transientSuite() (map[string]Series, []string) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	out := map[string]Series{}
+	names := []string{"outages", "spikes", "outage_on_trend", "closed_sundays", "poisson_low", "weekly_with_outage"}
+
+	rng := rand.New(rand.NewSource(201))
+	out["outages"] = makeSeries(120, func(i int) float64 {
+		if i == 25 || i == 26 || i == 70 || i == 105 {
+			return 0
+		}
+		return 500 + rng.NormFloat64()*25
+	})
+
+	rng2 := rand.New(rand.NewSource(202))
+	out["spikes"] = makeSeries(120, func(i int) float64 {
+		if i == 40 || i == 88 {
+			return 2500
+		}
+		return 400 + rng2.NormFloat64()*30
+	})
+
+	rng3 := rand.New(rand.NewSource(203))
+	out["outage_on_trend"] = makeSeries(120, func(i int) float64 {
+		if i == 60 || i == 61 {
+			return 0
+		}
+		return 200 + 3*float64(i) + rng3.NormFloat64()*15
+	})
+
+	rng4 := rand.New(rand.NewSource(204))
+	out["closed_sundays"] = makeSeries(120, func(i int) float64 {
+		if base.AddDate(0, 0, i).Weekday() == time.Sunday {
+			return 0
+		}
+		return 300 + rng4.NormFloat64()*20
+	})
+
+	rng5 := rand.New(rand.NewSource(205))
+	out["poisson_low"] = makeSeries(120, func(i int) float64 {
+		// Poisson(3) via inversion.
+		l, k, p := math.Exp(-3), 0, 1.0
+		for {
+			p *= rng5.Float64()
+			if p < l {
+				return float64(k)
+			}
+			k++
+		}
+	})
+
+	rng6 := rand.New(rand.NewSource(206))
+	weekly := []float64{0.7, 1.1, 1.25, 1.2, 1.15, 1.0, 0.6}
+	out["weekly_with_outage"] = makeSeries(120, func(i int) float64 {
+		if i == 80 {
+			return 0
+		}
+		return 300*weekly[i%7] + rng6.NormFloat64()*15
+	})
+	return out, names
+}
+
+// transientStats measures rolling-backtest accuracy and band behavior
+// with masking on or off. Evaluation points that are themselves transients
+// are excluded from RMSE (no forecaster should be scored on predicting an
+// outage) but counted separately as "flagged": actuals outside the band,
+// which is what the alerting layer sees.
+type transientStats struct {
+	rmse, coverage, flaggedTransients float64
+	masked, n, transients             int
+}
+
+func rollingTransient(s Series, transientIdx map[int]bool, disable bool) transientStats {
+	sumSq, covered, flagged, masked, n, nt := 0.0, 0, 0, 0, 0, 0
+	for c := 30; c < len(s); c += 2 {
+		steps := len(s) - c
+		if steps > 7 {
+			steps = 7
+		}
+		train := make(Series, c)
+		copy(train, s[:c])
+		res, err := Run(train, Config{Method: MethodAuto, Horizon: steps, Interval: IntervalDay,
+			ConfidenceLevel: 0.80, NonNegative: true, LogTransform: true, DisableAnomalyMask: disable})
+		if err != nil {
+			continue
+		}
+		masked += len(res.AnomaliesMasked)
+		for i := 0; i < steps; i++ {
+			actual := s[c+i].V
+			p := res.Predictions[i]
+			if transientIdx[c+i] {
+				nt++
+				if actual < p.LowerBound || actual > p.UpperBound {
+					flagged++
+				}
+				continue
+			}
+			d := actual - p.Value
+			sumSq += d * d
+			if actual >= p.LowerBound && actual <= p.UpperBound {
+				covered++
+			}
+			n++
+		}
+	}
+	st := transientStats{masked: masked, n: n, transients: nt}
+	if n > 0 {
+		st.rmse = math.Sqrt(sumSq / float64(n))
+		st.coverage = float64(covered) / float64(n)
+	}
+	if nt > 0 {
+		st.flaggedTransients = float64(flagged) / float64(nt)
+	}
+	return st
+}
+
+// transientIndices marks the injected transient points per suite series.
+func transientIndices(name string) map[int]bool {
+	m := map[int]bool{}
+	switch name {
+	case "outages":
+		for _, i := range []int{25, 26, 70, 105} {
+			m[i] = true
+		}
+	case "spikes":
+		m[40], m[88] = true, true
+	case "outage_on_trend":
+		m[60], m[61] = true, true
+	case "weekly_with_outage":
+		m[80] = true
+	}
+	return m
+}
+
+func TestMeasureTransientSuite(t *testing.T) {
+	if !*measureFlag {
+		t.Skip("measurement suite disabled; pass -measure to run")
+	}
+	series, names := transientSuite()
+	for _, name := range names {
+		idx := transientIndices(name)
+		for _, disable := range []bool{true, false} {
+			st := rollingTransient(series[name], idx, disable)
+			label := "masked"
+			if disable {
+				label = "unmasked"
+			}
+			fmt.Printf("%-20s %-8s rmse=%8.2f cover80=%5.1f%% masked_pts=%3d transients_flagged=%5.1f%% (n=%d, transients=%d)\n",
+				name, label, st.rmse, st.coverage*100, st.masked, st.flaggedTransients*100, st.n, st.transients)
+		}
+	}
+}
+
+// TestTransientMaskingHelpsAndDoesNoHarm enforces the masking contract on
+// a rolling backtest: on series with injected transients, masking must not
+// worsen point accuracy on normal days and must keep the transients
+// outside the band (so alerting sees them); on series whose "outliers" are
+// their own pattern, masking must fire rarely and leave accuracy intact.
+func TestTransientMaskingHelpsAndDoesNoHarm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping rolling-suite comparison in -short mode")
+	}
+	series, names := transientSuite()
+	for _, name := range names {
+		idx := transientIndices(name)
+		off := rollingTransient(series[name], idx, true)
+		on := rollingTransient(series[name], idx, false)
+		t.Logf("%s: rmse %.2f -> %.2f, coverage %.1f%% -> %.1f%%, masked %d, transients flagged %.0f%% -> %.0f%%",
+			name, off.rmse, on.rmse, off.coverage*100, on.coverage*100, on.masked,
+			off.flaggedTransients*100, on.flaggedTransients*100)
+		if on.rmse > off.rmse*1.02 {
+			t.Errorf("%s: masking worsened rolling RMSE %.2f -> %.2f", name, off.rmse, on.rmse)
+		}
+		if len(idx) > 0 && on.flaggedTransients < 0.9 {
+			t.Errorf("%s: only %.0f%% of transients fall outside the band with masking on", name, on.flaggedTransients*100)
+		}
+		if len(idx) == 0 && on.masked > 2 {
+			t.Errorf("%s: %d points masked on a series with no transients", name, on.masked)
+		}
+	}
+}

--- a/go-cli/internal/forecast/transient_suite_test.go
+++ b/go-cli/internal/forecast/transient_suite_test.go
@@ -192,3 +192,49 @@ func TestTransientMaskingHelpsAndDoesNoHarm(t *testing.T) {
 		}
 	}
 }
+
+func TestTrainingView_MasksTransientsPerPrefix(t *testing.T) {
+	// A one-day spike at index 40 in a flat series. A prefix's training
+	// view must depend on that prefix alone (adding later points never
+	// changes it), the deployed view drops the spike, the prefix ending
+	// before the spike is untouched, and the spike's date is never scored.
+	rng := rand.New(rand.NewSource(8))
+	s := makeSeries(60, func(i int) float64 {
+		if i == 40 {
+			return 3000
+		}
+		return 500 + rng.NormFloat64()*20
+	})
+	cfg := withDefaults(Config{Interval: IntervalDay, NonNegative: true})
+	for _, c := range []int{30, 40, 41, 45, 60} {
+		whole := trainingView(s, cfg, c)
+		alone := trainingView(s[:c], cfg, c)
+		if len(whole) != len(alone) {
+			t.Fatalf("prefix %d: view from the full series has %d points, from the prefix alone %d", c, len(whole), len(alone))
+		}
+		for i := range whole {
+			if !whole[i].T.Equal(alone[i].T) || whole[i].V != alone[i].V {
+				t.Fatalf("prefix %d: view differs at %d depending on data after the prefix", c, i)
+			}
+		}
+	}
+	if got := len(trainingView(s, cfg, 60)); got != 59 {
+		t.Errorf("deployed view has %d points, want 59 (spike masked)", got)
+	}
+	if got := len(trainingView(s, cfg, 40)); got != 40 {
+		t.Errorf("prefix before the spike has %d points, want 40 (nothing to mask)", got)
+	}
+
+	res, err := Run(s, Config{Interval: IntervalDay, NonNegative: true, Method: MethodSMA, Horizon: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.AnomaliesMasked) != 1 || res.DataPoints != 59 {
+		t.Errorf("anomalies %v, data points %d; want the spike reported and 59 fitted", res.AnomaliesMasked, res.DataPoints)
+	}
+	for k := range res.rolling {
+		if k.target.Equal(s[40].T) {
+			t.Fatal("a masked transient was scored as a held-out actual")
+		}
+	}
+}

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -103,19 +103,21 @@ func TestBuildMonthDayWeights(t *testing.T) {
 func TestSeasonalLagAutocorrelation(t *testing.T) {
 	weekly := []float64{0.6, 1.1, 1.3, 1.2, 1.1, 1.0, 0.7}
 	strong := makeSeries(56, func(i int) float64 { return 100 * weekly[i%7] })
-	if ac := seasonalLagAutocorrelation(strong, 7*24*time.Hour); ac < 0.8 {
+	if ac, ok := seasonalLagAutocorrelation(strong, 7*24*time.Hour); !ok || ac < 0.8 {
 		t.Errorf("weekly series lag-7 autocorr = %.3f, want > 0.8", ac)
 	}
 
 	rng := rand.New(rand.NewSource(71))
 	flat := makeSeries(56, func(i int) float64 { return 100 + rng.NormFloat64()*10 })
-	if ac := seasonalLagAutocorrelation(flat, 7*24*time.Hour); math.Abs(ac) > 0.3 {
+	if ac, ok := seasonalLagAutocorrelation(flat, 7*24*time.Hour); !ok || math.Abs(ac) > 0.3 {
 		t.Errorf("flat series lag-7 autocorr = %.3f, want near 0", ac)
 	}
 
 	// A strong trend must not fake weekly structure (detrended first).
 	trend := makeSeries(56, func(i int) float64 { return 100 + 10*float64(i) })
-	if ac := seasonalLagAutocorrelation(trend, 7*24*time.Hour); ac > 0.5 {
+	// (An exact line has no residual variance, so the gate reports "not
+	// measurable" rather than a high correlation.)
+	if ac, ok := seasonalLagAutocorrelation(trend, 7*24*time.Hour); ok && ac > 0.5 {
 		t.Errorf("pure trend lag-7 autocorr = %.3f, want low after detrending", ac)
 	}
 }
@@ -129,25 +131,28 @@ func TestDetectLevelShift(t *testing.T) {
 		}
 		return lvl + rng.NormFloat64()*8
 	})
-	idx, delta := detectLevelShift(shifted)
-	if idx < 25 || idx > 35 {
-		t.Fatalf("shift detected at index %d, want near 30", idx)
+	ls := detectLevelShift(shifted)
+	if ls == nil {
+		t.Fatal("no shift detected on a 70-unit step")
 	}
-	if delta < 30 {
-		t.Errorf("shift delta = %.1f, want strongly positive", delta)
+	if ls.idx < 25 || ls.idx > 35 {
+		t.Fatalf("shift detected at index %d, want near 30", ls.idx)
+	}
+	if ls.delta < 30 {
+		t.Errorf("shift delta = %.1f, want strongly positive", ls.delta)
 	}
 
 	rng2 := rand.New(rand.NewSource(74))
 	flat := makeSeries(60, func(i int) float64 { return 100 + rng2.NormFloat64()*8 })
-	if idx, _ := detectLevelShift(flat); idx >= 0 {
-		t.Errorf("false-positive shift at index %d on flat series", idx)
+	if ls := detectLevelShift(flat); ls != nil {
+		t.Errorf("false-positive shift at index %d on flat series", ls.idx)
 	}
 
 	// A steady trend is not a level shift.
 	rng3 := rand.New(rand.NewSource(75))
 	trend := makeSeries(60, func(i int) float64 { return 100 + 3*float64(i) + rng3.NormFloat64()*8 })
-	if idx, _ := detectLevelShift(trend); idx >= 0 {
-		t.Errorf("false-positive shift at index %d on trending series", idx)
+	if ls := detectLevelShift(trend); ls != nil {
+		t.Errorf("false-positive shift at index %d on trending series", ls.idx)
 	}
 }
 
@@ -348,5 +353,177 @@ func TestRun_MonthDayWeightsApplied(t *testing.T) {
 	}
 	if first <= other {
 		t.Errorf("day-1 prediction %.1f not above other days %.1f", first, other)
+	}
+}
+
+func TestDetectLevelShift_IgnoresEndOfHistoryBurst(t *testing.T) {
+	// A 2-day tracking outage (or promo spike) at the end of history is a
+	// transient, not a regime change: the forecast must stay near the
+	// established level and no level_shift_at may be reported.
+	cases := []struct {
+		name string
+		tail float64
+	}{
+		{"outage", 0},
+		{"promo_spike", 2000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(1))
+			s := makeSeries(60, func(i int) float64 {
+				if i >= 58 {
+					return tc.tail
+				}
+				return 500 + rng.NormFloat64()*20
+			})
+			if ls := detectLevelShift(s); ls != nil {
+				t.Fatalf("burst misread as level shift at index %d", ls.idx)
+			}
+			for _, logT := range []bool{false, true} {
+				in := make(Series, len(s))
+				copy(in, s)
+				r, err := Run(in, Config{Method: MethodAuto, Horizon: 3, Interval: IntervalDay, NonNegative: true, LogTransform: logT})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if r.LevelShiftAt != "" {
+					t.Errorf("logTransform=%v: level_shift_at = %q, want none", logT, r.LevelShiftAt)
+				}
+				if r.DataPoints != 60 {
+					t.Errorf("logTransform=%v: data points = %d, want 60 (history rewritten)", logT, r.DataPoints)
+				}
+			}
+			// On the natural scale the moving averages absorb a 2-day
+			// burst; the forecast stays near the established level.
+			r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v := r.Predictions[0].Value; v < 350 || v > 800 {
+				t.Errorf("prediction = %.1f, want near the 500 level (burst rewrote history)", v)
+			}
+		})
+	}
+}
+
+func TestRun_DisableLevelShift(t *testing.T) {
+	rng := rand.New(rand.NewSource(77))
+	s := makeSeries(90, func(i int) float64 {
+		lvl := 100.0
+		if i >= 45 {
+			lvl = 170
+		}
+		return lvl + rng.NormFloat64()*8
+	})
+	r, err := Run(s, Config{Method: MethodLinear, Horizon: 3, Interval: IntervalDay, DisableLevelShift: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.LevelShiftAt != "" {
+		t.Errorf("level shift handled despite DisableLevelShift: %q", r.LevelShiftAt)
+	}
+	if r.DataPoints != 90 {
+		t.Errorf("data points = %d, want 90 (no truncation)", r.DataPoints)
+	}
+}
+
+func TestRun_DataPointsReflectTruncation(t *testing.T) {
+	rng := rand.New(rand.NewSource(77))
+	s := makeSeries(90, func(i int) float64 {
+		lvl := 100.0
+		if i >= 45 {
+			lvl = 170
+		}
+		return lvl + rng.NormFloat64()*8
+	})
+	r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.LevelShiftAt == "" {
+		t.Fatal("expected a level shift")
+	}
+	if r.DataPoints >= 90 || r.DataPoints < 14 {
+		t.Errorf("data points = %d, want the post-shift count actually fitted", r.DataPoints)
+	}
+}
+
+func TestRelevelPrefix_NoLeakage(t *testing.T) {
+	// The re-leveled prefix must be estimated from post-shift points inside
+	// the prefix only: a prefix ending before the shift is unchanged, and a
+	// prefix with one post-shift point uses just that point's jump.
+	s := makeSeries(30, func(i int) float64 {
+		if i >= 25 {
+			return 300
+		}
+		return 100
+	})
+	ls := &levelShift{idx: 25, slope: 0, intercept: 100, base: s[0].T}
+	pre := ls.relevelPrefix(s, 20)
+	if pre[0].V != 100 {
+		t.Errorf("prefix before the shift was re-leveled to %.1f", pre[0].V)
+	}
+	one := ls.relevelPrefix(s, 26)
+	if math.Abs(one[0].V-300) > 1e-9 {
+		t.Errorf("prefix with one post-shift point re-leveled to %.1f, want 300", one[0].V)
+	}
+	if s[0].V != 100 {
+		t.Error("relevelPrefix modified its input")
+	}
+}
+
+func TestRun_LogTransformKeepsMovingAverageTrend(t *testing.T) {
+	// SMA's trend (avg − prevAvg) must survive the log transform as an
+	// absolute per-period change on the original scale, not collapse to 0.
+	s := makeSeries(40, func(i int) float64 { return 100 + 5*float64(i) })
+	r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, LogTransform: true, NonNegative: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Trend < 3 || r.Trend > 7 {
+		t.Errorf("SMA trend under log transform = %.3f, want ~5", r.Trend)
+	}
+}
+
+func TestBuildSlotWeights_SignedMetricGetsNoProfile(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	profit := makeSeries(60, func(i int) float64 { return rng.NormFloat64() * 50 })
+	if w := BuildMonthDayWeights(profit); w != nil {
+		t.Errorf("expected no month-day profile for a series with non-positive mean, got %v", w)
+	}
+	// Even a positive-mean series gets no profile once any value is
+	// negative: the metric is signed and the multipliers would be too.
+	mixed := makeSeries(60, func(i int) float64 {
+		if i%30 == 0 {
+			return -50
+		}
+		return 100
+	})
+	if w := BuildMonthDayWeights(mixed); w != nil {
+		t.Errorf("expected no profile for a series with negative values, got %v", w)
+	}
+}
+
+func TestSeasonalGateAllowsShortHistory(t *testing.T) {
+	// Too short to measure the weekly lag: no evidence against the profile,
+	// so supplied weights apply.
+	s := makeSeries(7, func(i int) float64 { return 100 })
+	if !seasonalGateAllows(s, 7*24*time.Hour) {
+		t.Error("gate rejected weights on a history too short to measure")
+	}
+}
+
+func TestAnchorOffset_CalendarMonths(t *testing.T) {
+	base := time.Date(2025, 11, 1, 0, 0, 0, 0, time.UTC)
+	s := Series{}
+	for i := 0; i < 4; i++ { // Nov, Dec, Jan, Feb
+		s = append(s, Point{T: base.AddDate(0, i, 0), V: 100})
+	}
+	// Feb 1 -> Mar 1 is 28 days: exactly one month step, not 0.
+	if got := anchorOffset(s, Config{Interval: IntervalMonth, Anchor: base.AddDate(0, 4, 0)}); got != 1 {
+		t.Errorf("month offset = %d, want 1", got)
+	}
+	if got := anchorOffset(s, Config{Interval: IntervalMonth, Anchor: base.AddDate(0, 5, 0)}); got != 2 {
+		t.Errorf("two-month offset = %d, want 2", got)
 	}
 }

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -662,3 +662,59 @@ func TestDetectTransients_ThresholdIsTunable(t *testing.T) {
 		t.Errorf("AnomalyCycles 2 masked %v, want the one dip", r.AnomaliesMasked)
 	}
 }
+
+func TestTrainingView_DetectsLevelShiftPerPrefix(t *testing.T) {
+	// A shift eight points before the end is handled by re-leveling on the
+	// full series, but a backtest prefix must only know what its own
+	// history reveals: a prefix ending on the first post-shift point, or
+	// before the shift, trains on unmodified data.
+	rng := rand.New(rand.NewSource(5))
+	s := makeSeries(60, func(i int) float64 {
+		lvl := 100.0
+		if i >= 52 {
+			lvl = 180
+		}
+		return lvl + rng.NormFloat64()*4
+	})
+	cfg := Config{Interval: IntervalDay}
+
+	full := trainingView(s, cfg, 60)
+	if len(full) != 60 {
+		t.Fatalf("full view has %d points, want 60 (re-leveled, not truncated)", len(full))
+	}
+	if math.Abs(full[0].V-s[0].V) < 40 {
+		t.Errorf("full view first point %.1f ≈ original %.1f; expected re-leveling to the new regime", full[0].V, s[0].V)
+	}
+	for _, c := range []int{50, 53} {
+		view := trainingView(s, cfg, c)
+		if len(view) != c {
+			t.Fatalf("prefix %d: view has %d points", c, len(view))
+		}
+		for i := range view {
+			if view[i].V != s[i].V {
+				t.Fatalf("prefix %d was modified at %d (%.2f vs %.2f): fold knows about a shift its history cannot reveal", c, i, view[i].V, s[i].V)
+			}
+		}
+	}
+	if disabled := trainingView(s, Config{Interval: IntervalDay, DisableLevelShift: true}, 60); disabled[0].V != s[0].V {
+		t.Error("DisableLevelShift should leave the training view untouched")
+	}
+}
+
+func TestTrainingView_TruncatesInsidePrefix(t *testing.T) {
+	// A shift with a long post segment truncates: a prefix that already
+	// holds 25 post-shift points trains on those alone, as the deployed
+	// model would have.
+	rng := rand.New(rand.NewSource(6))
+	s := makeSeries(60, func(i int) float64 {
+		lvl := 100.0
+		if i >= 20 {
+			lvl = 170
+		}
+		return lvl + rng.NormFloat64()*5
+	})
+	view := trainingView(s, Config{Interval: IntervalDay}, 45)
+	if len(view) != 25 || !view[0].T.Equal(s[20].T) {
+		t.Errorf("view has %d points starting %v, want 25 starting %v", len(view), view[0].T, s[20].T)
+	}
+}

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -1,0 +1,352 @@
+package forecast
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestShrinkMultiplier(t *testing.T) {
+	tests := []struct {
+		raw  float64
+		n    int
+		want float64
+	}{
+		{1.9, 2, 1.3},    // 1 + 0.9 * 2/6: two samples barely move the needle
+		{1.9, 96, 1.864}, // 1 + 0.9 * 96/100: plenty of data keeps the signal
+		{1.0, 0, 1.0},
+		{0.4, 4, 0.7}, // 1 - 0.6 * 4/8
+	}
+	for _, tc := range tests {
+		got := shrinkMultiplier(tc.raw, tc.n)
+		if math.Abs(got-tc.want) > 0.001 {
+			t.Errorf("shrinkMultiplier(%v, %d) = %.4f, want %.4f", tc.raw, tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestShrinkWeekdayWeights(t *testing.T) {
+	weights := SeasonalWeights{time.Monday: 1.9, time.Friday: 0.5}
+	counts := map[time.Weekday]int{time.Monday: 2, time.Friday: 12}
+	shrunk := ShrinkWeekdayWeights(weights, counts)
+	if math.Abs(shrunk[time.Monday]-1.3) > 0.001 {
+		t.Errorf("Monday shrunk to %.3f, want 1.3 (2 samples)", shrunk[time.Monday])
+	}
+	if math.Abs(shrunk[time.Friday]-0.625) > 0.001 {
+		t.Errorf("Friday shrunk to %.3f, want 0.625 (12 samples)", shrunk[time.Friday])
+	}
+	// Input untouched.
+	if weights[time.Monday] != 1.9 {
+		t.Error("ShrinkWeekdayWeights modified its input")
+	}
+}
+
+func TestWeekdayCounts(t *testing.T) {
+	s := makeSeries(15, func(i int) float64 { return 1 }) // 2026-01-01 is a Thursday
+	counts := WeekdayCounts(s)
+	total := 0
+	for _, n := range counts {
+		total += n
+	}
+	if total != 15 {
+		t.Errorf("counts sum to %d, want 15", total)
+	}
+	if counts[time.Thursday] != 3 { // Jan 1, 8, 15
+		t.Errorf("Thursday count = %d, want 3", counts[time.Thursday])
+	}
+}
+
+func TestBuildHourlyWeights(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := make(Series, 0, 240)
+	for i := 0; i < 240; i++ { // 10 days of hourly data
+		t := base.Add(time.Duration(i) * time.Hour)
+		v := 100.0
+		if t.Hour() == 12 {
+			v = 200 // lunchtime spike
+		}
+		s = append(s, Point{T: t, V: v})
+	}
+	weights := BuildHourlyWeights(s)
+	if weights == nil {
+		t.Fatal("expected non-nil hourly weights")
+	}
+	if weights[12] < 1.3 {
+		t.Errorf("hour-12 weight = %.3f, want clearly above 1 (spike hour)", weights[12])
+	}
+	if weights[3] > 1.0 {
+		t.Errorf("hour-3 weight = %.3f, want below 1", weights[3])
+	}
+}
+
+func TestBuildMonthDayWeights(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := make(Series, 0, 90)
+	for i := 0; i < 90; i++ {
+		t := base.AddDate(0, 0, i)
+		v := 100.0
+		if t.Day() == 1 {
+			v = 300 // budget reset spike
+		}
+		s = append(s, Point{T: t, V: v})
+	}
+	weights := BuildMonthDayWeights(s)
+	if weights == nil {
+		t.Fatal("expected non-nil month-day weights")
+	}
+	if weights[1] < 1.5 {
+		t.Errorf("day-1 weight = %.3f, want clearly above 1", weights[1])
+	}
+}
+
+func TestSeasonalLagAutocorrelation(t *testing.T) {
+	weekly := []float64{0.6, 1.1, 1.3, 1.2, 1.1, 1.0, 0.7}
+	strong := makeSeries(56, func(i int) float64 { return 100 * weekly[i%7] })
+	if ac := seasonalLagAutocorrelation(strong, 7*24*time.Hour); ac < 0.8 {
+		t.Errorf("weekly series lag-7 autocorr = %.3f, want > 0.8", ac)
+	}
+
+	rng := rand.New(rand.NewSource(71))
+	flat := makeSeries(56, func(i int) float64 { return 100 + rng.NormFloat64()*10 })
+	if ac := seasonalLagAutocorrelation(flat, 7*24*time.Hour); math.Abs(ac) > 0.3 {
+		t.Errorf("flat series lag-7 autocorr = %.3f, want near 0", ac)
+	}
+
+	// A strong trend must not fake weekly structure (detrended first).
+	trend := makeSeries(56, func(i int) float64 { return 100 + 10*float64(i) })
+	if ac := seasonalLagAutocorrelation(trend, 7*24*time.Hour); ac > 0.5 {
+		t.Errorf("pure trend lag-7 autocorr = %.3f, want low after detrending", ac)
+	}
+}
+
+func TestDetectLevelShift(t *testing.T) {
+	rng := rand.New(rand.NewSource(73))
+	shifted := makeSeries(60, func(i int) float64 {
+		lvl := 100.0
+		if i >= 30 {
+			lvl = 170
+		}
+		return lvl + rng.NormFloat64()*8
+	})
+	idx, delta := detectLevelShift(shifted)
+	if idx < 25 || idx > 35 {
+		t.Fatalf("shift detected at index %d, want near 30", idx)
+	}
+	if delta < 30 {
+		t.Errorf("shift delta = %.1f, want strongly positive", delta)
+	}
+
+	rng2 := rand.New(rand.NewSource(74))
+	flat := makeSeries(60, func(i int) float64 { return 100 + rng2.NormFloat64()*8 })
+	if idx, _ := detectLevelShift(flat); idx >= 0 {
+		t.Errorf("false-positive shift at index %d on flat series", idx)
+	}
+
+	// A steady trend is not a level shift.
+	rng3 := rand.New(rand.NewSource(75))
+	trend := makeSeries(60, func(i int) float64 { return 100 + 3*float64(i) + rng3.NormFloat64()*8 })
+	if idx, _ := detectLevelShift(trend); idx >= 0 {
+		t.Errorf("false-positive shift at index %d on trending series", idx)
+	}
+}
+
+func TestRun_LevelShiftForecastsNewLevel(t *testing.T) {
+	// Level shift halfway through: forecasts must land near the NEW level
+	// (~170), not between the regimes (~135) as unweighted history implies.
+	rng := rand.New(rand.NewSource(77))
+	s := makeSeries(90, func(i int) float64 {
+		lvl := 100.0
+		if i >= 45 {
+			lvl = 170
+		}
+		return lvl + rng.NormFloat64()*8
+	})
+
+	result, err := Run(s, Config{Method: MethodAuto, Horizon: 7, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.LevelShiftAt == "" {
+		t.Error("expected level_shift_at to be recorded")
+	}
+	for i, p := range result.Predictions {
+		if p.Value < 150 || p.Value > 190 {
+			t.Errorf("prediction[%d] = %.1f, want near the new level (~170)", i, p.Value)
+		}
+	}
+}
+
+func TestRun_LevelShiftShortPostSegmentRelevels(t *testing.T) {
+	// Shift near the end (8 post-shift points, below the 14-point truncation
+	// bar): pre-shift history is re-leveled so forecasts still track the new
+	// regime.
+	rng := rand.New(rand.NewSource(79))
+	s := makeSeries(50, func(i int) float64 {
+		lvl := 100.0
+		if i >= 42 {
+			lvl = 180
+		}
+		return lvl + rng.NormFloat64()*6
+	})
+
+	result, err := Run(s, Config{Method: MethodAuto, Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.LevelShiftAt == "" {
+		t.Error("expected level_shift_at to be recorded")
+	}
+	for i, p := range result.Predictions {
+		if p.Value < 155 {
+			t.Errorf("prediction[%d] = %.1f, want near the new level (~180), not dragged down by old history", i, p.Value)
+		}
+	}
+}
+
+func TestRun_NoLevelShiftFieldOnStableSeries(t *testing.T) {
+	rng := rand.New(rand.NewSource(83))
+	s := makeSeries(60, func(i int) float64 { return 100 + rng.NormFloat64()*10 })
+	result, err := Run(s, Config{Method: MethodSMA, Horizon: 5, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.LevelShiftAt != "" {
+		t.Errorf("unexpected level_shift_at %q on stable series", result.LevelShiftAt)
+	}
+}
+
+func TestRun_LogTransformTracksMultiplicativeGrowth(t *testing.T) {
+	// Clean 3%-per-day growth: on log scale this is exactly linear, so the
+	// transformed linear forecast continues the compounding — while the
+	// untransformed fit undershoots badly at the far horizon.
+	s := makeSeries(60, func(i int) float64 { return 50 * math.Pow(1.03, float64(i)) })
+	want := 50 * math.Pow(1.03, 69) // 10 steps past the end
+
+	logRes, err := Run(s, Config{Method: MethodLinear, Horizon: 10, Interval: IntervalDay,
+		NonNegative: true, LogTransform: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := logRes.Predictions[9].Value
+	if math.Abs(got-want)/want > 0.02 {
+		t.Errorf("log-scale forecast = %.1f, want ~%.1f (exact compounding)", got, want)
+	}
+
+	rawRes, err := Run(s, Config{Method: MethodLinear, Horizon: 10, Interval: IntervalDay,
+		NonNegative: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rawGot := rawRes.Predictions[9].Value
+	if math.Abs(rawGot-want)/want < math.Abs(got-want)/want {
+		t.Errorf("expected log transform to beat raw fit: log err %.3f vs raw err %.3f",
+			math.Abs(got-want)/want, math.Abs(rawGot-want)/want)
+	}
+
+	// Positive trend reported on the original scale.
+	if logRes.Trend <= 0 {
+		t.Errorf("trend = %.3f, want positive on growing series", logRes.Trend)
+	}
+	// Error metrics are on the original scale: a clean exponential fit on
+	// log scale has tiny original-scale errors, far below the raw fit's.
+	if logRes.RMSE > rawRes.RMSE {
+		t.Errorf("log-fit RMSE %.3f should not exceed raw-fit RMSE %.3f", logRes.RMSE, rawRes.RMSE)
+	}
+}
+
+func TestRun_LogTransformSkippedOnNegativeValues(t *testing.T) {
+	s := makeSeries(30, func(i int) float64 { return float64(i) - 10 }) // crosses zero
+	result, err := Run(s, Config{Method: MethodLinear, Horizon: 3, Interval: IntervalDay, LogTransform: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The untransformed linear fit continues the line into positive values.
+	if math.Abs(result.Predictions[0].Value-20) > 0.5 {
+		t.Errorf("prediction = %.2f, want ~20 (transform skipped, plain linear)", result.Predictions[0].Value)
+	}
+}
+
+func TestRun_HourlyWeightsAppliedWithDailyPattern(t *testing.T) {
+	// Hourly series with a strong repeating daily pattern: hour weights
+	// pass the lag-24 gate and modulate the forecast.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := make(Series, 0, 240)
+	pattern := func(h int) float64 {
+		if h == 12 {
+			return 2.0
+		}
+		return 1.0
+	}
+	for i := 0; i < 240; i++ {
+		ts := base.Add(time.Duration(i) * time.Hour)
+		s = append(s, Point{T: ts, V: 100 * pattern(ts.Hour())})
+	}
+	weights := BuildHourlyWeights(s)
+
+	result, err := Run(s, Config{
+		Method:        MethodSMA,
+		Horizon:       24,
+		Interval:      IntervalHour,
+		HourlyWeights: weights,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SeasonalApplied {
+		t.Fatal("expected hourly weights to be applied")
+	}
+	var noon, offPeak float64
+	for _, p := range result.Predictions {
+		if p.T.Hour() == 12 {
+			noon = p.Value
+		} else if p.T.Hour() == 3 {
+			offPeak = p.Value
+		}
+	}
+	if noon <= offPeak {
+		t.Errorf("noon prediction %.1f not above off-peak %.1f despite daily pattern", noon, offPeak)
+	}
+}
+
+func TestRun_MonthDayWeightsApplied(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := make(Series, 90)
+	for i := range s {
+		ts := base.AddDate(0, 0, i)
+		v := 100.0
+		if ts.Day() == 1 {
+			v = 300
+		}
+		s[i] = Point{T: ts, V: v}
+	}
+	weights := BuildMonthDayWeights(s)
+
+	// Horizon long enough to cross the next month boundary (from Mar 31).
+	result, err := Run(s, Config{
+		Method:          MethodSMA,
+		Horizon:         5,
+		Interval:        IntervalDay,
+		MonthDayWeights: weights,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SeasonalApplied {
+		t.Fatal("expected month-day weights to be applied")
+	}
+	var first, other float64
+	for _, p := range result.Predictions {
+		if p.T.Day() == 1 {
+			first = p.Value
+		} else if other == 0 {
+			other = p.Value
+		}
+	}
+	if first == 0 {
+		t.Fatal("horizon did not cross a month boundary")
+	}
+	if first <= other {
+		t.Errorf("day-1 prediction %.1f not above other days %.1f", first, other)
+	}
+}

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -538,14 +538,14 @@ func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
 		}
 		return 200
 	})
-	if idx := detectTransients(closedSunday, IntervalDay); len(idx) != 0 {
+	if idx := detectTransients(closedSunday, IntervalDay, 0, 0); len(idx) != 0 {
 		t.Errorf("weekly closures masked as anomalies: %v", idx)
 	}
 
 	// Low-volume tracker: zeros are within its normal spread.
 	rng := rand.New(rand.NewSource(5))
 	low := makeSeries(60, func(i int) float64 { return math.Floor(rng.ExpFloat64() * 3) })
-	if idx := detectTransients(low, IntervalDay); len(idx) != 0 {
+	if idx := detectTransients(low, IntervalDay, 0, 0); len(idx) != 0 {
 		t.Errorf("low-volume zeros masked as anomalies: %v", idx)
 	}
 
@@ -560,7 +560,7 @@ func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
 		}
 		return 500 + rng2.NormFloat64()*20
 	})
-	idx := detectTransients(outage, IntervalDay)
+	idx := detectTransients(outage, IntervalDay, 0, 0)
 	if len(idx) != 2 || idx[0] != 30 || idx[1] != 45 {
 		t.Errorf("transients = %v, want [30 45]", idx)
 	}
@@ -573,7 +573,7 @@ func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
 		}
 		return 500 + rng3.NormFloat64()*20
 	})
-	if idx := detectTransients(paused, IntervalDay); len(idx) != 0 {
+	if idx := detectTransients(paused, IntervalDay, 0, 0); len(idx) != 0 {
 		t.Errorf("6-day run masked as transient: %v", idx)
 	}
 }
@@ -606,5 +606,38 @@ func TestRun_DisableAnomalyMask(t *testing.T) {
 	}
 	if len(r.AnomaliesMasked) != 0 {
 		t.Errorf("signed metric masked: %v", r.AnomaliesMasked)
+	}
+}
+
+func TestDetectTransients_ThresholdIsTunable(t *testing.T) {
+	// A 40% dip on a tight series is ~15 robust sigmas: masked at the
+	// default 5, still masked at 10, left alone at 25.
+	rng := rand.New(rand.NewSource(8))
+	s := makeSeries(60, func(i int) float64 {
+		if i == 30 {
+			return 300
+		}
+		return 500 + rng.NormFloat64()*10
+	})
+	if idx := detectTransients(s, IntervalDay, 0, 0); len(idx) != 1 {
+		t.Errorf("default sigma: transients = %v, want [30]", idx)
+	}
+	if idx := detectTransients(s, IntervalDay, 25, 0); len(idx) != 0 {
+		t.Errorf("sigma 25: transients = %v, want none", idx)
+	}
+	// Config threads the knobs through Run.
+	r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true, AnomalySigma: 25})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.AnomaliesMasked) != 0 {
+		t.Errorf("AnomalySigma 25 still masked %v", r.AnomaliesMasked)
+	}
+	r, err = Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true, AnomalyCycles: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.AnomaliesMasked) != 1 {
+		t.Errorf("AnomalyCycles 2 masked %v, want the one dip", r.AnomaliesMasked)
 	}
 }

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -538,14 +538,14 @@ func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
 		}
 		return 200
 	})
-	if idx := detectTransients(closedSunday, IntervalDay, 0, 0); len(idx) != 0 {
+	if idx := detectTransients(closedSunday, IntervalDay, false, 0, 0); len(idx) != 0 {
 		t.Errorf("weekly closures masked as anomalies: %v", idx)
 	}
 
 	// Low-volume tracker: zeros are within its normal spread.
 	rng := rand.New(rand.NewSource(5))
 	low := makeSeries(60, func(i int) float64 { return math.Floor(rng.ExpFloat64() * 3) })
-	if idx := detectTransients(low, IntervalDay, 0, 0); len(idx) != 0 {
+	if idx := detectTransients(low, IntervalDay, false, 0, 0); len(idx) != 0 {
 		t.Errorf("low-volume zeros masked as anomalies: %v", idx)
 	}
 
@@ -560,7 +560,7 @@ func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
 		}
 		return 500 + rng2.NormFloat64()*20
 	})
-	idx := detectTransients(outage, IntervalDay, 0, 0)
+	idx := detectTransients(outage, IntervalDay, false, 0, 0)
 	if len(idx) != 2 || idx[0] != 30 || idx[1] != 45 {
 		t.Errorf("transients = %v, want [30 45]", idx)
 	}
@@ -573,7 +573,7 @@ func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
 		}
 		return 500 + rng3.NormFloat64()*20
 	})
-	if idx := detectTransients(paused, IntervalDay, 0, 0); len(idx) != 0 {
+	if idx := detectTransients(paused, IntervalDay, false, 0, 0); len(idx) != 0 {
 		t.Errorf("6-day run masked as transient: %v", idx)
 	}
 }
@@ -610,28 +610,39 @@ func TestRun_DisableAnomalyMask(t *testing.T) {
 }
 
 func TestDetectTransients_ThresholdIsTunable(t *testing.T) {
-	// A 40% dip on a tight series is ~15 robust sigmas: masked at the
-	// default 5, still masked at 10, left alone at 25.
+	// A 60% dip on a tight series clears the magnitude floor (at least
+	// halved) and sits far beyond 5 robust sigmas: masked at the default,
+	// left alone once the threshold is raised past it.
 	rng := rand.New(rand.NewSource(8))
 	s := makeSeries(60, func(i int) float64 {
 		if i == 30 {
-			return 300
+			return 200
 		}
 		return 500 + rng.NormFloat64()*10
 	})
-	if idx := detectTransients(s, IntervalDay, 0, 0); len(idx) != 1 {
+	if idx := detectTransients(s, IntervalDay, false, 0, 0); len(idx) != 1 {
 		t.Errorf("default sigma: transients = %v, want [30]", idx)
 	}
-	if idx := detectTransients(s, IntervalDay, 25, 0); len(idx) != 0 {
-		t.Errorf("sigma 25: transients = %v, want none", idx)
+	if idx := detectTransients(s, IntervalDay, false, 1000, 0); len(idx) != 0 {
+		t.Errorf("sigma 1000: transients = %v, want none", idx)
+	}
+	// A 15% dip never counts, however tight the noise.
+	mild := makeSeries(60, func(i int) float64 {
+		if i == 30 {
+			return 425
+		}
+		return 500 + rng.NormFloat64()*2
+	})
+	if idx := detectTransients(mild, IntervalDay, false, 0, 0); len(idx) != 0 {
+		t.Errorf("15%% dip masked: %v", idx)
 	}
 	// Config threads the knobs through Run.
-	r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true, AnomalySigma: 25})
+	r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true, AnomalySigma: 1000})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(r.AnomaliesMasked) != 0 {
-		t.Errorf("AnomalySigma 25 still masked %v", r.AnomaliesMasked)
+		t.Errorf("AnomalySigma 1000 still masked %v", r.AnomaliesMasked)
 	}
 	r, err = Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true, AnomalyCycles: 2})
 	if err != nil {

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -73,14 +73,14 @@ func TestProfileFor_EstimatesFromPrefixOnly(t *testing.T) {
 	s[28].V = 500 // Monday of week 5
 	cfg := Config{Interval: IntervalDay, WeekdayProfile: true}
 
-	full, names := profileFor(s, cfg, len(s))
+	full, names := profileFor(s, cfg)
 	if full == nil || len(names) != 1 || names[0] != "weekday" {
 		t.Fatalf("full-history profile nil=%v names=%v, want a weekday profile", full == nil, names)
 	}
 	if full(s[28].T) <= 1.5 {
 		t.Errorf("full-history Monday multiplier %.3f should reflect the spike", full(s[28].T))
 	}
-	prefix, _ := profileFor(s, cfg, 28)
+	prefix, _ := profileFor(s[:28], cfg)
 	if prefix == nil {
 		t.Fatal("prefix profile missing: four weeks of a weekly pattern should pass the gate")
 	}

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -718,3 +718,80 @@ func TestTrainingView_TruncatesInsidePrefix(t *testing.T) {
 		t.Errorf("view has %d points starting %v, want 25 starting %v", len(view), view[0].T, s[20].T)
 	}
 }
+
+func TestRun_SeasonalProfileCalibratesAdjustedForecaster(t *testing.T) {
+	// A perfectly weekly series with the matching weekday profile: the
+	// adjusted forecaster is near exact, so the rolling error and the band
+	// must describe it (small), not the flat forecaster it was built from.
+	// Without the profile the same series has a large rolling error.
+	factors := map[time.Weekday]float64{time.Monday: 1.5, time.Tuesday: 0.6, time.Saturday: 0.7}
+	base := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // a Monday
+	s := makeSeries(56, func(i int) float64 {
+		if f, ok := factors[base.AddDate(0, 0, i).Weekday()]; ok {
+			return 100 * f
+		}
+		return 100
+	})
+	// makeSeries starts 2026-01-01; rebuild on the Monday base so the
+	// factors line up with the timestamps.
+	for i := range s {
+		s[i].T = base.AddDate(0, 0, i)
+	}
+	weights := SeasonalWeights{}
+	mean := 0.0
+	for _, p := range s[:7] {
+		mean += p.V / 7
+	}
+	for d := time.Sunday; d <= time.Saturday; d++ {
+		f := 1.0
+		if v, ok := factors[d]; ok {
+			f = v
+		}
+		weights[d] = 100 * f / mean
+	}
+
+	cfg := Config{Method: MethodSMA, SMAWindow: 7, Horizon: 7, Interval: IntervalDay, SeasonalWeights: weights}
+	with, err := Run(s, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg.SeasonalWeights = nil
+	without, err := Run(s, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !with.SeasonalApplied {
+		t.Fatal("expected the weekday profile to apply")
+	}
+	if with.RMSE > 1 || with.RMSE*10 > without.RMSE {
+		t.Errorf("rolling rmse with profile %.2f vs without %.2f: errors must describe the adjusted forecaster", with.RMSE, without.RMSE)
+	}
+	for i, p := range with.Predictions {
+		if width := p.UpperBound - p.LowerBound; width > 5 {
+			t.Errorf("step %d: band width %.2f; bands must calibrate the adjusted forecaster (near exact here)", i, width)
+		}
+	}
+}
+
+func TestRollingBacktest_HorizonByCalendarDistance(t *testing.T) {
+	// The last retained point sits two days after the one before it (a
+	// masked gap). The cut ending just before the gap has one held-out
+	// observation but a two-step calendar horizon: the residual must be
+	// recorded at step 2, not rejected because only one point remained.
+	s := makeSeries(20, func(i int) float64 { return 100 })
+	s[19].T = s[18].T.AddDate(0, 0, 2)
+	eval := runRollingBacktest(s, Config{Horizon: 3, Interval: IntervalDay, ConfidenceLevel: 0.95}, []Method{MethodSMA})
+	c := len(s) - 1
+	found := false
+	for _, r := range eval.rows {
+		if r.cut == c && r.step == 2 && r.t.Equal(s[c].T) {
+			found = true
+		}
+		if r.cut == c && r.step == 1 {
+			t.Errorf("cut %d has a step-1 row, but no point lies one day after its training end", c)
+		}
+	}
+	if !found {
+		t.Errorf("cut %d: no step-2 residual for the point across the gap", c)
+	}
+}

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -26,44 +26,66 @@ func TestShrinkMultiplier(t *testing.T) {
 	}
 }
 
-func TestShrinkWeekdayWeights(t *testing.T) {
-	weights := SeasonalWeights{time.Monday: 1.9, time.Friday: 0.5, time.Sunday: 0.2, time.Saturday: 1.4}
-	counts := map[time.Weekday]int{time.Monday: 2, time.Friday: 12, time.Saturday: 0}
-	shrunk := ShrinkWeekdayWeights(weights, counts)
-	if math.Abs(shrunk[time.Monday]-1.3) > 0.001 {
-		t.Errorf("Monday shrunk to %.3f, want 1.3 (2 samples)", shrunk[time.Monday])
-	}
-	if math.Abs(shrunk[time.Friday]-0.625) > 0.001 {
-		t.Errorf("Friday shrunk to %.3f, want 0.625 (12 samples)", shrunk[time.Friday])
-	}
-	// Unobserved weekdays (missing from counts, or counted zero) are dropped
-	// rather than carried as a meaningless 1.0.
-	for _, dow := range []time.Weekday{time.Sunday, time.Saturday} {
-		if _, ok := shrunk[dow]; ok {
-			t.Errorf("%s has no observations but kept weight %.3f", dow, shrunk[dow])
+func TestBuildWeekdayWeightsFromSeries(t *testing.T) {
+	// Four weeks with Mondays at 2x: the Monday multiplier is the raw 1.75x
+	// (2 / mean 1.143) shrunk by 4/(4+4); every other day sits below 1.
+	base := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // a Monday
+	s := make(Series, 28)
+	for i := range s {
+		v := 100.0
+		if i%7 == 0 {
+			v = 200
 		}
+		s[i] = Point{T: base.AddDate(0, 0, i), V: v}
 	}
-	if len(shrunk) != 2 {
-		t.Errorf("shrunk has %d entries, want 2", len(shrunk))
+	weights := buildWeekdayWeights(s)
+	if len(weights) != 7 {
+		t.Fatalf("got %d weekdays, want 7", len(weights))
 	}
-	// Input untouched.
-	if weights[time.Monday] != 1.9 {
-		t.Error("ShrinkWeekdayWeights modified its input")
+	mean := (200 + 6*100) / 7.0
+	wantMonday := 1 + (200/mean-1)*4/(4+4)
+	if math.Abs(weights[time.Monday]-wantMonday) > 1e-9 {
+		t.Errorf("Monday = %.4f, want %.4f (shrunk by 4 samples)", weights[time.Monday], wantMonday)
+	}
+	if weights[time.Tuesday] >= 1 {
+		t.Errorf("Tuesday = %.4f, want below 1", weights[time.Tuesday])
+	}
+	if buildWeekdayWeights(makeSeries(20, func(i int) float64 { return -1 })) != nil {
+		t.Error("a series with negative values must get no multiplicative profile")
 	}
 }
 
-func TestWeekdayCounts(t *testing.T) {
-	s := makeSeries(15, func(i int) float64 { return 1 }) // 2026-01-01 is a Thursday
-	counts := WeekdayCounts(s)
-	total := 0
-	for _, n := range counts {
-		total += n
+func TestProfileFor_EstimatesFromPrefixOnly(t *testing.T) {
+	// A weekly series (Mondays at 2x) whose final Monday spikes to 5x:
+	// the profile for the prefix that excludes that point must not know
+	// about it, so the fold holding that Monday out scales it by the
+	// multiplier four ordinary Mondays support (1.75 raw, 1.375 shrunk),
+	// while the full-history profile reflects the spike.
+	base := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC) // a Monday
+	s := make(Series, 29)
+	for i := range s {
+		v := 100.0
+		if i%7 == 0 {
+			v = 200
+		}
+		s[i] = Point{T: base.AddDate(0, 0, i), V: v}
 	}
-	if total != 15 {
-		t.Errorf("counts sum to %d, want 15", total)
+	s[28].V = 500 // Monday of week 5
+	cfg := Config{Interval: IntervalDay, WeekdayProfile: true}
+
+	full, names := profileFor(s, cfg, len(s))
+	if full == nil || len(names) != 1 || names[0] != "weekday" {
+		t.Fatalf("full-history profile nil=%v names=%v, want a weekday profile", full == nil, names)
 	}
-	if counts[time.Thursday] != 3 { // Jan 1, 8, 15
-		t.Errorf("Thursday count = %d, want 3", counts[time.Thursday])
+	if full(s[28].T) <= 1.5 {
+		t.Errorf("full-history Monday multiplier %.3f should reflect the spike", full(s[28].T))
+	}
+	prefix, _ := profileFor(s, cfg, 28)
+	if prefix == nil {
+		t.Fatal("prefix profile missing: four weeks of a weekly pattern should pass the gate")
+	}
+	if got := prefix(s[28].T); math.Abs(got-1.375) > 1e-9 {
+		t.Errorf("prefix profile scales the held-out Monday by %.3f, want 1.375; the spike leaked into its own multiplier", got)
 	}
 }
 
@@ -297,13 +319,11 @@ func TestRun_HourlyWeightsAppliedWithDailyPattern(t *testing.T) {
 		ts := base.Add(time.Duration(i) * time.Hour)
 		s = append(s, Point{T: ts, V: 100 * pattern(ts.Hour())})
 	}
-	weights := BuildHourlyWeights(s)
-
 	result, err := Run(s, Config{
 		Method:        MethodSMA,
 		Horizon:       24,
 		Interval:      IntervalHour,
-		HourlyWeights: weights,
+		HourlyProfile: true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -335,14 +355,12 @@ func TestRun_MonthDayWeightsApplied(t *testing.T) {
 		}
 		s[i] = Point{T: ts, V: v}
 	}
-	weights := BuildMonthDayWeights(s)
-
 	// Horizon long enough to cross the next month boundary (from Mar 31).
 	result, err := Run(s, Config{
 		Method:          MethodSMA,
 		Horizon:         5,
 		Interval:        IntervalDay,
-		MonthDayWeights: weights,
+		MonthDayProfile: true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -379,6 +379,9 @@ func TestDetectLevelShift_IgnoresEndOfHistoryBurst(t *testing.T) {
 			if ls := detectLevelShift(s); ls != nil {
 				t.Fatalf("burst misread as level shift at index %d", ls.idx)
 			}
+			// Through Run the burst is masked as a transient (not a shift),
+			// so even the log-scale ensemble forecasts the established level
+			// and predictions start after the burst, not inside it.
 			for _, logT := range []bool{false, true} {
 				in := make(Series, len(s))
 				copy(in, s)
@@ -389,18 +392,15 @@ func TestDetectLevelShift_IgnoresEndOfHistoryBurst(t *testing.T) {
 				if r.LevelShiftAt != "" {
 					t.Errorf("logTransform=%v: level_shift_at = %q, want none", logT, r.LevelShiftAt)
 				}
-				if r.DataPoints != 60 {
-					t.Errorf("logTransform=%v: data points = %d, want 60 (history rewritten)", logT, r.DataPoints)
+				if len(r.AnomaliesMasked) != 2 || r.DataPoints != 58 {
+					t.Errorf("logTransform=%v: masked %v, data points %d; want the 2 burst days masked", logT, r.AnomaliesMasked, r.DataPoints)
 				}
-			}
-			// On the natural scale the moving averages absorb a 2-day
-			// burst; the forecast stays near the established level.
-			r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true})
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if v := r.Predictions[0].Value; v < 350 || v > 800 {
-				t.Errorf("prediction = %.1f, want near the 500 level (burst rewrote history)", v)
+				if v := r.Predictions[0].Value; v < 400 || v > 620 {
+					t.Errorf("logTransform=%v: prediction = %.1f, want near the 500 level", logT, v)
+				}
+				if want := s[len(s)-1].T.AddDate(0, 0, 1); !r.Predictions[0].T.Equal(want) {
+					t.Errorf("logTransform=%v: first prediction at %v, want %v (after the masked tail)", logT, r.Predictions[0].T, want)
+				}
 			}
 		})
 	}
@@ -525,5 +525,86 @@ func TestAnchorOffset_CalendarMonths(t *testing.T) {
 	}
 	if got := anchorOffset(s, Config{Interval: IntervalMonth, Anchor: base.AddDate(0, 5, 0)}); got != 2 {
 		t.Errorf("two-month offset = %d, want 2", got)
+	}
+}
+
+func TestDetectTransients_RespectsSeriesOwnPattern(t *testing.T) {
+	// Closed on Sundays: zeros every week are this series' normal and must
+	// not be masked.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	closedSunday := makeSeries(56, func(i int) float64 {
+		if base.AddDate(0, 0, i).Weekday() == time.Sunday {
+			return 0
+		}
+		return 200
+	})
+	if idx := detectTransients(closedSunday, IntervalDay); len(idx) != 0 {
+		t.Errorf("weekly closures masked as anomalies: %v", idx)
+	}
+
+	// Low-volume tracker: zeros are within its normal spread.
+	rng := rand.New(rand.NewSource(5))
+	low := makeSeries(60, func(i int) float64 { return math.Floor(rng.ExpFloat64() * 3) })
+	if idx := detectTransients(low, IntervalDay); len(idx) != 0 {
+		t.Errorf("low-volume zeros masked as anomalies: %v", idx)
+	}
+
+	// A zero Tuesday in a 500-a-day series is a transient; so is a spike.
+	rng2 := rand.New(rand.NewSource(6))
+	outage := makeSeries(60, func(i int) float64 {
+		switch i {
+		case 30:
+			return 0
+		case 45:
+			return 3000
+		}
+		return 500 + rng2.NormFloat64()*20
+	})
+	idx := detectTransients(outage, IntervalDay)
+	if len(idx) != 2 || idx[0] != 30 || idx[1] != 45 {
+		t.Errorf("transients = %v, want [30 45]", idx)
+	}
+
+	// A run as long as a regime change is left to the level-shift detector.
+	rng3 := rand.New(rand.NewSource(7))
+	paused := makeSeries(60, func(i int) float64 {
+		if i >= 54 {
+			return 0
+		}
+		return 500 + rng3.NormFloat64()*20
+	})
+	if idx := detectTransients(paused, IntervalDay); len(idx) != 0 {
+		t.Errorf("6-day run masked as transient: %v", idx)
+	}
+}
+
+func TestRun_DisableAnomalyMask(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	s := makeSeries(60, func(i int) float64 {
+		if i >= 58 {
+			return 0
+		}
+		return 500 + rng.NormFloat64()*20
+	})
+	r, err := Run(s, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay, NonNegative: true, DisableAnomalyMask: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.AnomaliesMasked) != 0 || r.DataPoints != 60 {
+		t.Errorf("masking ran despite DisableAnomalyMask: %v, %d points", r.AnomaliesMasked, r.DataPoints)
+	}
+	// Signed metrics are never masked.
+	profit := makeSeries(60, func(i int) float64 {
+		if i == 30 {
+			return -900
+		}
+		return 100 + rng.NormFloat64()*10
+	})
+	r, err = Run(profit, Config{Method: MethodSMA, Horizon: 3, Interval: IntervalDay})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.AnomaliesMasked) != 0 {
+		t.Errorf("signed metric masked: %v", r.AnomaliesMasked)
 	}
 }

--- a/go-cli/internal/forecast/ws4_test.go
+++ b/go-cli/internal/forecast/ws4_test.go
@@ -27,14 +27,24 @@ func TestShrinkMultiplier(t *testing.T) {
 }
 
 func TestShrinkWeekdayWeights(t *testing.T) {
-	weights := SeasonalWeights{time.Monday: 1.9, time.Friday: 0.5}
-	counts := map[time.Weekday]int{time.Monday: 2, time.Friday: 12}
+	weights := SeasonalWeights{time.Monday: 1.9, time.Friday: 0.5, time.Sunday: 0.2, time.Saturday: 1.4}
+	counts := map[time.Weekday]int{time.Monday: 2, time.Friday: 12, time.Saturday: 0}
 	shrunk := ShrinkWeekdayWeights(weights, counts)
 	if math.Abs(shrunk[time.Monday]-1.3) > 0.001 {
 		t.Errorf("Monday shrunk to %.3f, want 1.3 (2 samples)", shrunk[time.Monday])
 	}
 	if math.Abs(shrunk[time.Friday]-0.625) > 0.001 {
 		t.Errorf("Friday shrunk to %.3f, want 0.625 (12 samples)", shrunk[time.Friday])
+	}
+	// Unobserved weekdays (missing from counts, or counted zero) are dropped
+	// rather than carried as a meaningless 1.0.
+	for _, dow := range []time.Weekday{time.Sunday, time.Saturday} {
+		if _, ok := shrunk[dow]; ok {
+			t.Errorf("%s has no observations but kept weight %.3f", dow, shrunk[dow])
+		}
+	}
+	if len(shrunk) != 2 {
+		t.Errorf("shrunk has %d entries, want 2", len(shrunk))
 	}
 	// Input untouched.
 	if weights[time.Monday] != 1.9 {


### PR DESCRIPTION
## Summary

This PR adds a complete forecasting engine to the Go CLI with rolling-origin backtesting, empirical prediction bounds via conformal prediction, an accuracy-weighted ensemble method, and coherent multi-metric forecasting. The implementation includes level-shift detection, transient anomaly masking, seasonal profile support, and event-aware adjustments.

## Key Changes

**Core Forecasting Engine**
- `backtest.go`: Rolling-origin backtesting framework that re-fits models at multiple cut points, collects residuals per horizon step, and computes empirical quantile-based prediction bounds (conformal prediction)
- `conformal.go`: Empirical quantile computation with bucket merging for thin residual pools and monotone-widening enforcement to prevent bounds from narrowing with horizon
- `ensemble.go`: Accuracy-weighted ensemble that combines linear, SMA, WMA, and Holt-Winters forecasts using inverse squared recency-discounted rolling-backtest RMSE; includes damped-trend Holt-Winters implementation with Gardner–McKenzie damping to prevent runaway trend extrapolation

**Data Quality & Preprocessing**
- `anomaly.go`: Transient anomaly masking that identifies short outlier runs abnormal for the series at that point of its cycle (e.g., tracking outages, one-off spikes) and excludes them from fitting
- `levelshift.go`: Level-shift detection via CUSUM statistics on one-step residuals; automatically truncates pre-shift history or re-levels it to the new regime depending on segment length
- `seasonal.go` (extended): Shrinkage-based seasonal multiplier estimation for weekday, hourly, and day-of-month profiles; gated on detrended autocorrelation at the seasonal lag

**Multi-Metric Coherence**
- `coherent.go`: Ratio decomposition forecasting that maintains identities (leads = clicks × conv_rate, income = leads × avg_payout, net = income − cost) by forecasting drivers (clicks and rates) and composing derived metrics per timestep; falls back to direct forecasting when driver rates are too sparse

**API & Output**
- Extended `Result` struct with `Weights` (ensemble member shares), `Composition` (direct vs. derived), `LevelShiftAt`, `AnomaliesMasked`, seasonal application flags, and `BoundsSource` (conformal/gaussian/mixed)
- Extended `Prediction` struct with `Quantiles` map holding full empirical quantile set (p05–p95)
- New constants: `BoundsConformal`, `BoundsGaussian`, `BoundsMixed`; `MetricClicks`, `MetricLeads`, `MetricIncome`, `MetricCost`, `MetricNet`; `CompositionDirect`, `CompositionDerived`

**CLI Integration**
- `forecast.go` (cmd): Updated help text and examples; added `--all-metrics` flag for coherent multi-metric forecasting; added `--no-anomaly-mask` and `--no-level-shift` flags to disable preprocessing
- `forecast_test.go`: Added `TestForecastAllMetricsCoherent` validating identity preservation and composition metadata
- `cli_errors.go`: Added `Hint` field to `CLIError` for recovery guidance; implemented `Hinted` interface in api/client.go
- Updated error handling across multiple commands to use `validationError()` helper for consistent categorization

**Documentation**
- `documentation/cli/11-forecasting.md`: Comprehensive forecasting guide covering the pipeline, methods, ensemble weighting, bounds interpretation, seasonal profiles, event handling, and worked examples
- Updated `documentation/cli/10-go-cli.md` and `docs/cli.md` with forecasting reference
- Updated `README.md` and `AGENTS.md` with forecasting capabilities

**Testing**
- `ws4_test.go`: Tests for shrinkage multipliers, weekday/hourly/monthday weight building, seasonal lag autocorrelation, and level-shift detection
- `conformal_test.go`: Tests for quantile computation, bound pair selection, bucket merging, and monotone-widening enforcement
- `ensemble_test.go`: Tests

https://claude.ai/code/session_01QhFxBpYNHvFC4kp8wBSWbK